### PR TITLE
Bug in error on initial memory allocation, before terminal init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ config.status
 *.bak
 *.log
 *.pdf
-.swp
+*.swp
 xwpe

--- a/we_main.c
+++ b/we_main.c
@@ -307,8 +307,10 @@ int main(int argc, char **argv)
  int so = 0, sd = 1;
  char *tp;
 
- if ((cn = (ECNT *)MALLOC(sizeof(ECNT))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 2, fb);
+ if ((cn = (ECNT *)MALLOC(sizeof(ECNT))) == NULL) {
+  printf(" Fatal Error: %s\n", e_msg[ERR_LOWMEM]);
+  return 0;
+ }
  ECNT_Init(cn);
  e_ini_unix(&argc, argv);
  e_switch_screen(1);


### PR DESCRIPTION
Corrected a bug where the program responds to the first memory allocation failing by calling e_error which wants to write an error message to a message window. However, no terminal was initialized yet (neither XWindows term nor text term), so this results in a segfault.

I replaced the original call with a simple printf and return.