### PR TITLE
Replace defines

### DIFF
--- a/WeExpArr.c
+++ b/WeExpArr.c
@@ -27,7 +27,7 @@ void *WpeExpArrayCreate(int initial_num, int elem_size, int growth_num)
 {
  int *exp_array;
 
- exp_array = (int *)WpeMalloc(initial_num * elem_size + sizeof(int) * 4);
+ exp_array = (int *)malloc(initial_num * elem_size + sizeof(int) * 4);
  *(exp_array) = initial_num;
  *(exp_array + 1) = elem_size;
  *(exp_array + 2) = growth_num;

--- a/WeExpArr.c
+++ b/WeExpArr.c
@@ -70,6 +70,6 @@ void WpeExpArrayDestroy(void *exp_array)
  int *real_array;
 
  real_array = ((int *)exp_array) - 4;
- WpeFree(real_array);
+ free(real_array);
 }
 

--- a/WeExpArr.c
+++ b/WeExpArr.c
@@ -43,7 +43,7 @@ void WpeExpArrayAdd(void **exp_array, void *new_elem)
  if (*real_array == *(real_array + 3))
  {
   *(real_array) += *(real_array + 2);
-  real_array = WpeRealloc(real_array, (*real_array) * (*(real_array + 1)) +
+  real_array = realloc(real_array, (*real_array) * (*(real_array + 1)) +
                                       sizeof(int) * 4);
   if (real_array == NULL)
   {

--- a/WeString.c
+++ b/WeString.c
@@ -56,7 +56,7 @@ char *WpeStrdup(const char *str)
 {
  char *newstr;
  
- newstr = WpeMalloc((strlen(str)+1)*sizeof(char));
+ newstr = malloc((strlen(str)+1)*sizeof(char));
  if (newstr != NULL)
  {
   strcpy(newstr, str);

--- a/WeString.h
+++ b/WeString.h
@@ -50,7 +50,7 @@ char *WpeStrcstr(char *str, const char *substr);
 
     Parameters:
       str          (In)  String to copy
-    Returns: Pointer to new string created with WpeMalloc().  NULL if
+    Returns: Pointer to new string created with malloc().  NULL if
   insufficient memory free to create the string.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 char *WpeStrdup(const char *str);

--- a/WeSyntax.c
+++ b/WeSyntax.c
@@ -95,13 +95,13 @@ void WpeSyntaxReadFile(ECNT *cn)
   if ((syntax_file = fopen(tmp, "r")) == NULL)
   {
    /* C Syntax (".c" extension) */
-   new_syntax = WpeMalloc(sizeof(WpeSyntaxExt));
+   new_syntax = malloc(sizeof(WpeSyntaxExt));
    new_syntax->extension = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
    new_syntax->extension[0] = strdup(".c");
    new_syntax->syntax_rule = &WpeCSyntaxRule;
    WpeExpArrayAdd((void **)&WpeSyntaxDef, &new_syntax);
    /* C++ Syntax (".C", ".cpp", ".cxx", ".cc", ".h", and ".hpp" extensions) */
-   new_syntax = WpeMalloc(sizeof(WpeSyntaxExt));
+   new_syntax = malloc(sizeof(WpeSyntaxExt));
    new_syntax->extension = (char **)WpeExpArrayCreate(6, sizeof(char *), 1);
    new_syntax->extension[0] = strdup(".C");
    new_syntax->extension[1] = strdup(".cpp");
@@ -117,7 +117,7 @@ void WpeSyntaxReadFile(ECNT *cn)
  }
  while (fscanf(syntax_file, "%s", tmp) == 1)
  {
-  new_syntax = WpeMalloc(sizeof(WpeSyntaxExt));
+  new_syntax = malloc(sizeof(WpeSyntaxExt));
   i = atoi(tmp);
   if (i > 0)
   {
@@ -137,13 +137,13 @@ void WpeSyntaxReadFile(ECNT *cn)
    new_syntax->extension = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
    new_syntax->extension[0] = WpeStrdup(tmp);
   }
-  new_syntax->syntax_rule = WpeMalloc(sizeof(WpeSyntaxRule));
+  new_syntax->syntax_rule = malloc(sizeof(WpeSyntaxRule));
   if (fscanf(syntax_file, "%d", &reserved_num) != 1)
   {
    e_error("Error reading syntax_def", 0, cn->fb);
    return ;
   }
-  new_syntax->syntax_rule->reserved_word = WpeMalloc((reserved_num + 1) *
+  new_syntax->syntax_rule->reserved_word = malloc((reserved_num + 1) *
                                                      sizeof(char *));
   for (i = 0; i < reserved_num; i++)
   {
@@ -160,7 +160,7 @@ void WpeSyntaxReadFile(ECNT *cn)
    e_error("Error reading syntax_def", 0, cn->fb);
    return ;
   }
-  new_syntax->syntax_rule->long_operator = WpeMalloc((long_op_num + 1) *
+  new_syntax->syntax_rule->long_operator = malloc((long_op_num + 1) *
                                                      sizeof(char *));
   for (i = 0; i < long_op_num; i++)
   {

--- a/WeXterm.c
+++ b/WeXterm.c
@@ -457,7 +457,7 @@ void WpeXInit(int *argc, char **argv)
  WpeXInfo.protocol_atom = XInternAtom(WpeXInfo.display, "WM_PROTOCOLS", False);
  XSetWMProtocols(WpeXInfo.display, WpeXInfo.window, new_atom_list,
    atom_num + 1);
- WpeFree(new_atom_list);
+ free(new_atom_list);
 
  WpeXInfo.selection_atom = XInternAtom(WpeXInfo.display, "PRIMARY", False);
  WpeXInfo.text_atom = XInternAtom(WpeXInfo.display, "STRING", False);

--- a/WeXterm.c
+++ b/WeXterm.c
@@ -446,7 +446,7 @@ void WpeXInit(int *argc, char **argv)
  {
   atom_num = 0;
  }
- new_atom_list = WpeMalloc((atom_num + 1) * sizeof(Atom));
+ new_atom_list = malloc((atom_num + 1) * sizeof(Atom));
  if (atom_list != NULL)
  {
   memcpy(new_atom_list, atom_list, atom_num * sizeof(Atom));

--- a/Xwpe.h
+++ b/Xwpe.h
@@ -20,7 +20,7 @@ typedef enum wpeMouseShape {
 
 //#define WpeMalloc(x) malloc(x)
 //#define WpeRealloc(x, y) realloc(x, y)
-#define WpeFree(x) free(x)
+//#define WpeFree(x) free(x)
 
 #endif
 

--- a/Xwpe.h
+++ b/Xwpe.h
@@ -19,7 +19,7 @@ typedef enum wpeMouseShape {
 #define WpeIsXwin() (e_we_sw & 1)
 
 //#define WpeMalloc(x) malloc(x)
-#define WpeRealloc(x, y) realloc(x, y)
+//#define WpeRealloc(x, y) realloc(x, y)
 #define WpeFree(x) free(x)
 
 #endif

--- a/Xwpe.h
+++ b/Xwpe.h
@@ -18,7 +18,7 @@ typedef enum wpeMouseShape {
 /* Checks if x windows is running (old variable currently used) */
 #define WpeIsXwin() (e_we_sw & 1)
 
-#define WpeMalloc(x) malloc(x)
+//#define WpeMalloc(x) malloc(x)
 #define WpeRealloc(x, y) realloc(x, y)
 #define WpeFree(x) free(x)
 

--- a/Xwpe.h
+++ b/Xwpe.h
@@ -18,9 +18,5 @@ typedef enum wpeMouseShape {
 /* Checks if x windows is running (old variable currently used) */
 #define WpeIsXwin() (e_we_sw & 1)
 
-//#define WpeMalloc(x) malloc(x)
-//#define WpeRealloc(x, y) realloc(x, y)
-//#define WpeFree(x) free(x)
-
 #endif
 

--- a/old/we_djgpp.c
+++ b/old/we_djgpp.c
@@ -118,7 +118,7 @@ void end_repaint()
    {  schirm = svschirm;
       for(n = 0; n < 160*MAXSLNS; n++)
 	    *(schirm + n) = *(tmpschirm + n);
-      FREE((char *)tmpschirm);
+      free((char *)tmpschirm);
    }
 }
 
@@ -140,7 +140,7 @@ void end_repaint_1(FENSTER *f)
       {  *(schirm+2*MAXSCOL*j+2*i)   = *(tmpschirm+2*MAXSCOL*j+2*i);
 	 *(schirm+2*MAXSCOL*j+2*i+1) = *(tmpschirm+2*MAXSCOL*j+2*i+1);
       }
-      FREE((char *)tmpschirm);
+      free((char *)tmpschirm);
    }
 }
 
@@ -398,7 +398,7 @@ int e_exec_inf(FENSTER *f, char **argv, int n)
    sp = argv[0];
    argv[0] = s_tmp;
    if(spawnvp(P_WAIT, s_tmp, argv)) e_print_arg(stderr, e_p_msg[ERR_IN_COMMAND], argv, n);
-   FREE(s_tmp);
+   free(s_tmp);
    argv[0] = sp;
 /*
    if(system(s_tmp)) e_print_arg(stderr, e_p_msg[ERR_IN_COMMAND], argv, n);
@@ -558,12 +558,12 @@ void e_free_djenv()
    if(e_djenv)
    {  for(i = 0; i < e_djenv_n; i++)
       {  if(e_djenv[i])
-         {  if(e_djenv[i]->var) FREE(e_djenv[i]->var);
-            if(e_djenv[i]->string) FREE(e_djenv[i]->string);
-            FREE(e_djenv[i]->var);
+         {  if(e_djenv[i]->var) free(e_djenv[i]->var);
+            if(e_djenv[i]->string) free(e_djenv[i]->string);
+            free(e_djenv[i]->var);
          }
       }
-      FREE(e_djenv);
+      free(e_djenv);
    }
    e_djenv = NULL;
    e_djenv_n = 0;

--- a/old/we_djgpp.c
+++ b/old/we_djgpp.c
@@ -101,7 +101,7 @@ char *tmpschirm, *svschirm;
 void ini_repaint(ECNT *cn)
 {
    svschirm = schirm;
-   if((tmpschirm = (char *)MALLOC(4000*sizeof(char))) == NULL)
+   if((tmpschirm = (char *)malloc(4000*sizeof(char))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
    else
    {
@@ -125,7 +125,7 @@ void end_repaint()
 void ini_repaint_1(FENSTER *f)
 {
    svschirm = schirm;
-   if((tmpschirm = (char *)MALLOC(4000*sizeof(char))) == NULL)
+   if((tmpschirm = (char *)malloc(4000*sizeof(char))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
    else  schirm = tmpschirm;
 }
@@ -393,7 +393,7 @@ int e_exec_inf(FENSTER *f, char **argv, int n)
       write(e_p_err_file, " ", 1);
    }
    write(e_p_err_file, "\n", 1);
-   s_tmp = MALLOC((strlen(argv[0])+1)*sizeof(char));
+   s_tmp = malloc((strlen(argv[0])+1)*sizeof(char));
    strcpy(s_tmp, argv[0]);
    sp = argv[0];
    argv[0] = s_tmp;
@@ -571,13 +571,13 @@ void e_free_djenv()
 
 void e_add_djvar(char *var, char *string)
 {
-   if(!e_djenv) e_djenv = MALLOC(sizeof(struct dj_env *));
-   else e_djenv = REALLOC(e_djenv, (e_djenv_n+1) * sizeof(struct dj_env *));
+   if(!e_djenv) e_djenv = malloc(sizeof(struct dj_env *));
+   else e_djenv = realloc(e_djenv, (e_djenv_n+1) * sizeof(struct dj_env *));
    if(!e_djenv) return;
-   e_djenv[e_djenv_n] = MALLOC(sizeof(struct dj_env));
+   e_djenv[e_djenv_n] = malloc(sizeof(struct dj_env));
    if(!e_djenv[e_djenv_n]) return;
-   e_djenv[e_djenv_n]->var = MALLOC((strlen(var)+1) * sizeof(char));
-   e_djenv[e_djenv_n]->string = MALLOC((strlen(string)+1) * sizeof(char));
+   e_djenv[e_djenv_n]->var = malloc((strlen(var)+1) * sizeof(char));
+   e_djenv[e_djenv_n]->string = malloc((strlen(string)+1) * sizeof(char));
    if(!e_djenv[e_djenv_n]->var || !e_djenv[e_djenv_n]->var) return;
    strcpy(e_djenv[e_djenv_n]->var, var);
    strcpy(e_djenv[e_djenv_n]->string, string);
@@ -672,13 +672,13 @@ char *e_getenv(char *var)
 
 struct dirfile *e_mk_drives(void)
 {
-   struct dirfile *df = MALLOC(sizeof(struct dirfile));
+   struct dirfile *df = malloc(sizeof(struct dirfile));
    int drvs, i;
-   df->name = MALLOC(sizeof(char *) * 26);
+   df->name = malloc(sizeof(char *) * 26);
    df->anz = 0;
    for ( i = 0; i < 26; i++)
    {  if(fk_lfw_test(i) >= 0)
-      {  *(df->name + df->anz) = MALLOC(2 * sizeof(char));
+      {  *(df->name + df->anz) = malloc(2 * sizeof(char));
 	 *(*(df->name + df->anz)) = 'A'+i;
 	 *(*(df->name + df->anz)+1) = '\0';
 	 (df->anz)++;

--- a/unixmakr.h
+++ b/unixmakr.h
@@ -93,7 +93,7 @@ extern char *ctree[5];
 
 //#define REALLOC(p, n) realloc((p), (n))
 //#define MALLOC(n) malloc(n)
-#define FREE(n) free(n)
+//#define FREE(n) free(n)
 
 #ifdef NEWSTYLE
 extern char *extbyte, *altextbyte;

--- a/unixmakr.h
+++ b/unixmakr.h
@@ -91,10 +91,6 @@ extern char *ctree[5];
 #define e_s_clr(f, b) (*e_s_u_clr)(f, b)
 #define e_n_clr(fb) (*e_n_u_clr)(fb)
 
-//#define REALLOC(p, n) realloc((p), (n))
-//#define MALLOC(n) malloc(n)
-//#define FREE(n) free(n)
-
 #ifdef NEWSTYLE
 extern char *extbyte, *altextbyte;
 #endif

--- a/unixmakr.h
+++ b/unixmakr.h
@@ -91,8 +91,8 @@ extern char *ctree[5];
 #define e_s_clr(f, b) (*e_s_u_clr)(f, b)
 #define e_n_clr(fb) (*e_n_u_clr)(fb)
 
-#define REALLOC(p, n) realloc((p), (n))
-#define MALLOC(n) malloc(n)
+//#define REALLOC(p, n) realloc((p), (n))
+//#define MALLOC(n) malloc(n)
 #define FREE(n) free(n)
 
 #ifdef NEWSTYLE
@@ -106,7 +106,7 @@ extern char *extbyte, *altextbyte;
     {	if(f->s->mark_begin.y == f->s->mark_end.y)                      \
         e_sc_nw_txt(f->s->mark_end.y, f->b, 0);                         \
 	else								\
-	{  f->c_sw = REALLOC(f->c_sw, f->b->mx.y * sizeof(int));	\
+	{  f->c_sw = realloc(f->c_sw, f->b->mx.y * sizeof(int));	\
 	   f->c_sw = e_sc_txt(f->c_sw, f->b);				\
 	}								\
     }									\

--- a/we_block.c
+++ b/we_block.c
@@ -321,7 +321,7 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
  {
   n = kex - kax;
   bz->b.x = x; bz->b.y = y;
-  if ((cstr = MALLOC(f->ed->maxcol * sizeof(char))) == NULL)
+  if ((cstr = malloc(f->ed->maxcol * sizeof(char))) == NULL)
   {
    e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
    return;
@@ -345,7 +345,7 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
  {
   n = kax - x;
   bv->b.x = x; bv->b.y = y;
-  if ((cstr = MALLOC(f->ed->maxcol * sizeof(char))) == NULL)
+  if ((cstr = malloc(f->ed->maxcol * sizeof(char))) == NULL)
   {
    e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
    return;
@@ -367,7 +367,7 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
  {
   n = x - kex;
   bv->b.x = kex; bv->b.y = y;
-  if ((cstr = MALLOC(f->ed->maxcol * sizeof(char))) == NULL)
+  if ((cstr = malloc(f->ed->maxcol * sizeof(char))) == NULL)
   {
    e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
    return;
@@ -388,14 +388,14 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
  while (bz->mxlines+n > bz->mx.y-2)
  {
   bz->mx.y += MAXLINES;
-  if ((tmp = REALLOC(bz->bf, bz->mx.y * sizeof(STRING))) == NULL)
+  if ((tmp = realloc(bz->bf, bz->mx.y * sizeof(STRING))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, bz->fb);
   else
    bz->bf = tmp;
   if (bz->f->c_sw)
-   bz->f->c_sw = REALLOC(bz->f->c_sw, bz->mx.y * sizeof(int));
+   bz->f->c_sw = realloc(bz->f->c_sw, bz->mx.y * sizeof(int));
  }
- if ((str = MALLOC((n+2) * sizeof(STRING))) == NULL)
+ if ((str = malloc((n+2) * sizeof(STRING))) == NULL)
  {
   e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
   return;
@@ -493,7 +493,7 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
  unsigned char *cstr;
 
  if (key < kay || (kay == key && kex <= kax)) return;
- if ((cstr = MALLOC(buffer_src->mx.x + 1)) == NULL)
+ if ((cstr = malloc(buffer_src->mx.x + 1)) == NULL)
  {
   e_error(e_msg[ERR_LOWMEM], 0, buffer_dst->fb);
   return;
@@ -528,14 +528,14 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
  while (buffer_dst->mxlines+n > buffer_dst->mx.y-2)
  {
   buffer_dst->mx.y += MAXLINES;
-  if ((tmp = REALLOC(buffer_dst->bf, buffer_dst->mx.y * sizeof(STRING))) == NULL)
+  if ((tmp = realloc(buffer_dst->bf, buffer_dst->mx.y * sizeof(STRING))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, buffer_dst->fb);
   else
    buffer_dst->bf = tmp;
   if (buffer_dst->f->c_sw)
-   buffer_dst->f->c_sw = REALLOC(buffer_dst->f->c_sw , buffer_dst->mx.y * sizeof(int));
+   buffer_dst->f->c_sw = realloc(buffer_dst->f->c_sw , buffer_dst->mx.y * sizeof(int));
  }
- if ((str = MALLOC((n+2) * sizeof(STRING *))) == NULL)
+ if ((str = malloc((n+2) * sizeof(STRING *))) == NULL)
  {
   e_error(e_msg[ERR_LOWMEM], 0, buffer_dst->fb);
   FREE(cstr);
@@ -564,7 +564,7 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
   buffer_dst->bf[i+y].s = NULL;
  for (i = 1; i <= n; i++)
  {
-  if ((buffer_dst->bf[i+y].s = MALLOC(buffer_dst->mx.x+1)) == NULL)
+  if ((buffer_dst->bf[i+y].s = malloc(buffer_dst->mx.x+1)) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, b->fb);
   for (j = 0; j <= str[i]->len; j++)
    *(buffer_dst->bf[i+y].s+j) = *(str[i]->s+j);
@@ -803,7 +803,7 @@ int e_blck_to_left(FENSTER *f)
  BUFFER *b;
  SCHIRM *s;
  int n = f->ed->tabn/2, i, j, k, l, m, nn;
- char *tstr = MALLOC((n+2)*sizeof(char));
+ char *tstr = malloc((n+2)*sizeof(char));
 
  for(i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--);
  if(i <= 0) return(0);
@@ -851,7 +851,7 @@ int e_blck_to_right(FENSTER *f)
  BUFFER *b;
  SCHIRM *s;
  int n = f->ed->tabn/2, i, j;
- char *tstr = MALLOC((n+1)*sizeof(char));
+ char *tstr = malloc((n+1)*sizeof(char));
 
  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
   ;

--- a/we_block.c
+++ b/we_block.c
@@ -100,7 +100,7 @@ int e_blck_clear(BUFFER *b, SCHIRM *s)
  return(0);
  }
  for (i = s->mark_begin.y + 1; i < s->mark_end.y; i++)
-  FREE(b->bf[i].s);
+  free(b->bf[i].s);
  for (i = s->mark_begin.y + 1; i <= b->mxlines-len; i++)
   b->bf[i] = b->bf[i+len];
  (b->mxlines) -= len;
@@ -217,7 +217,7 @@ int e_edt_copy(FENSTER *f)
   return(0);
  }
  for (i = 1; i < b0->mxlines; i++)
-  FREE(b0->bf[i].s);
+  free(b0->bf[i].s);
  b0->mxlines = 1;
  *(b0->bf[0].s) = WPE_WR;
  *(b0->bf[0].s+1) = '\0';
@@ -337,7 +337,7 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
   sz->mark_begin.y = sz->mark_end.y = bz->b.y = y;
   e_cursor(f, 1);
   e_schirm(f, 1);
-  FREE(cstr);
+  free(cstr);
   return;
  }
 
@@ -359,7 +359,7 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
   sv->mark_end.x = kex;  sv->mark_end.y = key;
   e_cursor(f, 1);
   e_schirm(f, 1);
-  FREE(cstr);
+  free(cstr);
   return;
  }
 
@@ -381,7 +381,7 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
   bv->b.x = sv->mark_end.x;  bv->b.y = sv->mark_end.y;
   e_cursor(f, 1);
   e_schirm(f, 1);
-  FREE(cstr);
+  free(cstr);
   return;
  }
 
@@ -452,7 +452,7 @@ void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
  sc_txt_1(bz->f);
  e_cursor(f, 1);
  e_schirm(f, 1);
- FREE(str);
+ free(str);
 }
 
 /*   copy block within window   */
@@ -502,7 +502,7 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
  {
   if (buffer_src == buffer_dst && y == kay && x >= kax && x < kex)
   {
-   FREE(cstr);
+   free(cstr);
    return;
   }
   n = kex - kax;
@@ -513,7 +513,7 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
   s_dst->mark_begin.x = x;
   s_dst->mark_end.x = buffer_dst->b.x = x + n;
   s_dst->mark_begin.y = s_dst->mark_end.y = buffer_dst->b.y = y;
-  FREE(cstr);
+  free(cstr);
   e_cursor(f, 1);
   e_schirm(f, 1);
   return;
@@ -522,7 +522,7 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
  if (buffer_src == buffer_dst && ( (y > kay && y < key) ||
    ( y == kay && x >= kax ) || ( y == key && x < kex) ))
  {
-  FREE(cstr);
+  free(cstr);
   return;
  }
  while (buffer_dst->mxlines+n > buffer_dst->mx.y-2)
@@ -538,7 +538,7 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
  if ((str = malloc((n+2) * sizeof(STRING *))) == NULL)
  {
   e_error(e_msg[ERR_LOWMEM], 0, buffer_dst->fb);
-  FREE(cstr);
+  free(cstr);
   return;
  }
  e_new_line(y+1, buffer_dst);
@@ -590,8 +590,8 @@ void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
 
  e_cursor(f, 1);
  e_schirm(f, 1);
- FREE(cstr);
- FREE(str);
+ free(cstr);
+ free(str);
 }
 
 /*   delete block marks   */
@@ -840,7 +840,7 @@ int e_blck_to_left(FENSTER *f)
    s->mark_begin.x = nn;
   }
  }
- FREE(tstr);
+ free(tstr);
  e_schirm(f, 1);
  return(0);
 }
@@ -873,7 +873,7 @@ int e_blck_to_right(FENSTER *f)
   if (i == s->mark_begin.y)
    s->mark_begin.x = 0;
  }
- FREE(tstr);
+ free(tstr);
  e_schirm(f, 1);
  return(0);
 }

--- a/we_debug.c
+++ b/we_debug.c
@@ -776,7 +776,7 @@ int e_d_p_watches(FENSTER *f, int sw)
 
   /* Print variable name */
   for ( ; str[k] != '\0' && isspace(str[k]); k++);
-  str2 = WpeMalloc(strlen(e_d_swtchs[l]) + strlen(str + k) + 4);
+  str2 = malloc(strlen(e_d_swtchs[l]) + strlen(str + k) + 4);
   sprintf(str2, "%s: %s", e_d_swtchs[l], str + k);
 
   e_d_nrwtchs[l] = b->mxlines;

--- a/we_debug.c
+++ b/we_debug.c
@@ -783,7 +783,7 @@ int e_d_p_watches(FENSTER *f, int sw)
   print_to_end_of_buffer(b, str2, b->mx.x);
 
   /* Free any allocated string */
-  WpeFree(str2);
+  free(str2);
   if(str != str1)
   {
    FREE(str);

--- a/we_debug.c
+++ b/we_debug.c
@@ -577,8 +577,8 @@ int e_delete_watches(FENSTER *f)
  for (; n < e_d_nwtchs; n++)
   e_d_swtchs[n - 1] = e_d_swtchs[n];
  e_d_nwtchs--;
- e_d_swtchs = REALLOC(e_d_swtchs, e_d_nwtchs * sizeof(char *));
- e_d_nrwtchs = REALLOC(e_d_nrwtchs, e_d_nwtchs * sizeof(int));
+ e_d_swtchs = realloc(e_d_swtchs, e_d_nwtchs * sizeof(char *));
+ e_d_nrwtchs = realloc(e_d_nrwtchs, e_d_nwtchs * sizeof(int));
  e_d_p_watches(f, 0);
  return(0);
 }
@@ -604,13 +604,13 @@ int e_make_watches(FENSTER *f)
   e_d_nwtchs++;
   if (e_d_nwtchs == 1)
   {
-   e_d_swtchs = MALLOC(sizeof(char *));
-   e_d_nrwtchs = MALLOC(sizeof(int));
+   e_d_swtchs = malloc(sizeof(char *));
+   e_d_nrwtchs = malloc(sizeof(int));
   }
   else
   {
-   e_d_swtchs = REALLOC(e_d_swtchs, e_d_nwtchs * sizeof(char *));
-   e_d_nrwtchs = REALLOC(e_d_nrwtchs, e_d_nwtchs * sizeof(int));
+   e_d_swtchs = realloc(e_d_swtchs, e_d_nwtchs * sizeof(char *));
+   e_d_nrwtchs = realloc(e_d_nrwtchs, e_d_nwtchs * sizeof(int));
   }
   
   /*
@@ -626,7 +626,7 @@ int e_make_watches(FENSTER *f)
    */
    e_d_nrwtchs[i] = e_d_nrwtchs[i-1];
   }
-  e_d_swtchs[y] = MALLOC(strlen(str) + 1); /* insert...                    */
+  e_d_swtchs[y] = malloc(strlen(str) + 1); /* insert...                    */
   strcpy(e_d_swtchs[y], str);              /*       ... new watch at pos y */
   e_d_p_watches(f, 1);
   return(0);
@@ -649,7 +649,7 @@ int e_edit_watches(FENSTER *f)
  strcpy(str, e_d_swtchs[l - 1]);
  if (e_d_add_watch(str, f))
  {
-  e_d_swtchs[l - 1] = REALLOC(e_d_swtchs[l - 1], strlen(str) + 1);
+  e_d_swtchs[l - 1] = realloc(e_d_swtchs[l - 1], strlen(str) + 1);
   strcpy(e_d_swtchs[l - 1], str);
   e_d_p_watches(f, 0);
   return(0);
@@ -736,13 +736,13 @@ int e_d_p_watches(FENSTER *f, int sw)
    {
     return(ret); /* BUG? e_d_nrwtchs not initialized if this return is taken */
    }
-   str = MALLOC(strlen(str1) + 1);
+   str = malloc(strlen(str1) + 1);
    strcpy(str, str1);
    while ((ret = e_d_line_read(wfildes[0], str1, 256, 0, 0)) == 0 || ret == 2)
    {
     if (ret == -1) return(ret); /* BUG? e_d_nrwtchs not initialized if this return is taken */
     if (ret == 2) e_d_error(str1);
-    str = REALLOC(str, (k = strlen(str)) + strlen(str1) + 1);
+    str = realloc(str, (k = strlen(str)) + strlen(str1) + 1);
     if (str[k-1] == '\n') str[k-1] = ' ';
     strcat(str, str1);
    }
@@ -832,7 +832,7 @@ int e_d_reinit_watches(FENSTER * f,char * prj)
   }
  }
  g=strlen(prj);
- prj2=MALLOC(sizeof(char)*(g+1));
+ prj2=malloc(sizeof(char)*(g+1));
  strcpy(prj2,prj);
  q=0;
  y=0;
@@ -846,12 +846,12 @@ int e_d_reinit_watches(FENSTER * f,char * prj)
   r++;
  } 
  e_d_nwtchs=r;
- e_d_swtchs = (char **) MALLOC(e_d_nwtchs * sizeof(char *));
- e_d_nrwtchs =(int *) MALLOC(e_d_nwtchs * sizeof(int));   
+ e_d_swtchs = (char **) malloc(e_d_nwtchs * sizeof(char *));
+ e_d_nrwtchs =(int *) malloc(e_d_nwtchs * sizeof(int));   
 
  for(e=0,q=0;e<r;e++)
  {
-  e_d_swtchs[e] = MALLOC(strlen(prj2+q)+1);
+  e_d_swtchs[e] = malloc(strlen(prj2+q)+1);
   strcpy(e_d_swtchs[e], prj2+q); 
   q+=strlen(prj2+q)+1;
  } 
@@ -980,7 +980,7 @@ int e_d_p_stack(FENSTER *f, int sw)
 
 int e_make_stack(FENSTER *f)
 {
-   char file[128], str[128], *tmpstr = MALLOC(1);
+   char file[128], str[128], *tmpstr = malloc(1);
    int i, ret, line = 0, dif;
    BUFFER *b = f->ed->f[f->ed->mxedt]->b;
    e_d_switch_out(0);
@@ -992,7 +992,7 @@ int e_make_stack(FENSTER *f)
 	 for(i = b->b.y; i >= 0 && b->bf[i].s[0] != '#'; i--);
 	 if(i < 0) return(1);
 	 for(; i < b->mxlines; i++)
-	 {  if(!(tmpstr = REALLOC(tmpstr, strlen(tmpstr) + b->bf[i].len + 2)))
+	 {  if(!(tmpstr = realloc(tmpstr, strlen(tmpstr) + b->bf[i].len + 2)))
 	    {  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
 	    strcat(tmpstr, (char *) b->bf[i].s);
 	    if(i == b->mxlines-1 || b->bf[i+1].s[0] == '#') break;
@@ -1009,7 +1009,7 @@ int e_make_stack(FENSTER *f)
 	    i--);
 	 if(i == 0 && b->bf[i].len == 0) return(1);
 	 for(; i < b->mxlines; i++)
-	 {  if(!(tmpstr = REALLOC(tmpstr, strlen(tmpstr) + b->bf[i].len + 2)))
+	 {  if(!(tmpstr = realloc(tmpstr, strlen(tmpstr) + b->bf[i].len + 2)))
 	    {  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
 	    strcat(tmpstr, (char *) b->bf[i].s);
 	    if(i == b->mxlines-1 || b->bf[i].s[b->bf[i].len - 1] != '\\')
@@ -1056,7 +1056,7 @@ int e_brk_schirm(FENSTER *f)
  int n;
 
  SCHIRM *s = f->s;
- s->brp= REALLOC(s->brp, sizeof(int));
+ s->brp= realloc(s->brp, sizeof(int));
  s->brp[0]=0;
  for(i=0;i<e_d_nbrpts;i++)
  {
@@ -1067,7 +1067,7 @@ int e_brk_schirm(FENSTER *f)
    {
     /****  New break, not in schirm  ****/   
     (s->brp[0])++;
-    s->brp = REALLOC(s->brp, (s->brp[0]+1) * sizeof(int));
+    s->brp = realloc(s->brp, (s->brp[0]+1) * sizeof(int));
     s->brp[s->brp[0]] = e_d_ybrpts[i]-1; 
    }
   }
@@ -1086,7 +1086,7 @@ int e_d_reinit_brks(FENSTER * f,char * prj)
 
    e_remove_breakpoints(f);
    g=strlen(prj);
-   prj2=MALLOC(sizeof(char)*(g+1));
+   prj2=malloc(sizeof(char)*(g+1));
    strcpy(prj2,prj);
    q=0;
    r=0;
@@ -1102,9 +1102,9 @@ int e_d_reinit_brks(FENSTER * f,char * prj)
    e_d_nbrpts=0;
    
 /**** allocate memory for breakpoints ****/   
-   e_d_sbrpts = MALLOC(sizeof(char *) * r);
-   e_d_ybrpts = MALLOC(sizeof(int) * r);
-   e_d_nrbrpts = MALLOC(sizeof(int) * r);
+   e_d_sbrpts = malloc(sizeof(char *) * r);
+   e_d_ybrpts = malloc(sizeof(int) * r);
+   e_d_nrbrpts = malloc(sizeof(int) * r);
    
    name=prj2;
    for(q=0;q<r;q++)
@@ -1121,7 +1121,7 @@ int e_d_reinit_brks(FENSTER * f,char * prj)
 /**** hopefully we have filename and line number ****/
 
 	   e_d_ybrpts[e_d_nbrpts]=line;
-	   e_d_sbrpts[e_d_nbrpts]=MALLOC(sizeof(char)*(strlen(name)+1));
+	   e_d_sbrpts[e_d_nbrpts]=malloc(sizeof(char)*(strlen(name)+1));
 	   strcpy(e_d_sbrpts[e_d_nbrpts],name);
 	   e_d_nbrpts++;
 	   
@@ -1294,17 +1294,17 @@ int e_mk_brk_main(FENSTER *f, int sw)
   e_d_nbrpts++;
   if (e_d_nbrpts == 1)
   {
-   e_d_sbrpts = MALLOC(sizeof(char *));
-   e_d_ybrpts = MALLOC(sizeof(int));
-   e_d_nrbrpts = MALLOC(sizeof(int));
+   e_d_sbrpts = malloc(sizeof(char *));
+   e_d_ybrpts = malloc(sizeof(int));
+   e_d_nrbrpts = malloc(sizeof(int));
   }
   else
   {
-   e_d_sbrpts = REALLOC(e_d_sbrpts, e_d_nbrpts * sizeof(char *));
-   e_d_ybrpts = REALLOC(e_d_ybrpts, e_d_nbrpts * sizeof(int));
-   e_d_nrbrpts = REALLOC(e_d_nrbrpts, e_d_nbrpts * sizeof(int));
+   e_d_sbrpts = realloc(e_d_sbrpts, e_d_nbrpts * sizeof(char *));
+   e_d_ybrpts = realloc(e_d_ybrpts, e_d_nbrpts * sizeof(int));
+   e_d_nrbrpts = realloc(e_d_nrbrpts, e_d_nbrpts * sizeof(int));
   }
-  e_d_sbrpts[e_d_nbrpts - 1] = MALLOC(1);
+  e_d_sbrpts[e_d_nbrpts - 1] = malloc(1);
   if (e_d_swtch)
   {
    if (e_deb_type == 0)
@@ -1429,17 +1429,17 @@ int e_make_breakpoint(FENSTER *f, int sw)
    e_d_nbrpts++;
    if (e_d_nbrpts == 1)
    {
-    e_d_sbrpts = MALLOC(sizeof(char *));
-    e_d_ybrpts = MALLOC(sizeof(int));
-    e_d_nrbrpts = MALLOC(sizeof(int));
+    e_d_sbrpts = malloc(sizeof(char *));
+    e_d_ybrpts = malloc(sizeof(int));
+    e_d_nrbrpts = malloc(sizeof(int));
    }
    else
    {
-    e_d_sbrpts = REALLOC(e_d_sbrpts, e_d_nbrpts * sizeof(char *));
-    e_d_ybrpts = REALLOC(e_d_ybrpts, e_d_nbrpts * sizeof(int));
-    e_d_nrbrpts = REALLOC(e_d_nrbrpts, e_d_nbrpts * sizeof(int));
+    e_d_sbrpts = realloc(e_d_sbrpts, e_d_nbrpts * sizeof(char *));
+    e_d_ybrpts = realloc(e_d_ybrpts, e_d_nbrpts * sizeof(int));
+    e_d_nrbrpts = realloc(e_d_nrbrpts, e_d_nbrpts * sizeof(int));
    }
-   e_d_sbrpts[e_d_nbrpts - 1] = MALLOC(strlen(f->datnam) + 1);
+   e_d_sbrpts[e_d_nbrpts - 1] = malloc(strlen(f->datnam) + 1);
    strcpy(e_d_sbrpts[e_d_nbrpts - 1], f->datnam);
    e_d_ybrpts[e_d_nbrpts - 1] = b->b.y + 1;
    if (e_d_swtch)
@@ -1492,7 +1492,7 @@ int e_make_breakpoint(FENSTER *f, int sw)
     }
    }
    (s->brp[0])++;
-   s->brp = REALLOC(s->brp, (s->brp[0]+1) * sizeof(int));
+   s->brp = realloc(s->brp, (s->brp[0]+1) * sizeof(int));
    s->brp[s->brp[0]] = b->b.y;
   }
  }
@@ -1576,7 +1576,7 @@ int e_exec_deb(FENSTER *f, char *prog)
   {
    if (npipe[i])
     FREE(npipe[i]);
-   npipe[i] = MALLOC(128);
+   npipe[i] = malloc(128);
    sprintf(npipe[i], "%s/we_pipe%d", e_tmp_dir, i);
    remove(npipe[i]);
   }

--- a/we_debug.c
+++ b/we_debug.c
@@ -467,7 +467,7 @@ int e_d_quit_basic(FENSTER *f)
  if (!WpeIsXwin())
  {
   if (e_d_out)
-   FREE(e_d_out);
+   free(e_d_out);
   e_d_out = NULL;
  }
  if (rfildes[1] >= 0)
@@ -544,9 +544,9 @@ int e_remove_all_watches(FENSTER *f)
  int i, n;
 
  if (e_d_nwtchs < 1) return(0);
- for (n = 0; n < e_d_nwtchs;n++) FREE(e_d_swtchs[n]);
- FREE(e_d_swtchs);
- FREE(e_d_nrwtchs);
+ for (n = 0; n < e_d_nwtchs;n++) free(e_d_swtchs[n]);
+ free(e_d_swtchs);
+ free(e_d_nrwtchs);
  e_d_nwtchs = 0;
  for (i = cn->mxedt; i > 0; i--)
  {
@@ -573,7 +573,7 @@ int e_delete_watches(FENSTER *f)
   return(0);
  for (n = 0; n < e_d_nwtchs && e_d_nrwtchs[n] <= b->b.y; n++)
   ;
- FREE(e_d_swtchs[n - 1]);
+ free(e_d_swtchs[n - 1]);
  for (; n < e_d_nwtchs; n++)
   e_d_swtchs[n - 1] = e_d_swtchs[n];
  e_d_nwtchs--;
@@ -697,7 +697,7 @@ int e_d_p_watches(FENSTER *f, int sw)
  
  /* free all lines of BUFFER b */
  e_p_red_buffer(b);
- FREE(b->bf[0].s);
+ free(b->bf[0].s);
  b->mxlines=0;
 
  for (i = 0, l = 0; l < e_d_nwtchs; l++)
@@ -759,7 +759,7 @@ int e_d_p_watches(FENSTER *f, int sw)
      for(k = 0; str[k] != '\0' && str[k] != '='; k++);
     if (str[k] == '\0')
     {
-     if (str != str1) FREE(str);
+     if (str != str1) free(str);
      str = str1;
      strcpy(str, e_d_msg[ERR_NOSYMBOL]);
      k = 0;
@@ -786,7 +786,7 @@ int e_d_p_watches(FENSTER *f, int sw)
   free(str2);
   if(str != str1)
   {
-   FREE(str);
+   free(str);
   }
  }
 
@@ -855,7 +855,7 @@ int e_d_reinit_watches(FENSTER * f,char * prj)
   strcpy(e_d_swtchs[e], prj2+q); 
   q+=strlen(prj2+q)+1;
  } 
- FREE(prj2);
+ free(prj2);
  e_d_p_watches(f, 1);   
  return 0;
 }
@@ -1137,7 +1137,7 @@ int e_d_reinit_brks(FENSTER * f,char * prj)
      }
      name+=e+1;
    }
-   FREE(prj2);
+   free(prj2);
    return 0;
 }
 
@@ -1223,24 +1223,24 @@ int e_remove_breakpoints(FENSTER *f)
    write(rfildes[1], "db *\n", 2);
  }
  for (i = 0; i < e_d_nbrpts; i++)
-  FREE(e_d_sbrpts[i]);
+  free(e_d_sbrpts[i]);
  for (i = cn->mxedt; i >= 0; i--)
   if (DTMD_ISTEXT(cn->f[i]->dtmd))
    cn->f[i]->s->brp[0] = 0;
  e_d_nbrpts = 0;
  if (e_d_sbrpts)
  {
-  FREE(e_d_sbrpts);
+  free(e_d_sbrpts);
   e_d_sbrpts = NULL;
  }
  if (e_d_ybrpts)
  {
-  FREE(e_d_ybrpts);
+  free(e_d_ybrpts);
   e_d_ybrpts = NULL;
  }
  if (e_d_nrbrpts)
  {
-  FREE(e_d_nrbrpts);
+  free(e_d_nrbrpts);
   e_d_nrbrpts = NULL;
  }
  e_rep_win_tree(cn);
@@ -1271,7 +1271,7 @@ int e_mk_brk_main(FENSTER *f, int sw)
    write(rfildes[1], eing, strlen(eing));
    if (e_d_dum_read() == -1) return(-1);
   }
-  FREE(e_d_sbrpts[sw-1]);
+  free(e_d_sbrpts[sw-1]);
   for (i = sw-1; i < e_d_nbrpts - 1; i++)
   {
    e_d_sbrpts[i] = e_d_sbrpts[i+1];
@@ -1281,11 +1281,11 @@ int e_mk_brk_main(FENSTER *f, int sw)
   e_d_nbrpts--;
   if (e_d_nbrpts == 0)
   {
-   FREE(e_d_sbrpts);
+   free(e_d_sbrpts);
    e_d_sbrpts = NULL;
-   FREE(e_d_ybrpts);
+   free(e_d_ybrpts);
    e_d_ybrpts = NULL;
-   FREE(e_d_nrbrpts);
+   free(e_d_nrbrpts);
    e_d_nrbrpts = NULL;
   }
  }
@@ -1406,7 +1406,7 @@ int e_make_breakpoint(FENSTER *f, int sw)
     write(rfildes[1], eing, strlen(eing));
     if (e_d_dum_read() == -1) return(-1);
    }
-   FREE(e_d_sbrpts[i]);
+   free(e_d_sbrpts[i]);
    for (; i < e_d_nbrpts - 1; i++)
    {
     e_d_sbrpts[i] = e_d_sbrpts[i+1];
@@ -1416,11 +1416,11 @@ int e_make_breakpoint(FENSTER *f, int sw)
    e_d_nbrpts--;
    if (e_d_nbrpts == 0)
    {
-    FREE(e_d_sbrpts);
+    free(e_d_sbrpts);
     e_d_sbrpts = NULL;
-    FREE(e_d_ybrpts);
+    free(e_d_ybrpts);
     e_d_ybrpts = NULL;
-    FREE(e_d_nrbrpts);
+    free(e_d_nrbrpts);
     e_d_nrbrpts = NULL;
    }
   }
@@ -1575,7 +1575,7 @@ int e_exec_deb(FENSTER *f, char *prog)
   for (i = 0; i < 5; i++)
   {
    if (npipe[i])
-    FREE(npipe[i]);
+    free(npipe[i]);
    npipe[i] = malloc(128);
    sprintf(npipe[i], "%s/we_pipe%d", e_tmp_dir, i);
    remove(npipe[i]);
@@ -2468,8 +2468,8 @@ int e_d_goto_break(char *file, int line, FENSTER *f)
    break;
   }
  f = cn->f[cn->mxedt];
- FREE(ftmp.dirct);
- FREE(ftmp.datnam);
+ free(ftmp.dirct);
+ free(ftmp.datnam);
  if (i <= 0)
  {
   if (access(file, 0))

--- a/we_e_aus.c
+++ b/we_e_aus.c
@@ -180,7 +180,7 @@ int e_schreib_zif(int *num, int x, int y, int max, int ft, int fs)
 #endif
  int c, i, jc = max-1, ntmp = *num, nnum = WpeNumberOfPlaces(ntmp);
  int first = 1;
- char *s = MALLOC((max+1)*sizeof(char));
+ char *s = malloc((max+1)*sizeof(char));
 
  e_pr_zstring(WpeNumberToString(ntmp, max, s), x, y, max, fs);
  fk_locate(x+jc, y);
@@ -275,7 +275,7 @@ int e_schreib_leiste(char *s, int x, int y, int n, int max, int ft, int fs)
  int c, i, ja = 0, jc, l = strlen(s);
  int jd;
  int sond = 0, first = 1;
- unsigned char *tmp = MALLOC(max+1);
+ unsigned char *tmp = malloc(max+1);
 
  fk_cursor(1);
  strcpy(tmp, s);
@@ -444,7 +444,7 @@ int e_schreib_leiste(char *s, int x, int y, int n, int max, int ft, int fs)
 
 int e_schr_nzif(int num, int x, int y, int max, int col)
 {
- char *str = MALLOC((max+1)*sizeof(char));
+ char *str = malloc((max+1)*sizeof(char));
  int i, nt;
 
  for (i = 0, nt = 1; i < max; i++) nt *= 10;

--- a/we_e_aus.c
+++ b/we_e_aus.c
@@ -198,7 +198,7 @@ int e_schreib_zif(int *num, int x, int y, int max, int ft, int fs)
    {
     if (c > -2)
      *num = WpeStringToNumber(s);
-    FREE(s);
+    free(s);
     return(c);
    }
   }
@@ -251,7 +251,7 @@ int e_schreib_zif(int *num, int x, int y, int max, int ft, int fs)
   {
    if (c != WPE_ESC)
     *num = WpeStringToNumber(s);
-   FREE(s);
+   free(s);
    return(c);
   }
   if (jc > max -1)
@@ -325,7 +325,7 @@ int e_schreib_leiste(char *s, int x, int y, int n, int max, int ft, int fs)
    else
    {
     if (c > -4) strcpy(s, tmp);
-    FREE(tmp);
+    free(tmp);
     fk_cursor(0);
     return(c);
    }
@@ -419,7 +419,7 @@ int e_schreib_leiste(char *s, int x, int y, int n, int max, int ft, int fs)
   else if (c > 0)	
   { 
    if (c != WPE_ESC) strcpy(s, tmp);
-   FREE(tmp);fk_cursor(0);
+   free(tmp);fk_cursor(0);
    if (c == CtrlP) c = CUP;
    else if (c == CtrlN) c = CDO;
    return(c);
@@ -451,7 +451,7 @@ int e_schr_nzif(int num, int x, int y, int max, int col)
  if (num >= nt)
   num = nt - 1;
  e_pr_zstring(WpeNumberToString(num, max, str), x, y, max, col);
- FREE(str);
+ free(str);
  return(0);
 }
 

--- a/we_edit.c
+++ b/we_edit.c
@@ -1948,7 +1948,7 @@ void WpeFilenameToPathFile(char *filename, char **path, char **file)
     len -= 3;
     filename += 3;
    }
-   *path = WpeMalloc((strlen(cur_dir) + len + 2) * sizeof(char));
+   *path = malloc((strlen(cur_dir) + len + 2) * sizeof(char));
    strcpy(*path, cur_dir);
    strcat(*path, DIRS);
    strncat(*path, filename, len);
@@ -1966,7 +1966,7 @@ void WpeFilenameToPathFile(char *filename, char **path, char **file)
   else
   {
    len = tmp - filename + 1;
-   *path = WpeMalloc(len + 1 * sizeof(char));
+   *path = malloc(len + 1 * sizeof(char));
    strncpy(*path, filename, len);
    (*path)[len] = 0;
   }

--- a/we_edit.c
+++ b/we_edit.c
@@ -75,8 +75,8 @@ int e_edit(ECNT *cn, char *filename)
     (strcmp(cn->f[i]->dirct, path) == 0))
   {
    e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-   WpeFree(path);
-   WpeFree(file);
+   free(path);
+   free(file);
    return(0);
   }
  }
@@ -229,7 +229,7 @@ int e_edit(ECNT *cn, char *filename)
  {
   cn->curedt=0;
   cn->edt[cn->mxedt]=0;
-  WpeFree(file);
+  free(file);
   file = f->datnam = WpeStrdup(BUFFER_NAME);
 #ifdef UNIX
   f->filemode = 0600;
@@ -243,7 +243,7 @@ int e_edit(ECNT *cn, char *filename)
  }
  if (strcmp(file,"") == 0)
  {
-  WpeFree(file);
+  free(file);
   file = f->datnam = WpeStrdup("Noname");
  }
  else
@@ -1926,7 +1926,7 @@ void WpeFilenameToPathFile(char *filename, char **path, char **file)
   {
    if ((cur_dir = WpeGetCurrentDir(WpeEditor)) == NULL)
    {
-    WpeFree(*file);
+    free(*file);
     *file = NULL;
     return ;
    }
@@ -1961,7 +1961,7 @@ void WpeFilenameToPathFile(char *filename, char **path, char **file)
     (*path)[strlen(cur_dir) + len] = DIRC;
     (*path)[strlen(cur_dir) + len + 1] = 0;
    }
-   WpeFree(cur_dir);
+   free(cur_dir);
   }
   else
   {

--- a/we_edit.c
+++ b/we_edit.c
@@ -42,7 +42,7 @@ int e_edit(ECNT *cn, char *filename)
  {
   if (!e_prog.project)
   {
-   e_prog.project = MALLOC(1);
+   e_prog.project = malloc(1);
    e_prog.project[0] = '\0';
   }
   else
@@ -56,7 +56,7 @@ int e_edit(ECNT *cn, char *filename)
     e_close_window(cn->f[cn->mxedt]);
    }
   }
-  e_prog.project = REALLOC(e_prog.project, j + 1);
+  e_prog.project = realloc(e_prog.project, j + 1);
   strcpy(e_prog.project, filename);
   e_make_prj_opt(cn->f[cn->mxedt]);
 /************************************/  
@@ -103,17 +103,17 @@ int e_edit(ECNT *cn, char *filename)
  (cn->mxedt)++;
  cn->edt[cn->mxedt]=j;
    
- if ((f = (FENSTER *)MALLOC(sizeof(FENSTER))) == NULL)
+ if ((f = (FENSTER *)malloc(sizeof(FENSTER))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
    
  f->fb = cn->fb;
  cn->f[cn->mxedt] = f;
 
- if ((f->b = (BUFFER *)MALLOC(sizeof(BUFFER))) == NULL)
+ if ((f->b = (BUFFER *)malloc(sizeof(BUFFER))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, f->fb);
- if ((f->s = (SCHIRM*)MALLOC(sizeof(SCHIRM))) == NULL)
+ if ((f->s = (SCHIRM*)malloc(sizeof(SCHIRM))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, f->fb);
- if ((f->b->bf = (STRING *) MALLOC(MAXLINES*sizeof(STRING))) == NULL)
+ if ((f->b->bf = (STRING *) malloc(MAXLINES*sizeof(STRING))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, f->fb);
 #ifdef PROG
  for (i = cn->mxedt-1;
@@ -218,7 +218,7 @@ int e_edit(ECNT *cn, char *filename)
  f->s->fe = e_set_pnt(0, 0);
  f->s->fb = f->fb;
 #ifdef DEBUGGER
- f->s->brp = MALLOC(sizeof(int));
+ f->s->brp = malloc(sizeof(int));
  f->s->brp[0] = 0;
  f->s->da.y = -1;
 #endif
@@ -1315,7 +1315,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
  if (!do_auto_indent)
  {
   /* insert TAB char */
-  str = MALLOC(sizeof(char));
+  str = malloc(sizeof(char));
   str[0] = '\t';
   char_to_ins = 1;
  }
@@ -1340,7 +1340,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
    /* indent to x with spaces */
    /* insert chars */
    k = x - b->b.x;
-   str = MALLOC(k * sizeof(char));
+   str = malloc(k * sizeof(char));
    for (x = 0; x < k; x++)
     str[x] = ' ';
    char_to_ins = k;
@@ -1350,7 +1350,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
    /* indent to x + a_indent with spaces */
    /* insert chars */
    k = x + a_indent - b->b.x;
-   str = MALLOC(k * sizeof(char));
+   str = malloc(k * sizeof(char));
    for (x = 0; x < k; x++)
     str[x] = ' ';
    char_to_ins = k;
@@ -1358,7 +1358,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
   else
   {
    /* insert TAB char */
-   str = MALLOC(sizeof(char));
+   str = malloc(sizeof(char));
    str[0] = '\t';
    char_to_ins = 1;
   }
@@ -1387,7 +1387,7 @@ int e_del_a_ind(BUFFER *b, SCHIRM *s)
    }
    if (i != j)
    {
-    char *str = MALLOC(i * sizeof(char));
+    char *str = malloc(i * sizeof(char));
     e_del_nchar(b, s, 0, b->b.y, j);
     for (j = 0; j < i; j++)
      str[j] = ' ';
@@ -1438,7 +1438,7 @@ int e_car_a_ind(BUFFER *b, SCHIRM *s)
   i--;
  if (i > 0)
  {
-  str = MALLOC(i * sizeof(char));
+  str = malloc(i * sizeof(char));
   for (j = 0; j < i; j++)
    str[j] = ' ';
   e_ins_nchar(b, s, str, 0, b->b.y, i);
@@ -1810,17 +1810,17 @@ int e_new_line(int yd, BUFFER *b)
  if (b->mxlines > b->mx.y-2)
  {
   b->mx.y += MAXLINES;
-  if ((b->bf = REALLOC(b->bf, b->mx.y * sizeof(STRING))) == NULL)
+  if ((b->bf = realloc(b->bf, b->mx.y * sizeof(STRING))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, b->fb);
   if (b->f->c_sw)
-   b->f->c_sw = REALLOC(b->f->c_sw , b->mx.y * sizeof(int));
+   b->f->c_sw = realloc(b->f->c_sw , b->mx.y * sizeof(int));
  }
  for (i = b->mxlines-1; i >= yd; i--)
  {
   b->bf[i+1] = b->bf[i];
  }
  (b->mxlines)++;
- b->bf[yd].s = MALLOC(b->mx.x+1);
+ b->bf[yd].s = malloc(b->mx.x+1);
  if (b->bf[yd].s == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, b->fb);
  *(b->bf[yd].s) = '\0';
@@ -2047,7 +2047,7 @@ int e_autosave(FENSTER *f)
  if (((maxname = pathconf(f->dirct, _PC_NAME_MAX)) >= strlen(f->datnam) + 4) &&
    (maxname > 12))
  {
-  str = MALLOC(strlen(f->datnam) + 5);
+  str = malloc(strlen(f->datnam) + 5);
   str = e_make_postf(str, f->datnam, ".ASV");
   tmp = f->datnam;
   f->datnam = str;
@@ -2103,7 +2103,7 @@ int e_add_undo(int sw, BUFFER *b, int x, int y, int n)
  if (e_undo_sw) return(0);
  if (!e_redo_sw && b->rd)
   b->rd = e_remove_undo(b->rd, WpeEditor->numundo+1);
- if ((next = MALLOC(sizeof(Undo))) == NULL)
+ if ((next = malloc(sizeof(Undo))) == NULL)
  {
   e_error(e_msg[ERR_LOWMEM], 0, b->fb);
   return(-1);
@@ -2118,7 +2118,7 @@ int e_add_undo(int sw, BUFFER *b, int x, int y, int n)
  else if (sw == 'p') next->u.c = b->bf[y].s[x];
  else if (sw == 'r' || sw == 's')
  {
-  char *str = MALLOC(n);
+  char *str = malloc(n);
   int i;
 
   if (str == NULL)
@@ -2147,12 +2147,12 @@ int e_add_undo(int sw, BUFFER *b, int x, int y, int n)
  }
  else if (sw == 'd')
  {
-  BUFFER *bn = MALLOC(sizeof(BUFFER));
-  SCHIRM *sn = MALLOC(sizeof(SCHIRM));
-  FENSTER *fn = MALLOC(sizeof(FENSTER));
+  BUFFER *bn = malloc(sizeof(BUFFER));
+  SCHIRM *sn = malloc(sizeof(SCHIRM));
+  FENSTER *fn = malloc(sizeof(FENSTER));
   FENSTER *f = b->cn->f[b->cn->mxedt];
 
-  bn->bf = (STRING *) MALLOC(MAXLINES*sizeof(STRING));
+  bn->bf = (STRING *) malloc(MAXLINES*sizeof(STRING));
   if (bn == NULL || sn == 0 || bn->bf == NULL)
    return(e_error(e_msg[ERR_LOWMEM], 0, b->fb));
   fn->b = bn;

--- a/we_edit.c
+++ b/we_edit.c
@@ -304,7 +304,7 @@ int e_edit(ECNT *cn, char *filename)
   f->filemode = 0666 & ~i;
  }
 #endif
- FREE(complete_fname);
+ free(complete_fname);
 
  if (fp != NULL && ftype != 1)
  {
@@ -349,7 +349,7 @@ int e_edit(ECNT *cn, char *filename)
   else
   {
    e_p_m_buffer = f->b;
-   FREE(f->b->bf[0].s);
+   free(f->b->bf[0].s);
    f->b->mxlines = 0;
   }
  }
@@ -1365,7 +1365,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
  }
 
  e_ins_nchar(b, s, str, b->b.x, b->b.y, char_to_ins);
- FREE(str);
+ free(str);
  return(b->b.x);
 }
 
@@ -1393,7 +1393,7 @@ int e_del_a_ind(BUFFER *b, SCHIRM *s)
      str[j] = ' ';
     e_ins_nchar(b, s, str, 0, b->b.y, i);
     b->b.x = i - 1;
-    FREE(str);
+    free(str);
    }
    for (j = b->b.y-1; j >= 0; j--)
    {
@@ -1443,7 +1443,7 @@ int e_car_a_ind(BUFFER *b, SCHIRM *s)
    str[j] = ' ';
   e_ins_nchar(b, s, str, 0, b->b.y, i);
   b->b.x = i;
-  FREE(str);
+  free(str);
  }
  return(i);
 }
@@ -2057,7 +2057,7 @@ int e_autosave(FENSTER *f)
   WpeMouseRestoreShape();
   f->datnam = tmp;
   f->save = 1;
-  FREE(str);
+  free(str);
  }
  return(0);
 }
@@ -2070,27 +2070,27 @@ Undo *e_remove_undo(Undo *ud, int sw)
  if (sw > WpeEditor->numundo)
  {
   if(ud->type == 'l')
-   FREE(ud->u.pt);
+   free(ud->u.pt);
   else if (ud->type == 'd')
   {
    BUFFER *b = (BUFFER*) ud->u.pt;
    int i;
 
-   FREE(b->f->s);
-   FREE(b->f);
+   free(b->f->s);
+   free(b->f);
    if (b->bf != NULL)
    {
     for (i = 0; i < b->mxlines; i++)
     {
      if (b->bf[i].s != NULL)
-      FREE( b->bf[i].s );
+      free( b->bf[i].s );
      b->bf[i].s = NULL;
     }
-    FREE(b->bf);
+    free(b->bf);
    }
-   FREE(b);
+   free(b);
   }
-  FREE(ud);
+  free(ud);
   ud = NULL;
  }
  return(ud);
@@ -2124,7 +2124,7 @@ int e_add_undo(int sw, BUFFER *b, int x, int y, int n)
   if (str == NULL)
   {
    e_error(e_msg[ERR_LOWMEM], 0, b->fb);
-   FREE(next);
+   free(next);
    return(-1);
   }
   for (i = 0; i < n; i++)
@@ -2241,7 +2241,7 @@ int e_make_rudo(FENSTER *f, int sw)
   s->mark_begin = ud->b;
   s->mark_end.y = ud->b.y;
   s->mark_end.x = ud->b.x + ud->a.x;
-  FREE(ud->u.pt);
+  free(ud->u.pt);
  }
  else if (ud->type == 'l')
  {
@@ -2283,17 +2283,17 @@ int e_make_rudo(FENSTER *f, int sw)
   s->mark_end = bn->f->s->mark_end;
   e_move_block(ud->b.x, ud->b.y, bn, b, f);
   e_undo_sw = 0;
-  FREE(bn->f->s);
-  FREE(bn->f);
-  FREE(bn->bf[0].s);
-  FREE(bn->bf);
-  FREE(ud->u.pt);
+  free(bn->f->s);
+  free(bn->f);
+  free(bn->bf[0].s);
+  free(bn->bf);
+  free(ud->u.pt);
   e_add_undo('c', b, ud->b.x, ud->b.y, 0);
  }
  if (!sw) b->ud = ud->next;
  else b->rd = ud->next;
  e_redo_sw = 0;
- FREE(ud);
+ free(ud);
  e_schirm(f, 1);
  e_cursor(f, 1);
  return(0);

--- a/we_fl_fkt.c
+++ b/we_fl_fkt.c
@@ -266,7 +266,7 @@ int e_write(int xa, int ya, int xe, int ye, FENSTER *f, int backup)
   if (access(tmp, 0) == 0)
    remove(tmp);
   WpeRenameCopy(ptmp, tmp, f, 1);
-  WpeFree(tmp);
+  free(tmp);
  }
  if ((fp = fopen(ptmp, "wb")) == NULL)
  {

--- a/we_fl_fkt.c
+++ b/we_fl_fkt.c
@@ -355,7 +355,7 @@ char *e_bakfilename(char* s)
   if (!bak) bak = SIMPLE_BACKUP_SUFFIX;
  }
 
- result = WpeMalloc(strlen(s) + strlen(bak) + 5);
+ result = malloc(strlen(s) + strlen(bak) + 5);
  if (!*bak)
   return e_new_qual(s, "bak", result); /* TurboC style */
  else

--- a/we_fl_fkt.c
+++ b/we_fl_fkt.c
@@ -33,11 +33,11 @@ char *e_mkfilename(char *dr, char *fn)
   return(NULL);
  if(!dr)
  {
-  fl = MALLOC(strlen(fn) + 1);
+  fl = malloc(strlen(fn) + 1);
   strcpy(fl, fn);
   return(fl);
  }
- fl = MALLOC(strlen(dr) + strlen(fn) + 2);
+ fl = malloc(strlen(dr) + strlen(fn) + 2);
  strcpy(fl, dr);
  if (dr[0] != '\0' && dr[strlen(dr)-1] != DIRC)
   strcat(fl, DIRS);
@@ -541,7 +541,7 @@ typedef struct
 int e_mkdir_path(char *path)
 {
  int i, len;
- char *tmp = MALLOC(((len=strlen(path))+1)*sizeof(char));
+ char *tmp = malloc(((len=strlen(path))+1)*sizeof(char));
 
  if (!tmp)
   return(-1);
@@ -569,7 +569,7 @@ IFILE *e_i_fopen(char *path, char *stat)
 
  if (!path) {  return(NULL);  }
  if ((fp = gzopen(path, stat))) {  return(fp);  }
- if (!(tmp2 = MALLOC((strlen(path)+11)*sizeof(char))))
+ if (!(tmp2 = malloc((strlen(path)+11)*sizeof(char))))
  {
   FREE(fp);
   return(NULL);
@@ -616,12 +616,12 @@ IFILE *e_i_fopen(char *path, char *stat)
  extern char *e_tmp_dir;
  char *tmp, *command;
  int len;
- IFILE *fp = MALLOC(sizeof(IFILE));
+ IFILE *fp = malloc(sizeof(IFILE));
 
  if (!fp) return(NULL);
  if (!path) {  FREE(fp); return(NULL);  }
  if ((fp->fp = fopen(path, stat))) {  fp->sw = 0;  return(fp);  }
- if (!(tmp2 = MALLOC((strlen(path)+11)*sizeof(char)))) 
+ if (!(tmp2 = malloc((strlen(path)+11)*sizeof(char)))) 
  {
   FREE(fp);
   return(NULL);
@@ -657,7 +657,7 @@ IFILE *e_i_fopen(char *path, char *stat)
    }
   }
  }
- if (!(tmp = MALLOC((strlen(path)+(len=strlen(e_tmp_dir))+2)*sizeof(char)))) 
+ if (!(tmp = malloc((strlen(path)+(len=strlen(e_tmp_dir))+2)*sizeof(char)))) 
  {
   FREE(fp);
   FREE(tmp2);
@@ -673,7 +673,7 @@ IFILE *e_i_fopen(char *path, char *stat)
   FREE(tmp2);
   return(fp);
  }
- command = MALLOC((strlen(tmp) + strlen(tmp2) + 14) * sizeof(char));
+ command = malloc((strlen(tmp) + strlen(tmp2) + 14) * sizeof(char));
  if (!command) {  FREE(fp);  FREE(tmp);  FREE(tmp2);  return(NULL);  }
  e_mkdir_path(tmp);
  sprintf(command, "gunzip < %s > %s", tmp2, tmp);
@@ -710,9 +710,9 @@ int e_read_help(char *str, FENSTER *f, int sw)
  if (!fp)
   return(1);
  e_close_buffer(f->b);
- if ((f->b = (BUFFER *) MALLOC(sizeof(BUFFER))) == NULL)
+ if ((f->b = (BUFFER *) malloc(sizeof(BUFFER))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, f->fb);
- if ((f->b->bf = (STRING *) MALLOC(MAXLINES*sizeof(STRING))) == NULL)
+ if ((f->b->bf = (STRING *) malloc(MAXLINES*sizeof(STRING))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, f->fb);
  f->b->f = f;
  f->b->b = e_set_pnt(0, 0);
@@ -753,7 +753,7 @@ int e_read_help(char *str, FENSTER *f, int sw)
    for (i = 0; (tmp[i] = tp[i]) && tp[i] != HED; i++)
     ;
    tmp[i] = HED;  tmp[i+1] = '\0';
-   if ((ud_help->str = MALLOC((strlen(tmp)+1)*sizeof(char))) != NULL)
+   if ((ud_help->str = malloc((strlen(tmp)+1)*sizeof(char))) != NULL)
     strcpy(ud_help->str, tmp);
    strcpy(f->b->bf[f->b->mxlines-1].s, tstr);
    f->b->bf[f->b->mxlines-1].len = e_str_len(f->b->bf[f->b->mxlines-1].s);
@@ -786,11 +786,11 @@ int e_help_ret(FENSTER *f)
 	 for(j = i+1; j < b->bf[b->b.y].len
 			&& (str[j-i] = b->bf[b->b.y].s[j]) != HED; j++);
 	 str[j-i+1] = '\0';
-	 if((next = MALLOC(sizeof(struct help_ud))) != NULL)
-	 {  next->str = MALLOC((strlen(str)+1) * sizeof(char));
+	 if((next = malloc(sizeof(struct help_ud))) != NULL)
+	 {  next->str = malloc((strlen(str)+1) * sizeof(char));
 	    if(next->str) strcpy(next->str, str);
             if(ud_help && ud_help->file)
-            {  next->file = MALLOC((strlen(ud_help->file)+1) * sizeof(char));
+            {  next->file = malloc((strlen(ud_help->file)+1) * sizeof(char));
                if(next->file) strcpy(next->file, ud_help->file);
             }
             else next->file = NULL;
@@ -813,10 +813,10 @@ int e_help_ret(FENSTER *f)
 	 for(i++, j = 0; j+i < b->bf[b->b.y].len
 			&& (str[j] = b->bf[b->b.y].s[j+i]) != HED; j++);
 	 str[j] = '\0';
-	 if((next = MALLOC(sizeof(struct help_ud))) != NULL)
-	 {  next->str = MALLOC(4 * sizeof(char));
+	 if((next = malloc(sizeof(struct help_ud))) != NULL)
+	 {  next->str = malloc(4 * sizeof(char));
 	    if(next->str) strcpy(next->str, "Top");
-            next->file = MALLOC((strlen(str)+1) * sizeof(char));
+            next->file = malloc((strlen(str)+1) * sizeof(char));
             if(next->file) strcpy(next->file, str);
             next->sw = 1;
 	    next->next = ud_help;
@@ -898,7 +898,7 @@ int e_help_next(FENSTER *f, int sw)
    }
    else
    {  if(sw)
-      {  if((last = MALLOC(sizeof(struct help_ud))) != NULL)
+      {  if((last = malloc(sizeof(struct help_ud))) != NULL)
 	 {  last->str = NULL;
             last->file = NULL;
 	    last->x = last->y = 0;
@@ -940,8 +940,8 @@ int e_help_comp(FENSTER *f)
 {
  BUFFER *b = f->b;
  int i, j, k, hn = 0, sn = 0;
- char **swtch = MALLOC(sizeof(char *));
- char **hdrs = MALLOC(sizeof(char *));
+ char **swtch = malloc(sizeof(char *));
+ char **hdrs = malloc(sizeof(char *));
  char str[256];
 
  if (f->dtmd != DTMD_HELP) return(1);
@@ -963,8 +963,8 @@ int e_help_comp(FENSTER *f)
     }
     str[k-i-1] = '\0';
     sn++;
-    swtch = REALLOC(swtch, sn * sizeof(char *));
-    swtch[sn-1] = MALLOC((strlen(str) + 1) + sizeof(char));
+    swtch = realloc(swtch, sn * sizeof(char *));
+    swtch[sn-1] = malloc((strlen(str) + 1) + sizeof(char));
     strcpy(swtch[sn-1], str);
    }
   }
@@ -987,8 +987,8 @@ int e_help_comp(FENSTER *f)
     }
     str[k-i-1] = '\0';
     hn++;
-    hdrs = REALLOC(hdrs, hn * sizeof(char *));
-    hdrs[hn-1] = MALLOC((strlen(str) + 1) + sizeof(char));
+    hdrs = realloc(hdrs, hn * sizeof(char *));
+    hdrs[hn-1] = malloc((strlen(str) + 1) + sizeof(char));
     strcpy(hdrs[hn-1], str);
    }
   }
@@ -1105,7 +1105,7 @@ IFILE *e_info_jump(char *str, char **path, IFILE *fp)
  IFILE *fpn;
  int i, j, n, anz = 0;
  char *ptmp, *fstr, tstr[256], nfl[128];
- struct FL_INFO{  char *name; int line;  } **files = MALLOC(1);
+ struct FL_INFO{  char *name; int line;  } **files = malloc(1);
 
  while (e_i_fgets(tstr, 256, fp) && tstr[0] != IFE)
  {
@@ -1114,14 +1114,14 @@ IFILE *e_info_jump(char *str, char **path, IFILE *fp)
   if (!tstr[i]) continue;
   nfl[i] = '\0';
   anz++;
-  files = REALLOC(files, anz * sizeof(struct FL_INFO *));
-  files[anz-1] = MALLOC(sizeof(struct FL_INFO));
-  files[anz-1]->name = MALLOC((strlen(nfl)+1)*sizeof(char));
+  files = realloc(files, anz * sizeof(struct FL_INFO *));
+  files[anz-1] = malloc(sizeof(struct FL_INFO));
+  files[anz-1]->name = malloc((strlen(nfl)+1)*sizeof(char));
   strcpy(files[anz-1]->name, nfl);
   files[anz-1]->line = atoi(tstr+i+1);
  }
  i = (strlen(str) + 6);
- fstr = MALLOC((i+1) * sizeof(char));
+ fstr = malloc((i+1) * sizeof(char));
  strcat(strcpy(fstr, "Node: "), str);
  if (fstr[n = strlen(fstr)-1] == HED) {  fstr[n] = '\0';  i--;  }
  while ((ptmp = e_i_fgets(tstr, 256, fp)) && strncmp(tstr, fstr, i))
@@ -1133,7 +1133,7 @@ IFILE *e_info_jump(char *str, char **path, IFILE *fp)
    ;
   if (files[i-1]->name[0] == DIRC)
   {
-   ptmp = MALLOC((strlen(files[i-1]->name)+1)*sizeof(char));
+   ptmp = malloc((strlen(files[i-1]->name)+1)*sizeof(char));
    strcpy(ptmp, files[i-1]->name);
   }
   else
@@ -1141,7 +1141,7 @@ IFILE *e_info_jump(char *str, char **path, IFILE *fp)
    for (n = strlen(*path)-1; n >= 0 && *(*path+n) != DIRC; n--)
     ;
    n++;
-   ptmp = MALLOC((strlen(files[i-1]->name)+n+1)*sizeof(char));
+   ptmp = malloc((strlen(files[i-1]->name)+n+1)*sizeof(char));
    for (j = 0; j < n; j++)
     ptmp[j] = *(*path+j);
    ptmp[j] = '\0';
@@ -1188,7 +1188,7 @@ char *e_mk_info_pt(char *str, char *node)
  tmp[i] = '\0';
  if (i == 0)
   return(NULL);
- ptmp = MALLOC((strlen(tmp)+1)*sizeof(char));
+ ptmp = malloc((strlen(tmp)+1)*sizeof(char));
  strcpy(ptmp, tmp);
  return(ptmp);
 }
@@ -1203,7 +1203,7 @@ char *e_mk_info_path(char *path, char *file)
  {
   if (path && !strcmp(path, file)) {  FREE(path);  return(NULL);  }
   else if(path) FREE(path);
-  if (!(path = MALLOC((strlen(file) + 1) * sizeof(char)))) return(NULL);
+  if (!(path = malloc((strlen(file) + 1) * sizeof(char)))) return(NULL);
   return (strcpy(path, file));
  }
  tp = info_file;
@@ -1217,7 +1217,7 @@ char *e_mk_info_path(char *path, char *file)
   FREE(path);
  }
  for (n = 0; tp[n] && tp[n] != PTHD; n++);
- if (!(path = MALLOC((strlen(file) + n + 2) * sizeof(char)))) return(NULL);
+ if (!(path = malloc((strlen(file) + n + 2) * sizeof(char)))) return(NULL);
  strncpy(path, tp, n);
  if (n > 1) path[n++] = DIRC;
  strcpy(path + n, file);
@@ -1241,9 +1241,9 @@ int e_read_info(char *str, FENSTER *f, char *file)
    } while(!fp && path);
    if(!fp) return(1);
    e_close_buffer(f->b);
-   if( (f->b = (BUFFER *) MALLOC(sizeof(BUFFER))) == NULL)
+   if( (f->b = (BUFFER *) malloc(sizeof(BUFFER))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-   if( (f->b->bf = (STRING *) MALLOC(MAXLINES*sizeof(STRING))) == NULL)
+   if( (f->b->bf = (STRING *) malloc(MAXLINES*sizeof(STRING))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
    f->b->f = f;
    f->b->b = e_set_pnt(0, 0);
@@ -1327,11 +1327,11 @@ int e_help_loc(FENSTER *f, int sw)
  }
  if (i < 0)
   e_edit(f->ed, "Help");
- if ((tmp || sw) && (next = MALLOC(sizeof(struct help_ud))))
+ if ((tmp || sw) && (next = malloc(sizeof(struct help_ud))))
  {
   if (tmp)
   {
-   next->str = MALLOC((strlen(tmp)+1) * sizeof(char));
+   next->str = malloc((strlen(tmp)+1) * sizeof(char));
    if (next->str)
     strcpy(next->str, tmp);
   }
@@ -1358,13 +1358,13 @@ int e_help_options(FENSTER *f)
 
  if (!info_file)
  {
-  info_file = MALLOC(1);
+  info_file = malloc(1);
   info_file[0] = '\0';
  }
  strcpy(str, info_file);
  if (e_add_arguments(str, "Info-Path", f, 0 , AltI, NULL))
  {
-  info_file = REALLOC(info_file, strlen(str) + 1);
+  info_file = realloc(info_file, strlen(str) + 1);
   strcpy(info_file, str);
  }
  return(0);

--- a/we_fl_fkt.c
+++ b/we_fl_fkt.c
@@ -107,7 +107,7 @@ POINT e_readin(int i, int j, FILE *fp, BUFFER *b, char *type)
   {
    if (i == 0 && j > 0)
    {
-    FREE(b->bf[j].s);
+    free(b->bf[j].s);
     for (k = j; k < b->mxlines; k++) b->bf[k] = b->bf[k+1];
     (b->mxlines)--;
    }
@@ -271,7 +271,7 @@ int e_write(int xa, int ya, int xe, int ye, FENSTER *f, int backup)
  if ((fp = fopen(ptmp, "wb")) == NULL)
  {
   e_error(e_msg[ERR_FOPEN], 0, f->fb);
-  FREE(ptmp);
+  free(ptmp);
   return(WPE_ESC);
  }
  if (f->filemode >= 0)
@@ -310,7 +310,7 @@ int e_write(int xa, int ya, int xe, int ye, FENSTER *f, int backup)
    else
     putc(*(b->bf[j].s+i), fp);
   }
- FREE(ptmp);
+ free(ptmp);
  fclose(fp);
  return(0);
 }
@@ -374,10 +374,10 @@ int freedf(struct dirfile *df)
  {
   for (; df->anz > 0; (df->anz)--)
    if (*(df->name+df->anz-1))
-    FREE(*(df->name+df->anz-1));
-   FREE(df->name);
+    free(*(df->name+df->anz-1));
+   free(df->name);
  }
- FREE(df);
+ free(df);
  df = NULL;
  return(0);
 }
@@ -557,7 +557,7 @@ int e_mkdir_path(char *path)
    mkdir(tmp, 0700);
   }
  }
- FREE(tmp);
+ free(tmp);
  return(0);
 }
 
@@ -571,46 +571,46 @@ IFILE *e_i_fopen(char *path, char *stat)
  if ((fp = gzopen(path, stat))) {  return(fp);  }
  if (!(tmp2 = malloc((strlen(path)+11)*sizeof(char))))
  {
-  FREE(fp);
+  free(fp);
   return(NULL);
  }
  strcpy(tmp2, path);
  strcat(tmp2, ".info");
  if ((fp = gzopen(tmp2, stat)))
  {
-  FREE(tmp2);
+  free(tmp2);
   return(fp);
  }
  strcpy(tmp2, path);
  strcat(tmp2, ".gz");
  if ((fp = gzopen(tmp2, stat)))
  {
-  FREE(tmp2);
+  free(tmp2);
   return(fp);
  }
  strcpy(tmp2, path);
  strcat(tmp2, ".Z");
  if ((fp = gzopen(tmp2, stat)))
  {
-  FREE(tmp2);
+  free(tmp2);
   return(fp);
  }
  strcpy(tmp2, path);
  strcat(tmp2, ".info.gz");
  if ((fp = gzopen(tmp2, stat)))
  {
-  FREE(tmp2);
+  free(tmp2);
   return(fp);
  }
  strcpy(tmp2, path);
  strcat(tmp2, ".info.Z");
  if ((fp = gzopen(tmp2, stat)))
  {
-  FREE(tmp2);
+  free(tmp2);
   return(fp);
  }
- FREE(fp);
- FREE(tmp2);
+ free(fp);
+ free(tmp2);
  return(NULL);
 #else
  extern char *e_tmp_dir;
@@ -619,18 +619,18 @@ IFILE *e_i_fopen(char *path, char *stat)
  IFILE *fp = malloc(sizeof(IFILE));
 
  if (!fp) return(NULL);
- if (!path) {  FREE(fp); return(NULL);  }
+ if (!path) {  free(fp); return(NULL);  }
  if ((fp->fp = fopen(path, stat))) {  fp->sw = 0;  return(fp);  }
  if (!(tmp2 = malloc((strlen(path)+11)*sizeof(char)))) 
  {
-  FREE(fp);
+  free(fp);
   return(NULL);
  }
  strcpy(tmp2, path);
  strcat(tmp2, ".info");
  if ((fp->fp = fopen(tmp2, stat))) 
  {
-  FREE(tmp2);
+  free(tmp2);
   fp->sw = 0;
   return(fp);
  }
@@ -650,8 +650,8 @@ IFILE *e_i_fopen(char *path, char *stat)
     strcat(tmp2, ".info.Z");
     if (access(tmp2, 0))
     {
-     FREE(fp);
-     FREE(tmp2);
+     free(fp);
+     free(tmp2);
      return(NULL);
     }
    }
@@ -659,8 +659,8 @@ IFILE *e_i_fopen(char *path, char *stat)
  }
  if (!(tmp = malloc((strlen(path)+(len=strlen(e_tmp_dir))+2)*sizeof(char)))) 
  {
-  FREE(fp);
-  FREE(tmp2);
+  free(fp);
+  free(tmp2);
   return(NULL);
  }
  strcpy(tmp, e_tmp_dir);
@@ -669,20 +669,20 @@ IFILE *e_i_fopen(char *path, char *stat)
  if ((fp->fp = fopen(tmp, stat)))
  {
   fp->sw = 1;
-  FREE(tmp);
-  FREE(tmp2);
+  free(tmp);
+  free(tmp2);
   return(fp);
  }
  command = malloc((strlen(tmp) + strlen(tmp2) + 14) * sizeof(char));
- if (!command) {  FREE(fp);  FREE(tmp);  FREE(tmp2);  return(NULL);  }
+ if (!command) {  free(fp);  free(tmp);  free(tmp2);  return(NULL);  }
  e_mkdir_path(tmp);
  sprintf(command, "gunzip < %s > %s", tmp2, tmp);
- FREE(tmp2);
+ free(tmp2);
  system(command);
- FREE(command);  
+ free(command);  
  fp->fp = fopen(tmp, stat);
- FREE(tmp);
- if (!fp->fp) {  FREE(fp);  return(NULL);  }
+ free(tmp);
+ if (!fp->fp) {  free(fp);  return(NULL);  }
  fp->sw = 1;
  return(fp);  
 #endif
@@ -693,7 +693,7 @@ int e_i_fclose(IFILE *fp)
 {
  int ret = fclose(fp->fp);
 
- FREE(fp);
+ free(fp);
  return(ret);
 }
 #endif
@@ -706,7 +706,7 @@ int e_read_help(char *str, FENSTER *f, int sw)
 
  ptmp = e_mkfilename(LIBRARY_DIR, HELP_FILE);
  fp = e_i_fopen(ptmp, "rb");
- FREE(ptmp);
+ free(ptmp);
  if (!fp)
   return(1);
  e_close_buffer(f->b);
@@ -867,8 +867,8 @@ int e_help_last(FENSTER *f)
  e_cursor(f, 1);
  e_schirm(f, 1);
  ud_help = last->next;
- FREE(last->str);
- FREE(last);
+ free(last->str);
+ free(last);
  return(0);
 }
 
@@ -877,14 +877,14 @@ int e_help_next(FENSTER *f, int sw)
    struct help_ud *last = ud_help;
    if(last && last->sw)
    {  if(sw && last->nstr)
-      {  if(last->str) FREE(last->str);
-         if(last->pstr) FREE(last->pstr);
+      {  if(last->str) free(last->str);
+         if(last->pstr) free(last->pstr);
          last->str = last->nstr;
          last->nstr = NULL;
       }
       else if(!sw && last->pstr)
-      {  if(last->str) FREE(last->str);
-         if(last->nstr) FREE(last->nstr);
+      {  if(last->str) free(last->str);
+         if(last->nstr) free(last->nstr);
          last->str = last->pstr;
          last->pstr = NULL;
       }
@@ -925,11 +925,11 @@ int e_help_free(FENSTER *f)
  while (last)
  {
   next = last->next;
-  if (last->str) FREE(last->str);
-  if (last->pstr) FREE(last->pstr);
-  if (last->nstr) FREE(last->nstr);
-  if (last->file) FREE(last->file);
-  FREE(last);
+  if (last->str) free(last->str);
+  if (last->pstr) free(last->pstr);
+  if (last->nstr) free(last->nstr);
+  if (last->file) free(last->file);
+  free(last);
   last = next;
  }
  ud_help = NULL;
@@ -1014,10 +1014,10 @@ int e_help_comp(FENSTER *f)
   }
  }
 ende:
- for (i = 0; i < sn; i++) FREE(swtch[i]);
- for (i = 0; i < hn; i++) FREE(hdrs[i]);
- FREE(swtch);
- FREE(hdrs);
+ for (i = 0; i < sn; i++) free(swtch[i]);
+ for (i = 0; i < hn; i++) free(hdrs[i]);
+ free(swtch);
+ free(hdrs);
  return(0);
 }
 
@@ -1151,19 +1151,19 @@ IFILE *e_info_jump(char *str, char **path, IFILE *fp)
   {
    e_i_fclose(fp);
    fp = fpn;
-   FREE(*path);
+   free(*path);
    *path = ptmp;
   }
   else
-   FREE(ptmp);
+   free(ptmp);
  }
- FREE(fstr);
+ free(fstr);
  for (i = 0; i < anz; i++)
  {
-  FREE(files[i]->name);
-  FREE(files[i]);
+  free(files[i]->name);
+  free(files[i]);
  }
- FREE(files);
+ free(files);
  return(fp);
 }
 
@@ -1201,8 +1201,8 @@ char *e_mk_info_path(char *path, char *file)
  if (!info_file || !*info_file) return(NULL);
  if (file[0] == DIRC)
  {
-  if (path && !strcmp(path, file)) {  FREE(path);  return(NULL);  }
-  else if(path) FREE(path);
+  if (path && !strcmp(path, file)) {  free(path);  return(NULL);  }
+  else if(path) free(path);
   if (!(path = malloc((strlen(file) + 1) * sizeof(char)))) return(NULL);
   return (strcpy(path, file));
  }
@@ -1214,7 +1214,7 @@ char *e_mk_info_path(char *path, char *file)
   else if (n == 1) path[n++] = PTHD;
   while (strncmp(tp, path, n) && (tp = strchr(tp, PTHD)) != NULL && *++tp);
   if (tp == NULL || !*tp || !*(tp += n)) return(NULL);
-  FREE(path);
+  free(path);
  }
  for (n = 0; tp[n] && tp[n] != PTHD; n++);
  if (!(path = malloc((strlen(file) + n + 2) * sizeof(char)))) return(NULL);
@@ -1257,7 +1257,7 @@ int e_read_info(char *str, FENSTER *f, char *file)
    {  if(!strncmp(tstr, "Indirect:", 9)) fp = e_info_jump(str, &path, fp);
       else if(!strncmp(tstr, "File:", 5) && strstr(tstr, fstr)) break;
    }
-   FREE(path);
+   free(path);
    if(ptmp)
    {  ud_help->nstr = e_mk_info_pt(tstr, "Next");
       ud_help->pstr = e_mk_info_pt(tstr, "Prev");

--- a/we_fl_unix.c
+++ b/we_fl_unix.c
@@ -222,7 +222,7 @@ int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
   sprintf(sfile, "%s/%s", f->dirct, b->rdfile);
   b->df = e_find_files(sfile, i);
 
-  FREE(sfile);
+  free(sfile);
 
   /* setup the drawing in the file list window */
   b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
@@ -429,7 +429,7 @@ int WpeCallFileManager(int sw, FENSTER * f)
       if ((tmp = WpeGetWastefile("")))
       {
         ret = WpeCreateFileManager(sw, f->ed, tmp);
-        FREE(tmp);
+        free(tmp);
         return(ret);
       }
       else
@@ -559,7 +559,7 @@ int WpeHandleFileManager(ECNT * cn)
             i++;
           b->rdfile[i] = '\0';
           /* change the working directory */
-          FREE(f->dirct);
+          free(f->dirct);
           if((f->dirct = malloc(strlen(b->rdfile) + 1)) == NULL)
             e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
           strcpy(f->dirct, b->rdfile);
@@ -654,7 +654,7 @@ int WpeHandleFileManager(ECNT * cn)
 
         c = e_schr_lst_wsv(dirtmp, f->a.x + b->xda, f->a.y + 3, b->xdd + 1, WPE_PATHMAX,
                            f->fb->fr.fb, f->fb->fz.fb, &f->ed->ddf, f);
-        FREE(f->dirct);
+        free(f->dirct);
         f->dirct = WpeStrdup(dirtmp);
         free(dirtmp);
 
@@ -699,7 +699,7 @@ int WpeHandleFileManager(ECNT * cn)
         {
           if ((dirtmp = WpeAssemblePath(f->dirct, b->cd, b->dd, b->dw->nf, f)))
           {
-            FREE(f->dirct);
+            free(f->dirct);
             f->dirct = dirtmp;
             e_schr_nchar_wsv(f->dirct, f->a.x + b->xda, f->a.y + 3, 0, b->xdd + 1,
                              f->fb->fr.fb, f->fb->fz.fb);
@@ -806,7 +806,7 @@ int WpeHandleFileManager(ECNT * cn)
         /* change the shape of the mouse */
         WpeMouseChangeShape(WpeWorkingShape);
 
-        FREE(f->dirct);
+        free(f->dirct);
         f->dirct = dirtmp;
 
         /* free up all relevant structures */
@@ -895,7 +895,7 @@ int WpeHandleFileManager(ECNT * cn)
             b->fw->ia = b->fw->nf = 0;
             b->fw->ja = b->fw->srcha;
           }
-          FREE(ftmp);
+          free(ftmp);
         }
         /* we are coming from dirs */
         else if(cold == AltT && b->dw->nf >= b->cd->anz)
@@ -951,7 +951,7 @@ int WpeHandleFileManager(ECNT * cn)
             nco = b->dw->nf = b->cd->anz - 1;
             b->dw->ia = b->dw->ja = 0;
           }
-          FREE(ftmp);
+          free(ftmp);
         }
         c = cold;
         cold = AltN; /* go back to name entry */
@@ -1126,7 +1126,7 @@ int WpeHandleFileManager(ECNT * cn)
 
           /* if there was no error */
           dirtmp = WpeGetCurrentDir(cn);
-          FREE(cn->dirct);
+          free(cn->dirct);
           cn->dirct = dirtmp;
 
           if (svmode >= 0)
@@ -1149,10 +1149,10 @@ int WpeHandleFileManager(ECNT * cn)
             /* determine current dir */
             dirtmp = WpeGetCurrentDir(cn);
 
-            FREE(cn->dirct);
+            free(cn->dirct);
             cn->dirct = dirtmp;
 
-            FREE(svdir);
+            free(svdir);
             svdir = NULL;
           }
 
@@ -1183,7 +1183,7 @@ int WpeHandleFileManager(ECNT * cn)
 
           sprintf(ftmp, "File %s exist\nDo you want to overwrite it ?", filen);
           i = e_message(1, ftmp, f);
-          FREE(ftmp);
+          free(ftmp);
 
           if(i == WPE_ESC)
           {
@@ -1203,8 +1203,8 @@ int WpeHandleFileManager(ECNT * cn)
         }
         else /* save as mode, current dir and window header will/may change */
         {
-          FREE(fe->dirct);
-          FREE(fe->datnam);
+          free(fe->dirct);
+          free(fe->datnam);
         }
 
         WpeFilenameToPathFile(filen, &fe->dirct, &fe->datnam);
@@ -1213,8 +1213,8 @@ int WpeHandleFileManager(ECNT * cn)
         else
         {
           e_write(se->mark_begin.x, se->mark_begin.y, se->mark_end.x, se->mark_end.y, fe, WPE_BACKUP);
-          FREE(fe->dirct);  /* restore current dir window header */
-          FREE(fe->datnam);
+          free(fe->dirct);  /* restore current dir window header */
+          free(fe->datnam);
           fe->dirct = dtp;
           fe->datnam = ftp;
         }
@@ -1222,13 +1222,13 @@ int WpeHandleFileManager(ECNT * cn)
         if(b->sw == 4 && (f->ed->edopt & ED_SYNTAX_HIGHLIGHT))
         {
           if(fe->c_sw)
-            FREE(fe->c_sw);
+            free(fe->c_sw);
           if(WpeIsProg())
             e_add_synt_tl(fe->datnam, fe);
           if(fe->c_st)
           {
             if(fe->c_sw)
-              FREE(fe->c_sw);
+              free(fe->c_sw);
             fe->c_sw = e_sc_txt(NULL, fe->b);
           }
           e_rep_win_tree(f->ed);
@@ -1253,10 +1253,10 @@ int WpeHandleFileManager(ECNT * cn)
           /* determine current dir */
           dirtmp = WpeGetCurrentDir(cn);
 
-          FREE(cn->dirct);
+          free(cn->dirct);
           cn->dirct = dirtmp;
 
-          FREE(svdir);
+          free(svdir);
           svdir = NULL;
         }
 
@@ -1337,7 +1337,7 @@ int WpeHandleFileManager(ECNT * cn)
             /* change the dir attributes */
             WpeFileDirAttributes(ftmp, f);
 
-            FREE(ftmp);
+            free(ftmp);
 
             /* free up old file list structures */
             freedf(b->dd);
@@ -1417,7 +1417,7 @@ int WpeHandleFileManager(ECNT * cn)
 
             /* determine current dir */
             dirtmp = WpeGetCurrentDir(f->ed);
-            FREE(f->ed->dirct);
+            free(f->ed->dirct);
             f->ed->dirct = dirtmp;
           }
 
@@ -1432,7 +1432,7 @@ int WpeHandleFileManager(ECNT * cn)
           {
             if(svdir != NULL)
             {
-              FREE(svdir);
+              free(svdir);
               svdir = NULL;
             }
 
@@ -1464,10 +1464,10 @@ int WpeHandleFileManager(ECNT * cn)
             /* determine current dir */
             dirtmp = WpeGetCurrentDir(cn);
 
-            FREE(cn->dirct);
+            free(cn->dirct);
             cn->dirct = dirtmp;
 
-            FREE(svdir);
+            free(svdir);
             svdir = NULL;
           }
 
@@ -1503,10 +1503,10 @@ int WpeHandleFileManager(ECNT * cn)
     /* determine current dir */
     dirtmp = WpeGetCurrentDir(cn);
 
-    FREE(cn->dirct);
+    free(cn->dirct);
     cn->dirct = dirtmp;
 
-    FREE(svdir);
+    free(svdir);
     svdir = NULL;
   }
 
@@ -1602,7 +1602,7 @@ int WpeMakeNewDir(FENSTER *f)
       ret = 0;
   }
 
-  FREE(dirct);
+  free(dirct);
   return(ret);
 }
 
@@ -1853,14 +1853,14 @@ struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
 
       if(!strncmp(tmp2, buf, i) && buf[i])
       {
-        FREE(tmp2);
+        free(tmp2);
         i++;
       }
       else
       {
-        FREE(tmp2);
-        FREE(buf);
-        FREE(tmp);
+        free(tmp2);
+        free(buf);
+        free(tmp);
         return(df);
       }
     }
@@ -1892,7 +1892,7 @@ struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
           e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
         for(k = 0; k < maxd - 10; k++)
           *(df->name + k) = *(dftmp + k);
-        FREE(dftmp);
+        free(dftmp);
       }
       /* save the current directory */
       if((*(df->name + df->anz) = malloc((strlen(tmp) + 1) * sizeof(char))) == NULL)
@@ -1902,8 +1902,8 @@ struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
       j = -1;
     }
   }
-  FREE(buf);
-  FREE(tmp);
+  free(buf);
+  free(tmp);
   return(df);
 }
 
@@ -1938,14 +1938,14 @@ char  *WpeGetWastefile(char *file)
     {
       if(mkdir(tmp, 0700))
       {
-        FREE(tmp);
+        free(tmp);
         return NULL;
       }
     }
     /* check for wastebasket's permissions */
     if(access(tmp, R_OK | W_OK | X_OK))
     {
-      FREE(tmp);
+      free(tmp);
       return NULL;
     }
     wastebasket = tmp;
@@ -2030,13 +2030,13 @@ struct dirfile *WpeGraphicalFileList(struct dirfile *df, int sw, ECNT *cn)
     *(name + n) = *(df->name + i);
     num[n] = ntmp;
    }
-   FREE(edf->name);
-   FREE(df->name);
+   free(edf->name);
+   free(df->name);
    edf->name = ename;
    df->name = name;
   }
 
-  FREE(num);
+  free(num);
 
   /* reverse order */
   if (sw & 4)
@@ -2137,13 +2137,13 @@ int WpeDelWastebasket(FENSTER *f)
   if ((tmp = WpeGetWastefile("")))
   {
     ret = WpeRemoveDir(tmp, "*", f, 0);
-    FREE(tmp);
+    free(tmp);
 
     /* Unfortunately there is this racing condition, so
        this is necessary to get back the deleted wastebasket. */
     if ((tmp = WpeGetWastefile("")))
     {
-      FREE(tmp);
+      free(tmp);
       ret = 0;
     }
     else
@@ -2186,7 +2186,7 @@ int WpeQuitWastebasket(FENSTER * f)
     if ((tmp = WpeGetWastefile("")))
     {
       ret = WpeRemoveDir(tmp, "*", f, 0);
-      FREE(tmp);
+      free(tmp);
     }
     else
     {
@@ -2223,10 +2223,10 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
       if(strncmp(tmp, dirct, i))
       {
         ret = WpeRenameCopyDir(dirct, file, tmp, f, 0, 0);
-        FREE(tmp);
+        free(tmp);
         return(ret);
       }
-      FREE(tmp);
+      free(tmp);
     }
     else
     {
@@ -2249,7 +2249,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
     if((ret = WpeDirDelOptions(f)) < 0)
     {
       freedf(dd);
-      FREE(tmp);
+      free(tmp);
       return(ret == WPE_ESC ? 1 : 0);
     }
     if(ret)
@@ -2258,7 +2258,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
       f->ed->flopt &= ~FM_REMOVE_PROMPT;
     rec = -1;
   }
-  FREE(tmp);
+  free(tmp);
 
   /* cleans up the files in the directory */
   for(i = 0; i < dd->anz; i++)
@@ -2276,7 +2276,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
     if(ret == WPE_ESC)
     {
       freedf(dd);
-      FREE(tmp);
+      free(tmp);
       f->ed->flopt = svmode;
       return(1);
     }
@@ -2288,7 +2288,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
       /* put message out */
       if(e_mess_win("Remove", tmp, &pic, f))
       {
-        FREE(tmp);
+        free(tmp);
         break;
       }
 
@@ -2303,12 +2303,12 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
       {
         e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
         freedf(dd);
-        FREE(tmp);
+        free(tmp);
         f->ed->flopt = svmode;
         return(1);
       }
     }
-    FREE(tmp);
+    free(tmp);
   }
 
   if(pic)
@@ -2332,7 +2332,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
       if((ret = WpeDirDelOptions(f)) < 0)
       {
         freedf(dd);
-        FREE(tmp);
+        free(tmp);
         return(ret == WPE_ESC ? 1 : 0);
       }
       if(ret)
@@ -2343,7 +2343,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
     else if(rec < 0)
       rec = 0;
 
-    FREE(tmp);
+    free(tmp);
 
     /* call recursively itself to delete the subdirectories */
     for(rec++, i = 0; i < dd->anz; i++)
@@ -2355,11 +2355,11 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
       if(WpeRemoveDir(tmp, file, f, rec))
       {
         freedf(dd);
-        FREE(tmp);
+        free(tmp);
         f->ed->flopt = svmode;
         return(1);
       }
-      FREE(tmp);
+      free(tmp);
     }
     freedf(dd);
   }
@@ -2405,7 +2405,7 @@ int WpeRemove(char *file, FENSTER * f)
         {
           e_rename(file, tmp2, f);
         }
-        FREE(tmp2);
+        free(tmp2);
         ret = 0;
       }
       else
@@ -2423,7 +2423,7 @@ int WpeRemove(char *file, FENSTER * f)
 
         sprintf(tmp2, "Remove File:\n%s", file);
         ret = e_message(1, tmp2, f);
-        FREE(tmp2);
+        free(tmp2);
       }
       else
         ret = 'Y';
@@ -2500,7 +2500,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
 
     sprintf(tmp, "%s%c%s", dirct, DIRC, SUDIR);
     dd = e_find_dir(tmp, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-    FREE(tmp);
+    free(tmp);
 
     for(rec++, i = 0; i < dd->anz; i++)
     {
@@ -2516,13 +2516,13 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
 
       if(WpeRenameCopyDir(tmp, file, ntmp, f, rec, sw))
       {
-        FREE(tmp);
-        FREE(ntmp);
+        free(tmp);
+        free(ntmp);
         freedf(dd);
         return(1);
       }
-      FREE(tmp);
-      FREE(ntmp);
+      free(tmp);
+      free(ntmp);
     }
     freedf(dd);
   }
@@ -2531,7 +2531,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
     e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
   sprintf(tmp, "%s%c%s", dirct, DIRC, file);
   dd = e_find_files(tmp, f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0);
-  FREE(tmp);
+  free(tmp);
 
   mode = f->ed->flopt;
   f->ed->flopt &= ~FM_REMOVE_PROMPT;
@@ -2558,20 +2558,20 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
           pic = NULL;
         }
         ret = e_message(1, tmp, f);
-        FREE(tmp);
+        free(tmp);
 
         if(ret == 'Y')
         {
           if(WpeRemove(ntmp, f))
           {
-            FREE(ntmp);
+            free(ntmp);
             freedf(dd);
             return(1);
           }
         }
         else if(ret == WPE_ESC)
         {
-          FREE(ntmp);
+          free(ntmp);
           freedf(dd);
           return(1);
         }
@@ -2580,7 +2580,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
       {
         if(WpeRemove(ntmp, f))
         {
-          FREE(ntmp);
+          free(ntmp);
           freedf(dd);
           return(1);
         }
@@ -2600,20 +2600,20 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
       sprintf(mtmp, "%s %s", tmp, ntmp);
       if(e_mess_win(!sw ? "Rename" : "Copy", mtmp, &pic, f))
       {
-        FREE(tmp);
-        FREE(ntmp);
-        FREE(mtmp);
+        free(tmp);
+        free(ntmp);
+        free(mtmp);
         break;
       }
-      FREE(mtmp);
+      free(mtmp);
 
       if (sw == 0)
       {
         if ((ret = rename(tmp, ntmp)))
         {
           e_error(e_msg[ERR_RENFILE], 0, f->ed->fb);
-          FREE(tmp);
-          FREE(ntmp);
+          free(tmp);
+          free(ntmp);
           freedf(dd);
           return(1);
         }
@@ -2622,8 +2622,8 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
       {
         if (WpeCopyFileCont(tmp, ntmp, f))
         {
-          FREE(tmp);
-          FREE(ntmp);
+          free(tmp);
+          free(ntmp);
           freedf(dd);
           return(1);
         }
@@ -2632,16 +2632,16 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
       {
         if(WpeLinkFile(tmp, ntmp, f->ed->flopt & FM_TRY_HARDLINK, f))
         {
-          FREE(tmp);
-          FREE(ntmp);
+          free(tmp);
+          free(ntmp);
           freedf(dd);
           return(1);
         }
       }
     }
 
-    FREE(tmp);
-    FREE(ntmp);
+    free(tmp);
+    free(ntmp);
   }
 
   if(pic)
@@ -2704,7 +2704,7 @@ int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
     sprintf(tmp, "File %s exist\nRemove File ?", newname);
     ret = e_message(1, tmp, f);
-    FREE(tmp);
+    free(tmp);
     if (ret == 'Y')
     {
      if (WpeRemove(newname, f))
@@ -2752,7 +2752,7 @@ int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
     do
     {
      if (tmp)
-      FREE(tmp);
+      free(tmp);
      allocate_size += 4;
      if ((tmp = malloc(allocate_size)) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
@@ -2770,7 +2770,7 @@ int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
 
      sprintf(tmpl, "%s%c%s", f->dirct, DIRC, tmp);
      retl = WpeRenameLink(file, newname, tmpl, f);
-     FREE(tmpl);
+     free(tmpl);
     }
     else
     {
@@ -3074,7 +3074,7 @@ int WpePrintFile(FENSTER *f)
 
  sprintf(str, "File: %s\nDo you want to print it?", f->datnam);
  c = e_message(1, str, f);
- FREE(str);
+ free(str);
  if (c != 'Y')
   return(0);
 
@@ -3099,7 +3099,7 @@ int WpePrintFile(FENSTER *f)
  if (remove(str))
   e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
 
- FREE(str);
+ free(str);
  return(0);
 }
 #else
@@ -3208,14 +3208,14 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
           df->name[df->anz - 1] = tp;
         }
         else
-          FREE(tp);
+          free(tp);
       }
     }
   }
 
   freedf(dd);
-  FREE(tmp2);
-  FREE(tmp);
+  free(tmp2);
+  free(tmp);
 
   /* whether recursive action */
   if(!(sw & 512))
@@ -3232,7 +3232,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
   /* find directories */
   dd = e_find_dir(tmp, 0);
 
-  FREE(tmp);
+  free(tmp);
 
   if(!dd)
     return(df);
@@ -3254,7 +3254,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
       sprintf(tmp, "%s%s", dirct, dd->name[i]);
 
     df = WpeSearchFiles(f, tmp, file, string, df, sw);
-    FREE(tmp);
+    free(tmp);
   }
 
   freedf(dd);
@@ -3594,7 +3594,7 @@ struct dirfile *e_make_funct(char *man)
    {
     if (!(ret = strcmp(df->name[j], dout->name[k])))
     {
-     FREE(df->name[j]);
+     free(df->name[j]);
      break;
     }
     else if (ret < 0)
@@ -3607,7 +3607,7 @@ struct dirfile *e_make_funct(char *man)
    dout->name[k] = df->name[j];
    dout->anz++;
   }
-  FREE(df);
+  free(df);
  }
  free(manpath);
  free(sustr);
@@ -3967,7 +3967,7 @@ int e_funct_in(FENSTER * f)
 
   n = e_opt_sec_box(xa, ya, num, opt, f, 1);
 
-  FREE(opt);
+  free(opt);
   if(n < 0)
     return(WPE_ESC);
 

--- a/we_fl_unix.c
+++ b/we_fl_unix.c
@@ -641,7 +641,7 @@ int WpeHandleFileManager(ECNT * cn)
         fk_cursor(1);
 
         /* get the directory name */
-        if ((dirtmp = WpeMalloc(WPE_PATHMAX)) == NULL)        /* dirct mat not have enough memory */
+        if ((dirtmp = malloc(WPE_PATHMAX)) == NULL)        /* dirct mat not have enough memory */
           e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
         if (strlen(f->dirct) >= WPE_PATHMAX)
@@ -1675,7 +1675,7 @@ char *WpeGetCurrentDir(ECNT *cn)
 
   home = 0;
   allocate_size = 256;
-  if ((current_dir = (char *)WpeMalloc(allocate_size + 1)) == NULL)
+  if ((current_dir = (char *)malloc(allocate_size + 1)) == NULL)
   {
    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
    return NULL;

--- a/we_fl_unix.c
+++ b/we_fl_unix.c
@@ -656,7 +656,7 @@ int WpeHandleFileManager(ECNT * cn)
                            f->fb->fr.fb, f->fb->fz.fb, &f->ed->ddf, f);
         FREE(f->dirct);
         f->dirct = WpeStrdup(dirtmp);
-        WpeFree(dirtmp);
+        free(dirtmp);
 
 #if  MOUSE
         if(c == -1)
@@ -3305,7 +3305,7 @@ int WpeGrepWindow(FENSTER * f)
     strcpy(fd->file, o->wstr[1]->txt);
     if (fd->dirct)
     {
-     WpeFree(fd->dirct);
+     free(fd->dirct);
     }
     fd->dirct = WpeStrdup(o->wstr[2]->txt);
   }
@@ -3344,7 +3344,7 @@ int WpeFindWindow(FENSTER * f)
     strcpy(fd->file, o->wstr[0]->txt);
     if (fd->dirct)
     {
-     WpeFree(fd->dirct);
+     free(fd->dirct);
     }
     fd->dirct = WpeStrdup(o->wstr[1]->txt);
   }

--- a/we_fl_unix.c
+++ b/we_fl_unix.c
@@ -1684,7 +1684,7 @@ char *WpeGetCurrentDir(ECNT *cn)
   do
   {
     /* allocate space for the directory name */
-    if ((current_dir = (char *)WpeRealloc(current_dir, allocate_size + 1)) == NULL)
+    if ((current_dir = (char *)realloc(current_dir, allocate_size + 1)) == NULL)
     {
      e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
      return NULL;

--- a/we_fl_unix.c
+++ b/we_fl_unix.c
@@ -94,11 +94,11 @@ int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
   cn->edt[cn->mxedt] = j;
 
   /* allocate window structure */
-  if((f = (FENSTER *)MALLOC(sizeof(FENSTER))) == NULL)
+  if((f = (FENSTER *)malloc(sizeof(FENSTER))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* allocate buffer related to the window (NOT proper type, later casted) */
-  if((b = (FLBFFR *) MALLOC(sizeof(FLBFFR))) == NULL)
+  if((b = (FLBFFR *) malloc(sizeof(FLBFFR))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   f->fb = cn->fb;
@@ -169,7 +169,7 @@ int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
   {
     /* working directory is given, copy it over */
     allocate_size = strlen(dirct);
-    if((f->dirct = MALLOC(allocate_size+1)) == NULL)
+    if((f->dirct = malloc(allocate_size+1)) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
     strcpy(f->dirct, dirct);
@@ -186,22 +186,22 @@ int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
 
   f->b = (BUFFER *)b;
   /* the find pattern can only be 79 see FIND structure */
-  if((b->rdfile = MALLOC(80)) == NULL)
+  if((b->rdfile = malloc(80)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
   strcpy(b->rdfile, f->fd.file);               /* find file pattern */
 
   b->sw = sw;
 
   /* window for files */
-  if((b->fw = (FLWND *) MALLOC(sizeof(FLWND))) == NULL)
+  if((b->fw = (FLWND *) malloc(sizeof(FLWND))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* window for directory */
-  if((b->dw = (FLWND *) MALLOC(sizeof(FLWND))) == NULL)
+  if((b->dw = (FLWND *) malloc(sizeof(FLWND))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
 
-  if((sfile = MALLOC(strlen(f->dirct)+strlen(b->rdfile)+2)) == NULL)
+  if((sfile = malloc(strlen(f->dirct)+strlen(b->rdfile)+2)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* determine current directory */
@@ -503,7 +503,7 @@ int WpeHandleFileManager(ECNT * cn)
      save the current directory to return to it */
   if(f->save == 1 || b->sw == 5)
   {
-    if((svdir = MALLOC(strlen(f->ed->dirct) + 1)) == NULL)
+    if((svdir = malloc(strlen(f->ed->dirct) + 1)) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
     strcpy(svdir, f->ed->dirct);
   }
@@ -560,7 +560,7 @@ int WpeHandleFileManager(ECNT * cn)
           b->rdfile[i] = '\0';
           /* change the working directory */
           FREE(f->dirct);
-          if((f->dirct = MALLOC(strlen(b->rdfile) + 1)) == NULL)
+          if((f->dirct = malloc(strlen(b->rdfile) + 1)) == NULL)
             e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
           strcpy(f->dirct, b->rdfile);
 
@@ -780,7 +780,7 @@ int WpeHandleFileManager(ECNT * cn)
           if(S_ISLNK(buf.st_mode))
           {
             /* cannot go out through a softlink, restore dir name */
-            if((f->dirct = REALLOC(f->dirct, strlen(f->ed->dirct) + 1)) == NULL)
+            if((f->dirct = realloc(f->dirct, strlen(f->ed->dirct) + 1)) == NULL)
               e_error(e_msg[ERR_LOWMEM], 1, f->fb);
             else
               strcpy(f->dirct, f->ed->dirct);
@@ -817,7 +817,7 @@ int WpeHandleFileManager(ECNT * cn)
         freedf(b->dd);
 
         /* reset the current dir path in the control structure */
-        if((f->ed->dirct = REALLOC(f->ed->dirct, strlen(f->dirct) + 1)) == NULL)
+        if((f->ed->dirct = realloc(f->ed->dirct, strlen(f->dirct) + 1)) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, f->fb);
         else
           strcpy(f->ed->dirct, f->dirct);
@@ -860,7 +860,7 @@ int WpeHandleFileManager(ECNT * cn)
         /* we are coming from files */
         if(cold == AltF)
         {
-          if((ftmp = MALLOC(129)) == NULL)
+          if((ftmp = malloc(129)) == NULL)
             e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
           if(strlen(*(b->df->name + b->fw->nf)) > 128)
@@ -900,7 +900,7 @@ int WpeHandleFileManager(ECNT * cn)
         /* we are coming from dirs */
         else if(cold == AltT && b->dw->nf >= b->cd->anz)
         {
-          if((ftmp = MALLOC(129)) == NULL)
+          if((ftmp = malloc(129)) == NULL)
             e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
           /* selected dir */
@@ -1178,7 +1178,7 @@ int WpeHandleFileManager(ECNT * cn)
         /* check whether the file exist */
         if(!access(filen, F_OK))
         {
-          if((ftmp = MALLOC(strlen(filen) + 42)) == NULL)
+          if((ftmp = malloc(strlen(filen) + 42)) == NULL)
             e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
           sprintf(ftmp, "File %s exist\nDo you want to overwrite it ?", filen);
@@ -1330,7 +1330,7 @@ int WpeHandleFileManager(ECNT * cn)
           {
             t = b->dw->nf - b->cd->anz;
 
-            if((ftmp = MALLOC(strlen(*(b->dd->name + t)) + 1)) == NULL)
+            if((ftmp = malloc(strlen(*(b->dd->name + t)) + 1)) == NULL)
               e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
             strcpy(ftmp, *(b->dd->name + t));
@@ -1355,7 +1355,7 @@ int WpeHandleFileManager(ECNT * cn)
           if (cold != AltN)
             strcpy(filen, *(b->df->name + b->fw->nf));
           dirtmp = cn->f[cn->mxedt - 1]->dirct;
-          ftmp = MALLOC(strlen(f->dirct) + strlen(filen) + 2);
+          ftmp = malloc(strlen(f->dirct) + strlen(filen) + 2);
           len = strlen(dirtmp);
           if (strncmp(dirtmp, f->dirct, len) == 0)
           {
@@ -1368,7 +1368,7 @@ int WpeHandleFileManager(ECNT * cn)
            sprintf(ftmp, "%s%s", f->dirct, filen);
           }
           fw->df->anz++;
-          fw->df->name = REALLOC(fw->df->name, fw->df->anz * sizeof(char *));
+          fw->df->name = realloc(fw->df->name, fw->df->anz * sizeof(char *));
           for(i = fw->df->anz - 1; i > fw->nf; i--)
             fw->df->name[i] = fw->df->name[i - 1];
           fw->df->name[i] = ftmp;
@@ -1576,7 +1576,7 @@ int WpeMakeNewDir(FENSTER *f)
   umask(msk = umask(077));
   mode = 0777 & ~msk;
 
-  if((dirct = MALLOC(strlen(f->dirct) + 9)) == NULL)
+  if((dirct = malloc(strlen(f->dirct) + 9)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
   if(f->dirct[strlen(f->dirct) - 1] != DIRC)
@@ -1744,7 +1744,7 @@ char *WpeAssemblePath(char *pth, struct dirfile *cd, struct dirfile *dd, int n,
     if ((adir = WpeGetWastefile("")))
     {
       totall = strlen(adir) + 16;
-      if ((adir = REALLOC(adir, totall)) == NULL)
+      if ((adir = realloc(adir, totall)) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, f->fb);
 
       strcat(adir, DIRS);
@@ -1764,7 +1764,7 @@ char *WpeAssemblePath(char *pth, struct dirfile *cd, struct dirfile *dd, int n,
     if(i >= totall-1)
     {
       totall += 16;
-      if((adir = REALLOC(adir, totall)) == NULL)
+      if((adir = realloc(adir, totall)) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, f->fb);
     }
     *(adir + i) = *(*(cd->name + k) + j);
@@ -1786,7 +1786,7 @@ char *WpeAssemblePath(char *pth, struct dirfile *cd, struct dirfile *dd, int n,
       if(i >= totall-2)
       {
         totall += 16;
-        if((adir = REALLOC(adir, totall)) == NULL)
+        if((adir = realloc(adir, totall)) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, f->fb);
       }
       *(adir + i) = *(*(dd->name + t) + j);
@@ -1822,12 +1822,12 @@ struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
   buf = WpeGetCurrentDir(cn);
 
   buflen = strlen(buf);
-  if((tmp = MALLOC(buflen+1)) == NULL)
+  if((tmp = malloc(buflen+1)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* initialise directory list */
-  if(   ((df = MALLOC(sizeof(struct dirfile))) == NULL)
-     || ((df->name = MALLOC(sizeof(char *) * maxd)) == NULL) )
+  if(   ((df = malloc(sizeof(struct dirfile))) == NULL)
+     || ((df->name = malloc(sizeof(char *) * maxd)) == NULL) )
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   df->anz = 0;
@@ -1847,7 +1847,7 @@ struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
       /* increase the level in the dir tree */
       df->anz = 1;
       /* save the name into first level */
-      if((*(df->name) = MALLOC(12 * sizeof(char))) == NULL)
+      if((*(df->name) = malloc(12 * sizeof(char))) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
       strcpy(*(df->name), "Wastebasket");
 
@@ -1888,14 +1888,14 @@ struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
       {
         maxd += 10;
         dftmp = df->name;
-        if((df->name = MALLOC(sizeof(char *) * maxd)) == NULL)
+        if((df->name = malloc(sizeof(char *) * maxd)) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
         for(k = 0; k < maxd - 10; k++)
           *(df->name + k) = *(dftmp + k);
         FREE(dftmp);
       }
       /* save the current directory */
-      if((*(df->name + df->anz) = MALLOC((strlen(tmp) + 1) * sizeof(char))) == NULL)
+      if((*(df->name + df->anz) = malloc((strlen(tmp) + 1) * sizeof(char))) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
       strcpy(*(df->name + df->anz), tmp);
       df->anz++;
@@ -1928,7 +1928,7 @@ char  *WpeGetWastefile(char *file)
 
     lw = strlen(tmp2) + 1 + strlen(WASTEBASKET) + 1;
     /*    HOME          /     WASTEBASKET       \0    */
-    if((tmp = (char *)MALLOC(lw)) == NULL)
+    if((tmp = (char *)malloc(lw)) == NULL)
       return NULL;
 
     sprintf(tmp, "%s/%s", tmp2, WASTEBASKET);
@@ -1962,7 +1962,7 @@ char  *WpeGetWastefile(char *file)
   /* return wastebasket directory path if no filename in 'file' */
   if(file[0] == '\0')
   {
-    if((tmp2 = MALLOC(strlen(wastebasket)+1)) == NULL)
+    if((tmp2 = malloc(strlen(wastebasket)+1)) == NULL)
       return NULL;
     strcpy(tmp2, wastebasket);
     return(tmp2);
@@ -1972,7 +1972,7 @@ char  *WpeGetWastefile(char *file)
      append to wastebasket sting */
   for(i = strlen(file) - 1; i >= 0 && file[i] != DIRC; i--)
     ;
-  if((tmp2 = MALLOC(strlen(wastebasket) + strlen(file + 1 + i) + 2)) == NULL)
+  if((tmp2 = malloc(strlen(wastebasket) + strlen(file + 1 + i) + 2)) == NULL)
     return NULL;
 
   sprintf(tmp2, "%s/%s", wastebasket, file + 1 + i);
@@ -1986,7 +1986,7 @@ struct dirfile *WpeGraphicalFileList(struct dirfile *df, int sw, ECNT *cn)
  int             ntmp, n, i, *num;
 
  /* allocate the same structure as the argument */
- if ((edf = MALLOC(sizeof(struct dirfile))) == NULL)
+ if ((edf = malloc(sizeof(struct dirfile))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
  edf->anz = df->anz;
@@ -1995,16 +1995,16 @@ struct dirfile *WpeGraphicalFileList(struct dirfile *df, int sw, ECNT *cn)
 /* OSF and AIX fix, for malloc(0) they return NULL */
  if (df->anz)
  {
-  if ((edf->name = MALLOC(df->anz * sizeof(char *))) == NULL)
+  if ((edf->name = malloc(df->anz * sizeof(char *))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
-  if ((num = MALLOC(df->anz * sizeof(int))) == NULL)
+  if ((num = malloc(df->anz * sizeof(int))) == NULL)
    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   for (i = 0; i < df->anz; i++)
   {
    e_file_info(*(df->name + i), str, num + i, sw);
-   if ((*(edf->name + i) = MALLOC(strlen(str) + 1)) == NULL)
+   if ((*(edf->name + i) = malloc(strlen(str) + 1)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
    strcpy(*(edf->name + i), str);
   }
@@ -2012,10 +2012,10 @@ struct dirfile *WpeGraphicalFileList(struct dirfile *df, int sw, ECNT *cn)
   /* sort by time or size mode */
   if (sw & 3)
   {
-   if ((ename = MALLOC(df->anz * sizeof(char *))) == NULL)
+   if ((ename = malloc(df->anz * sizeof(char *))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
-   if ((name = MALLOC(df->anz * sizeof(char *))) == NULL)
+   if ((name = malloc(df->anz * sizeof(char *))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
    for (i = 0; i < df->anz; i++)
@@ -2063,13 +2063,13 @@ struct dirfile *WpeGraphicalDirTree(struct dirfile *cd, struct dirfile *dd, ECNT
   char            str[256];
   int             i = 0, j;
 
-  if((edf = MALLOC(sizeof(struct dirfile))) == NULL)
+  if((edf = malloc(sizeof(struct dirfile))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* for the OSF and AIX this should never be zero, we are always somewhere */
   if(cd->anz + dd->anz > 0)
   {
-    if((edf->name = MALLOC((cd->anz + dd->anz) * sizeof(char *))) == NULL)
+    if((edf->name = malloc((cd->anz + dd->anz) * sizeof(char *))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
 
     for(i = 0; i < cd->anz; i++)
@@ -2098,7 +2098,7 @@ struct dirfile *WpeGraphicalDirTree(struct dirfile *cd, struct dirfile *dd, ECNT
           strcat(str, ctree[0]);
         strcat(str, *(cd->name + i));
       }
-      if((*(edf->name + i) = MALLOC((strlen(str) + 1) * sizeof(char))) == NULL)
+      if((*(edf->name + i) = malloc((strlen(str) + 1) * sizeof(char))) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
       strcpy(*(edf->name + i), str);
     }
@@ -2116,7 +2116,7 @@ struct dirfile *WpeGraphicalDirTree(struct dirfile *cd, struct dirfile *dd, ECNT
         int             tttt = i - cd->anz;
         strcat(str, *(dd->name + tttt));
       }
-      if((*(edf->name + i) = MALLOC((strlen(str) + 1) * sizeof(char))) == NULL)
+      if((*(edf->name + i) = malloc((strlen(str) + 1) * sizeof(char))) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
       strcpy(*(edf->name + i), str);
     }
@@ -2235,7 +2235,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
     }
   }
 
-  if((tmp = MALLOC(strlen(dirct) + strlen(file)+2)) == NULL)
+  if((tmp = malloc(strlen(dirct) + strlen(file)+2)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
   /* search for files in the directory */
@@ -2263,7 +2263,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
   /* cleans up the files in the directory */
   for(i = 0; i < dd->anz; i++)
   {
-    if((tmp = MALLOC(strlen(dirct) + strlen(dd->name[i])+15)) == NULL)
+    if((tmp = malloc(strlen(dirct) + strlen(dd->name[i])+15)) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
     sprintf(tmp, "Remove File:\n%s%c%s", dirct, DIRC, dd->name[i]);
@@ -2319,7 +2319,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
      subdirectories as well */
   if(f->ed->flopt & FM_REKURSIVE_ACTIONS)
   {
-    if((tmp = MALLOC(strlen(dirct) + strlen(SUDIR)+2)) == NULL)
+    if((tmp = malloc(strlen(dirct) + strlen(SUDIR)+2)) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
     /* search for subdirectories */
@@ -2348,7 +2348,7 @@ int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
     /* call recursively itself to delete the subdirectories */
     for(rec++, i = 0; i < dd->anz; i++)
     {
-      if((tmp = MALLOC(strlen(dirct) + strlen(dd->name[i])+2)) == NULL)
+      if((tmp = malloc(strlen(dirct) + strlen(dd->name[i])+2)) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
       sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
@@ -2418,7 +2418,7 @@ int WpeRemove(char *file, FENSTER * f)
     {
       if(f->ed->flopt & FM_REMOVE_PROMPT)
       {
-        if((tmp2 = MALLOC(strlen(file) + 14)) == NULL)
+        if((tmp2 = malloc(strlen(file) + 14)) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
         sprintf(tmp2, "Remove File:\n%s", file);
@@ -2495,7 +2495,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
 
   if(f->ed->flopt & FM_REKURSIVE_ACTIONS)
   {
-    if((tmp = MALLOC(strlen(dirct) + 2 + strlen(SUDIR))) == NULL)
+    if((tmp = malloc(strlen(dirct) + 2 + strlen(SUDIR))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
     sprintf(tmp, "%s%c%s", dirct, DIRC, SUDIR);
@@ -2505,10 +2505,10 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
     for(rec++, i = 0; i < dd->anz; i++)
     {
 
-      if((tmp = MALLOC(strlen(dirct) + 2 + strlen(dd->name[i]))) == NULL)
+      if((tmp = malloc(strlen(dirct) + 2 + strlen(dd->name[i]))) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-      if((ntmp = MALLOC(strlen(newname) + 2 + strlen(dd->name[i]))) == NULL)
+      if((ntmp = malloc(strlen(newname) + 2 + strlen(dd->name[i]))) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
       sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
@@ -2527,7 +2527,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
     freedf(dd);
   }
 
-  if((tmp = MALLOC(strlen(dirct) + 2 + strlen(file))) == NULL)
+  if((tmp = malloc(strlen(dirct) + 2 + strlen(file))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
   sprintf(tmp, "%s%c%s", dirct, DIRC, file);
   dd = e_find_files(tmp, f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0);
@@ -2538,7 +2538,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
 
   for(i = 0; i < dd->anz; i++)
   {
-    if((ntmp = MALLOC(strlen(newname) + 2 + strlen(dd->name[i]))) == NULL)
+    if((ntmp = malloc(strlen(newname) + 2 + strlen(dd->name[i]))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
     sprintf(ntmp, "%s%c%s", newname, DIRC, dd->name[i]);
@@ -2548,7 +2548,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
     {
       if(f->ed->flopt & FM_MOVE_PROMPT)
       {
-        if((tmp = MALLOC(strlen(ntmp) + 31)) == NULL)
+        if((tmp = malloc(strlen(ntmp) + 31)) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
         sprintf(tmp, "File %s exist !\nOverwrite File ?", ntmp);
@@ -2587,14 +2587,14 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
       }
     }
 
-    if((tmp = MALLOC(strlen(dirct) + 2 + strlen(dd->name[i]))) == NULL)
+    if((tmp = malloc(strlen(dirct) + 2 + strlen(dd->name[i]))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
     sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
 
     if(ret == 'Y')
     {
-      if((mtmp = MALLOC(strlen(tmp) + 2 + strlen(ntmp))) == NULL)
+      if((mtmp = malloc(strlen(tmp) + 2 + strlen(ntmp))) == NULL)
         e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
       sprintf(mtmp, "%s %s", tmp, ntmp);
@@ -2700,7 +2700,7 @@ int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
    }
    else if (f->ed->flopt & FM_MOVE_PROMPT)
    {
-    if ((tmp = MALLOC(strlen(newname) + 26)) == NULL)
+    if ((tmp = malloc(strlen(newname) + 26)) == NULL)
      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
     sprintf(tmp, "File %s exist\nRemove File ?", newname);
     ret = e_message(1, tmp, f);
@@ -2754,7 +2754,7 @@ int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
      if (tmp)
       FREE(tmp);
      allocate_size += 4;
-     if ((tmp = MALLOC(allocate_size)) == NULL)
+     if ((tmp = malloc(allocate_size)) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
       ln = readlink(file, tmp, allocate_size-1);
@@ -2765,7 +2765,7 @@ int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
      ;
     if (ln < 0)
     {
-     if ((tmpl = MALLOC(strlen(f->dirct) + 2 + strlen(tmp))) == NULL)
+     if ((tmpl = malloc(strlen(f->dirct) + 2 + strlen(tmp))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
      sprintf(tmpl, "%s%c%s", f->dirct, DIRC, tmp);
@@ -3069,7 +3069,7 @@ int WpePrintFile(FENSTER *f)
  {
   return(e_error(e_msg[ERR_NOPRINT], 0, f->fb));
  }
- if ((str = MALLOC(strlen(f->datnam) + 32 )) == NULL)
+ if ((str = malloc(strlen(f->datnam) + 32 )) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
  sprintf(str, "File: %s\nDo you want to print it?", f->datnam);
@@ -3087,7 +3087,7 @@ int WpePrintFile(FENSTER *f)
  f->dirct = dp;
  f->ins = sins;
 
- if ((str = MALLOC(strlen(e_tmp_dir) + 7 +
+ if ((str = malloc(strlen(e_tmp_dir) + 7 +
                    strlen(f->ed->print_cmd) + strlen(f->datnam) )) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
@@ -3125,7 +3125,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
   {
     tmp2 = WpeGetCurrentDir(f->ed);
 
-    tmp = REALLOC(tmp2, strlen(tmp2) + strlen(dirct) + 4);
+    tmp = realloc(tmp2, strlen(tmp2) + strlen(dirct) + 4);
     if(tmp == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
@@ -3137,7 +3137,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
   }
   else
   {
-    if((tmp2 = MALLOC(strlen(dirct) + 2)) == NULL)
+    if((tmp2 = malloc(strlen(dirct) + 2)) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
     if(dirct[strlen(dirct) - 1] != DIRC)
@@ -3147,18 +3147,18 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
   }
 
   /* assemble total path, dir + filename */
-  if((tmp = MALLOC(strlen(tmp2) + strlen(file) + 2)) == NULL)
+  if((tmp = malloc(strlen(tmp2) + strlen(file) + 2)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
   sprintf(tmp, "%s%s", tmp2, file);
 
   /* initialise structure, only once */
   if(df == NULL)
   {
-    if((df = MALLOC(sizeof(struct dirfile))) == NULL)
+    if((df = malloc(sizeof(struct dirfile))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
     df->anz = 0;
-    if((df->name = MALLOC(sizeof(char *))) == NULL)
+    if((df->name = malloc(sizeof(char *))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
   }
 
@@ -3174,14 +3174,14 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
     {
       for(i = 0; i < dd->anz; i++)
       {
-        if((tp = MALLOC(strlen(tmp2) + strlen(dd->name[i]) + 2)) == NULL)
+        if((tp = malloc(strlen(tmp2) + strlen(dd->name[i]) + 2)) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
         sprintf(tp, "%s%s", tmp2, dd->name[i]);
 
         df->anz++;
 
-        if((tname = REALLOC(df->name, df->anz * sizeof(char *))) == NULL)
+        if((tname = realloc(df->name, df->anz * sizeof(char *))) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
         df->name = tname;
@@ -3193,7 +3193,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
     {
       for(i = 0; i < dd->anz; i++)
       {
-        if((tp = MALLOC(strlen(tmp2) + strlen(dd->name[i]) + 2)) == NULL)
+        if((tp = malloc(strlen(tmp2) + strlen(dd->name[i]) + 2)) == NULL)
           e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
         sprintf(tp, "%s%s", tmp2, dd->name[i]);
@@ -3201,7 +3201,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
         if(WpeGrepFile(tp, string, sw))
         {
           df->anz++;
-          if((tname = REALLOC(df->name, df->anz * sizeof(char *))) == NULL)
+          if((tname = realloc(df->name, df->anz * sizeof(char *))) == NULL)
             e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
           df->name = tname;
@@ -3221,7 +3221,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
   if(!(sw & 512))
     return(df);
 
-  if((tmp = MALLOC(strlen(dirct) + strlen(SUDIR) + 2)) == NULL)
+  if((tmp = malloc(strlen(dirct) + strlen(SUDIR) + 2)) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
   if(dirct[strlen(dirct) - 1] != DIRC)
@@ -3240,7 +3240,7 @@ struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string
   rec++;
   for(i = 0; i < dd->anz; i++)
   {
-    if((tmp = MALLOC(strlen(dirct) + strlen(dd->name[i]) + 3)) == NULL)
+    if((tmp = malloc(strlen(dirct) + strlen(dd->name[i]) + 3)) == NULL)
     {
       e_error(e_msg[ERR_LOWMEM], 0, f->ed->fb);
       rec--;
@@ -3518,7 +3518,7 @@ int e_funct(FENSTER * f)
 
 struct dirfile *e_make_funct(char *man)
 {
- struct dirfile *df = NULL, *dout = MALLOC(sizeof(struct dirfile));
+ struct dirfile *df = NULL, *dout = malloc(sizeof(struct dirfile));
  char *sustr, *subpath, *manpath;
  int ret = 0, n, i = 0, j, k, l = 0;
 
@@ -3577,7 +3577,7 @@ struct dirfile *e_make_funct(char *man)
     ;
    if (k >= 0 /**(df->name[j]+k)*/ )
    {
-    df->name[j] = REALLOC(df->name[j],
+    df->name[j] = realloc(df->name[j],
       (l = strlen(df->name[j]) + 2) * sizeof(char));
     *(df->name[j] + k) = '(';
     *(df->name[j] + l - 2) = ')';
@@ -3585,9 +3585,9 @@ struct dirfile *e_make_funct(char *man)
    }
   }
   if (!dout->name)
-   dout->name = MALLOC(df->anz * sizeof(char *));
+   dout->name = malloc(df->anz * sizeof(char *));
   else
-   dout->name = REALLOC(dout->name, (df->anz + dout->anz) * sizeof(char *));
+   dout->name = realloc(dout->name, (df->anz + dout->anz) * sizeof(char *));
   for (j = 0; j < df->anz; j++)
   {
    for (k = 0; k < dout->anz; k++)
@@ -3644,9 +3644,9 @@ int e_data_first(int sw, ECNT *cn, char *nstr)
   (cn->mxedt)++;
   cn->edt[cn->mxedt] = j;
 
-  if((f = (FENSTER *) MALLOC(sizeof(FENSTER))) == NULL)
+  if((f = (FENSTER *) malloc(sizeof(FENSTER))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-  if((fw = (FLWND *) MALLOC(sizeof(FLWND))) == NULL)
+  if((fw = (FLWND *) malloc(sizeof(FLWND))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
   f->fb = cn->fb;
   cn->f[cn->mxedt] = f;
@@ -3667,7 +3667,7 @@ int e_data_first(int sw, ECNT *cn, char *nstr)
     f->dirct = NULL; /* how about a free up ??? */
   else
   {
-    f->dirct = MALLOC(strlen(nstr) + 1);
+    f->dirct = malloc(strlen(nstr) + 1);
     strcpy(f->dirct, nstr);
   }
   WpeMouseChangeShape(WpeWorkingShape);
@@ -3937,7 +3937,7 @@ int e_get_funct_in(char *nstr, FENSTER * f)
 int e_funct_in(FENSTER * f)
 {
   int             n, xa = 37, ya = 2, num = 8;
-  OPTK           *opt = MALLOC(num * sizeof(OPTK));
+  OPTK           *opt = malloc(num * sizeof(OPTK));
   char            nstr[2];
 
   opt[0].t = "User Commands";

--- a/we_hfkt.c
+++ b/we_hfkt.c
@@ -92,8 +92,8 @@ int e_urstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn)
   ;
 
  i = e_rstrstr(x, n, str, ft, nn);
- FREE(str);
- FREE(ft);
+ free(str);
+ free(ft);
  return(i);
 }
 
@@ -164,7 +164,7 @@ int e_num_kst(char *s, int num, int max, FENSTER *f, int n, int sw)
  o->crsw = AltO;
  sprintf(tmp, "%s:", s);
  e_add_numstr(3, 2, 29-nz, 2, nz, max, n, sw, tmp, num, o);
- FREE(tmp);
+ free(tmp);
  e_add_bttstr(6, 4, 1, AltO, " Ok ", NULL, o);
  e_add_bttstr(21, 4, -1, WPE_ESC, "Cancel", NULL, o);
  ret = e_opt_kst(o);

--- a/we_hfkt.c
+++ b/we_hfkt.c
@@ -72,18 +72,18 @@ int e_urstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn)
 {
  int i;
  unsigned char *str;
- unsigned char *ft = MALLOC((strlen(f)+1)*sizeof(unsigned char));
+ unsigned char *ft = malloc((strlen(f)+1)*sizeof(unsigned char));
 
  if (x <= n)
  {
-  str = MALLOC((n+1)*sizeof(unsigned char));
+  str = malloc((n+1)*sizeof(unsigned char));
   for (i = 0; i < n; i++)
    str[i] = e_toupper(s[i]);
   str[n] = '\0';
  }
  else
  {
-  str = MALLOC((x+1)*sizeof(unsigned char));
+  str = malloc((x+1)*sizeof(unsigned char));
   for (i = 0; i < x; i++)
    str[i] = e_toupper(s[i]);
   str[x] = '\0';
@@ -106,7 +106,7 @@ int e_rstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn)
  int res;
  unsigned char old;
 
- regz = MALLOC(sizeof(regex_t));
+ regz = malloc(sizeof(regex_t));
  if (regcomp(regz,f,REG_EXTENDED))
  {
   free(regz);
@@ -114,7 +114,7 @@ int e_rstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn)
  }
  len = regz->re_nsub;
  if (len)
-  matches = MALLOC(len*sizeof(regmatch_t));
+  matches = malloc(len*sizeof(regmatch_t));
  start = (x < n) ? x : n;
  end = (n > x) ? n : x;
  if (start < 0)
@@ -153,7 +153,7 @@ int e_rstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn)
 int e_num_kst(char *s, int num, int max, FENSTER *f, int n, int sw)
 {
  int ret, nz = WpeNumberOfPlaces(max);
- char *tmp = MALLOC((strlen(s)+2) * sizeof(char));
+ char *tmp = malloc((strlen(s)+2) * sizeof(char));
  W_OPTSTR *o = e_init_opt_kst(f);
 
  if (!o || !tmp)

--- a/we_main.c
+++ b/we_main.c
@@ -292,7 +292,7 @@ void ECNT_Init(ECNT *cn)
  cn->maxcol = MAXCOLUM;
  cn->tabn = 8;
  cn->autoindent = 3;
- cn->tabs = MALLOC((cn->tabn+1)*sizeof(char));
+ cn->tabs = malloc((cn->tabn+1)*sizeof(char));
  WpeStringBlank(cn->tabs, cn->tabn);
  cn->flopt = FM_REKURSIVE_ACTIONS | FM_REMOVE_INTO_WB | FM_MOVE_PROMPT |
    FM_MOVE_PROMPT | FM_PROMPT_DELETE;
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
  int so = 0, sd = 1;
  char *tp;
 
- if ((cn = (ECNT *)MALLOC(sizeof(ECNT))) == NULL) {
+ if ((cn = (ECNT *)malloc(sizeof(ECNT))) == NULL) {
   printf(" Fatal Error: %s\n", e_msg[ERR_LOWMEM]);
   return 0;
  }
@@ -318,7 +318,7 @@ int main(int argc, char **argv)
  WpeEditor = cn;
  cn->fb = fb;
 
- info_file = MALLOC((strlen(INFO_DIR)+1)*sizeof(char));
+ info_file = malloc((strlen(INFO_DIR)+1)*sizeof(char));
  strcpy(info_file, INFO_DIR);
  e_read_help_str();
  e_hlp = e_hlp_str[0];
@@ -330,9 +330,9 @@ int main(int argc, char **argv)
 #if defined(HAVE_TEMPNAM)
  e_tmp_dir = tempnam(NULL, "xwpe_");
 #else
- e_tmp_dir = MALLOC(128);
+ e_tmp_dir = malloc(128);
  sprintf(e_tmp_dir, "/tmp/we_%u", (unsigned) getpid());
- e_tmp_dir = REALLOC(e_tmp_dir, (strlen(e_tmp_dir)+1)*sizeof(char));
+ e_tmp_dir = realloc(e_tmp_dir, (strlen(e_tmp_dir)+1)*sizeof(char));
 #endif
  if ((e_tmp_dir == NULL) || (mkdir(e_tmp_dir, 0700) != 0))
 #endif
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
    else if (*(argv[i]+1) == 's' && *(argv[i]+2) == 'f')
    {
     sd = 0;
-    cn->optfile = MALLOC((strlen(argv[i+1])+1)*sizeof(char));
+    cn->optfile = malloc((strlen(argv[i+1])+1)*sizeof(char));
     strcpy(cn->optfile, argv[i+1]);
    }
   }
@@ -368,7 +368,7 @@ int main(int argc, char **argv)
   else
   {
    cn->optfile = e_mkfilename(getenv("HOME"), XWPE_HOME);
-   cn->optfile = REALLOC(cn->optfile,
+   cn->optfile = realloc(cn->optfile,
      strlen(cn->optfile) + strlen(OPTION_FILE) + 2);
    strcat(cn->optfile, DIRS);
    strcat(cn->optfile, OPTION_FILE);

--- a/we_main.c
+++ b/we_main.c
@@ -548,14 +548,14 @@ FARBE *e_ini_farbe()
  if (WpeIsXwin())
  {
   if (!x_fb)
-   x_fb = WpeMalloc(sizeof(FARBE));
+   x_fb = malloc(sizeof(FARBE));
   FARBE_Init(x_fb);
   return x_fb;
  }
  else
  {
   if (!u_fb)
-   u_fb = WpeMalloc(sizeof(FARBE));
+   u_fb = malloc(sizeof(FARBE));
   if (col_num)
   {
    FARBE_Init(u_fb);

--- a/we_main.c
+++ b/we_main.c
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
  e_edit(cn, ""); /* Clipboard (must first read option file) */
  if ((tp = getenv("INFOPATH")) != NULL)
  {
-  if (info_file) FREE(info_file);
+  if (info_file) free(info_file);
   info_file = WpeStrdup(tp);
  }
  if (cn->edopt & ED_CUA_STYLE) blst = eblst_u;

--- a/we_menue.c
+++ b/we_menue.c
@@ -34,7 +34,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   extern OPT      opt[];
   extern char    *e_hlp, *e_hlp_str[];
   ECNT           *cn = f->ed;
-  MENU           *mainmenu = MALLOC(MENOPT * sizeof(MENU));
+  MENU           *mainmenu = malloc(MENOPT * sizeof(MENU));
 
   for(i = 0; i < MENOPT; i++)
     mainmenu[i].width = 0;
@@ -57,7 +57,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   mainmenu[0].no_of_items = 4;
   mainmenu[0].width = 20;
 #endif
-  if((mainmenu[0].menuitems = MALLOC(mainmenu[0].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[0].menuitems = malloc(mainmenu[0].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   mainmenu[0].menuitems[0] = WpeFillSubmenuItem("About WE", 0, 'A', e_about_WE);
   mainmenu[0].menuitems[1] = WpeFillSubmenuItem("Clear Desktop", 0, 'C', e_clear_desk);
@@ -71,7 +71,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
 #ifdef UNIX
   mainmenu[1].width = 24;
   mainmenu[1].no_of_items = 11;
-  if((mainmenu[1].menuitems = MALLOC(mainmenu[1].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[1].menuitems = malloc(mainmenu[1].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   if(f->ed->edopt & ED_CUA_STYLE)
   {
@@ -102,7 +102,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   else
 #endif
     mainmenu[2].no_of_items = 7;
-  if((mainmenu[2].menuitems = MALLOC(mainmenu[2].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[2].menuitems = malloc(mainmenu[2].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   mainmenu[2].menuitems[0] = WpeFillSubmenuItem("Cut     Shift Del / ^X", 2, 'T', e_edt_del);
   mainmenu[2].menuitems[1] = WpeFillSubmenuItem("Copy         ^Ins / ^C", 0, 'C', e_edt_copy);
@@ -121,7 +121,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   mainmenu[3].position = -3;
   mainmenu[3].width = 28;
   mainmenu[3].no_of_items = 4;
-  if((mainmenu[3].menuitems = MALLOC(mainmenu[3].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[3].menuitems = malloc(mainmenu[3].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   if(f->ed->edopt & ED_CUA_STYLE)
   {
@@ -139,7 +139,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   mainmenu[4].position = -3;
   mainmenu[4].width = 25;
   mainmenu[4].no_of_items = 15;
-  if((mainmenu[4].menuitems = MALLOC(mainmenu[4].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[4].menuitems = malloc(mainmenu[4].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   mainmenu[4].menuitems[0] = WpeFillSubmenuItem("Begin Mark      ^K B", 0, 'B', e_blck_begin);
   mainmenu[4].menuitems[1] = WpeFillSubmenuItem("End Mark        ^K K", 0, 'E', e_blck_end);
@@ -162,7 +162,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
     mainmenu[5].position = -3;
     mainmenu[5].width = 35;
     mainmenu[5].no_of_items = 12;
-    if((mainmenu[5].menuitems = MALLOC(mainmenu[5].no_of_items * sizeof(OPTK))) == NULL)
+    if((mainmenu[5].menuitems = malloc(mainmenu[5].no_of_items * sizeof(OPTK))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->fb);
     mainmenu[5].menuitems[0] = WpeFillSubmenuItem("Compile         Alt F9 / Alt C", 0, 'C', e_compile);
     mainmenu[5].menuitems[1] = WpeFillSubmenuItem("Make                F9 / Alt M", 0, 'M', e_p_make);
@@ -180,7 +180,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
     mainmenu[MENOPT - 4].position = -3;
     mainmenu[MENOPT - 4].width = 23;
     mainmenu[MENOPT - 4].no_of_items = 5;
-    if((mainmenu[MENOPT - 4].menuitems = MALLOC(mainmenu[MENOPT - 4].no_of_items * sizeof(OPTK))) == NULL)
+    if((mainmenu[MENOPT - 4].menuitems = malloc(mainmenu[MENOPT - 4].no_of_items * sizeof(OPTK))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->fb);
     mainmenu[MENOPT - 4].menuitems[0] = WpeFillSubmenuItem("Open Project", 5, 'P', e_project);
     mainmenu[MENOPT - 4].menuitems[1] = WpeFillSubmenuItem("Close Project", 0, 'C', e_cl_project);
@@ -195,7 +195,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
     mainmenu[MENOPT - 5].position = -3;
     mainmenu[MENOPT - 5].width = 33;
     mainmenu[MENOPT - 5].no_of_items = 13;
-    if((mainmenu[MENOPT - 5].menuitems = MALLOC(mainmenu[MENOPT - 5].no_of_items * sizeof(OPTK))) == NULL)
+    if((mainmenu[MENOPT - 5].menuitems = malloc(mainmenu[MENOPT - 5].no_of_items * sizeof(OPTK))) == NULL)
       e_error(e_msg[ERR_LOWMEM], 1, f->fb);
 
     if(f->ed->edopt & ED_CUA_STYLE)
@@ -234,7 +234,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   else
 #endif
     mainmenu[MENOPT - 3].no_of_items = 5;
-  if((mainmenu[MENOPT - 3].menuitems = MALLOC(mainmenu[MENOPT - 3].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[MENOPT - 3].menuitems = malloc(mainmenu[MENOPT - 3].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   mainmenu[MENOPT - 3].menuitems[0] = WpeFillSubmenuItem("Adjust Colors", 0, 'A', e_ad_colors);
   mainmenu[MENOPT - 3].menuitems[1] = WpeFillSubmenuItem("Save Options", 0, 'S', e_opt_save);
@@ -280,7 +280,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin()? 7 : 6;
 #endif
 #endif
-  if((mainmenu[MENOPT - 2].menuitems = MALLOC(mainmenu[MENOPT - 2].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[MENOPT - 2].menuitems = malloc(mainmenu[MENOPT - 2].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   if(f->ed->edopt & ED_CUA_STYLE)
   {
@@ -328,7 +328,7 @@ int WpeHandleMainmenu(int n, FENSTER *f)
 #else
   mainmenu[MENOPT - 1].no_of_items = 6;
 #endif
-  if((mainmenu[MENOPT - 1].menuitems = MALLOC(mainmenu[MENOPT - 1].no_of_items * sizeof(OPTK))) == NULL)
+  if((mainmenu[MENOPT - 1].menuitems = malloc(mainmenu[MENOPT - 1].no_of_items * sizeof(OPTK))) == NULL)
     e_error(e_msg[ERR_LOWMEM], 1, f->fb);
   mainmenu[MENOPT - 1].menuitems[0] = WpeFillSubmenuItem("Editor              F1", 0, 'E', e_help);
 #if defined(PROG) && !defined(DJGPP)

--- a/we_menue.c
+++ b/we_menue.c
@@ -460,8 +460,8 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   /* free up the submenu structure */
   for(i = 0; i < MENOPT; i++)
     if(mainmenu[i].width != 0)
-      FREE(mainmenu[i].menuitems);
-  FREE(mainmenu);
+      free(mainmenu[i].menuitems);
+  free(mainmenu);
 
   fk_cursor(1);
   return(c);

--- a/we_mouse.c
+++ b/we_mouse.c
@@ -381,7 +381,7 @@ int fl_wnd_mouse(sw, k, fw)
 	       {  FLBFFR *b = (FLBFFR *)fw->f->b;
 		  if(b->cd->anz > fw->nf)
 		  {  while (e_mshit() != 0);
-		     FREE (file);  FREE (bgrd);  return(WPE_CR);
+		     free (file);  free (bgrd);  return(WPE_CR);
 		  }
 		  for(c = 0; *(fw->df->name[fw->nf]+c)
 			&& ( *(fw->df->name[fw->nf]+c) <= 32
@@ -402,10 +402,10 @@ int fl_wnd_mouse(sw, k, fw)
 		  e_refresh();
 	       }
 	       e_pt_btstr(xn-xdif, yn, MLEN, bgrd);
-	       FREE (file);  FREE (bgrd);
+	       free (file);  free (bgrd);
 	       return(k);
 	    }
-	    FREE (file);  FREE (bgrd);
+	    free (file);  free (bgrd);
 	    if(sw && k == -2) return(AltU);
 	    else if(sw && k == -4) return(AltM);
 	    else return(WPE_CR);

--- a/we_mouse.c
+++ b/we_mouse.c
@@ -372,8 +372,8 @@ int fl_wnd_mouse(sw, k, fw)
 	    for(MLEN = 1; *(fw->df->name[fw->nf]+c+MLEN)
 			&& *(fw->df->name[fw->nf]+c+MLEN) != ' '; MLEN++);
 	    MLEN *= 2;
-	    file = MALLOC(MLEN * sizeof(char));
-	    bgrd = MALLOC(MLEN * sizeof(char));
+	    file = malloc(MLEN * sizeof(char));
+	    bgrd = malloc(MLEN * sizeof(char));
 	    while (e_mshit() != 0)
 	    if(sw && (e_mouse.x != xa || e_mouse.y != ya))
 	    {  xn = e_mouse.x;  yn = e_mouse.y;

--- a/we_opt.c
+++ b/we_opt.c
@@ -242,7 +242,7 @@ int e_ad_colors(FENSTER *f)
 
  n = e_opt_sec_box(xa, ya, num, opt, f, 1);
 
- FREE(opt);
+ free(opt);
  if (n < 0)
   return(WPE_ESC);
 
@@ -919,25 +919,25 @@ int WpeReadLanguage(ECNT *cn, char *section, char *option, char *value)
  if (WpeStrccmp("Compiler", option) == 0)
  {
   if (e_prog.comp[i]->compiler)
-   FREE(e_prog.comp[i]->compiler);
+   free(e_prog.comp[i]->compiler);
   e_prog.comp[i]->compiler = WpeStrdup(value);
  }
  else if (WpeStrccmp("CompilerOptions", option) == 0)
  {
   if (e_prog.comp[i]->comp_str)
-   FREE(e_prog.comp[i]->comp_str);
+   free(e_prog.comp[i]->comp_str);
   e_prog.comp[i]->comp_str = WpeStrdup(value);
  }
  else if (WpeStrccmp("Libraries", option) == 0)
  {
   if (e_prog.comp[i]->libraries)
-   FREE(e_prog.comp[i]->libraries);
+   free(e_prog.comp[i]->libraries);
   e_prog.comp[i]->libraries = WpeStrdup(value);
  }
  else if (WpeStrccmp("Executable", option) == 0)
  {
   if (e_prog.comp[i]->exe_name)
-   FREE(e_prog.comp[i]->exe_name);
+   free(e_prog.comp[i]->exe_name);
   e_prog.comp[i]->exe_name = WpeStrdup(value);
  }
  else if (WpeStrccmp("FileExtension", option) == 0)
@@ -954,7 +954,7 @@ int WpeReadLanguage(ECNT *cn, char *section, char *option, char *value)
  else if (WpeStrccmp("MessageString", option) == 0)
  {
   if (e_prog.comp[i]->intstr)
-   FREE(e_prog.comp[i]->intstr);
+   free(e_prog.comp[i]->intstr);
   e_prog.comp[i]->intstr = WpeValueToString(value);
  }
  else if (WpeStrccmp("Key", option) == 0)
@@ -1006,7 +1006,7 @@ int e_save_opt(FENSTER *f)
  for (i = strlen(str_line); i > 0 && str_line[i] != DIRC; i--);
  str_line[i] = '\0';
  if (access(str_line, 0)) mkdir(str_line, 0700);
- FREE(str_line);
+ free(str_line);
  fp = fopen(cn->optfile, "w");
  if (fp == NULL)
  {
@@ -1030,7 +1030,7 @@ int e_save_opt(FENSTER *f)
   fprintf(fp, "[%s]\n", str_line);
   WpeWriteColor(cn, str_line, fp);
  }
- FREE(str_line);
+ free(str_line);
  str_line = OPT_SECTION_PROGRAMMING;
  fprintf(fp, "[%s]\n", str_line);
  WpeWriteProgramming(cn, str_line, fp);
@@ -1044,7 +1044,7 @@ int e_save_opt(FENSTER *f)
   fprintf(fp, "[%s]\n", str_line);
   WpeWriteLanguage(cn, str_line, fp);
  }
- FREE(str_line);
+ free(str_line);
  fclose(fp);
  return 0;
 }
@@ -1065,7 +1065,7 @@ int e_opt_read(ECNT *cn)
  {
   char *file = e_mkfilename(LIBRARY_DIR, OPTION_FILE);
   fp = fopen(file, "r");
-  FREE(file);
+  free(file);
  }
  if (fp == NULL) return(0);
  sz = 256;
@@ -1156,7 +1156,7 @@ int e_add_arguments(char *str, char *head, FENSTER *f, int n, int sw,
  e_add_wrstr(4, 2, 4, 3, 30, 128, n, sw, tmp, str, df, o);
  e_add_bttstr(7, 5, 1, AltO, " Ok ", NULL, o);
  e_add_bttstr(24, 5, -1, WPE_ESC, "Cancel", NULL, o);
- FREE(tmp);
+ free(tmp);
  ret = e_opt_kst(o);
  if (ret != WPE_ESC)
   strcpy(str, o->wstr[0]->txt);
@@ -1329,47 +1329,47 @@ int freeostr(W_OPTSTR *o)
   return(0);
  for (i = 0; i < o->tn; i++)
  {
-  FREE(o->tstr[i]->txt);
-  FREE(o->tstr[i]);
+  free(o->tstr[i]->txt);
+  free(o->tstr[i]);
  }
  if (o->tn)
-  FREE(o->tstr);
+  free(o->tstr);
  for (i = 0; i < o->wn; i++)
  {
-  FREE(o->wstr[i]->txt);
-  FREE(o->wstr[i]->header);
-  FREE(o->wstr[i]);
+  free(o->wstr[i]->txt);
+  free(o->wstr[i]->header);
+  free(o->wstr[i]);
  }
  if (o->wn)
-  FREE(o->wstr);
+  free(o->wstr);
  for (i = 0; i < o->nn; i++)
  {
-  FREE(o->nstr[i]->header);
-  FREE(o->nstr[i]);
+  free(o->nstr[i]->header);
+  free(o->nstr[i]);
  }
  if (o->nn)
-  FREE(o->nstr);
+  free(o->nstr);
  for (i = 0; i < o->pn; i++)
  {
   for (j = 0; j < o->pstr[i]->np; j++)
   {
-   FREE(o->pstr[i]->ps[j]->header);
-   FREE(o->pstr[i]->ps[j]);
+   free(o->pstr[i]->ps[j]->header);
+   free(o->pstr[i]->ps[j]);
   }
   if (o->pstr[i]->np)
-   FREE(o->pstr[i]->ps);
-  FREE(o->pstr[i]);
+   free(o->pstr[i]->ps);
+  free(o->pstr[i]);
  }
  if (o->pn)
-  FREE(o->pstr);
+  free(o->pstr);
  for (i = 0; i < o->bn; i++)
  {
-  FREE(o->bstr[i]->header);
-  FREE(o->bstr[i]);
+  free(o->bstr[i]->header);
+  free(o->bstr[i]);
  }
  if (o->bn)
-  FREE(o->bstr);
- FREE(o);
+  free(o->bstr);
+ free(o);
  return(0);
 }
 

--- a/we_opt.c
+++ b/we_opt.c
@@ -1076,7 +1076,7 @@ int e_opt_read(ECNT *cn)
   if (sz != 256)
   {
    sz = 256;
-   str_line = (char *)WpeRealloc(str_line, sz * sizeof(char));
+   str_line = (char *)realloc(str_line, sz * sizeof(char));
   }
   str_line[0] = 0;
   fgets(str_line, sz, fp);
@@ -1084,7 +1084,7 @@ int e_opt_read(ECNT *cn)
     ((str_line[0] == 0) || (str_line[strlen(str_line) - 1] != '\n')))
   {
    sz += 255;
-   str_line = (char *)WpeRealloc(str_line, sz * sizeof(char));
+   str_line = (char *)realloc(str_line, sz * sizeof(char));
    fgets(str_line + sz - 256, 256, fp);
   }
   i = strlen(str_line);

--- a/we_opt.c
+++ b/we_opt.c
@@ -589,7 +589,7 @@ char *WpeStringToValue(const char *str)
  int i, len;
 
  len = strlen(str);
- answer = WpeMalloc((len * 2) * sizeof(char));
+ answer = malloc((len * 2) * sizeof(char));
  for (i = strlen(str), cur_ans = answer, cur_str = str; i; i--, cur_str++)
  {
   if ((*cur_str == '\n') || (*cur_str == '\\'))
@@ -613,7 +613,7 @@ char *WpeValueToString(const char *value)
  const char *cur_val;
  int i;
 
- answer = WpeMalloc((strlen(value) + 1) * sizeof(char));
+ answer = malloc((strlen(value) + 1) * sizeof(char));
  for (i = strlen(value), cur_ans = answer, cur_val = value; i; i--, cur_ans++)
  {
   if (*cur_val == '\\')
@@ -687,7 +687,7 @@ int WpeReadColor(ECNT *cn, char *section, char *option, char *value)
  {
   if (!u_fb)
   {
-   u_fb = WpeMalloc(sizeof(FARBE));
+   u_fb = malloc(sizeof(FARBE));
    FARBE_Init(u_fb);
   }
   fb = u_fb;
@@ -696,7 +696,7 @@ int WpeReadColor(ECNT *cn, char *section, char *option, char *value)
  {
   if (!x_fb)
   {
-   x_fb = WpeMalloc(sizeof(FARBE));
+   x_fb = malloc(sizeof(FARBE));
    FARBE_Init(x_fb);
   }
   fb = x_fb;
@@ -1069,7 +1069,7 @@ int e_opt_read(ECNT *cn)
  }
  if (fp == NULL) return(0);
  sz = 256;
- str_line = (char *)WpeMalloc(256 * sizeof(char));
+ str_line = (char *)malloc(256 * sizeof(char));
  section = NULL;
  while (!feof(fp))
  {

--- a/we_opt.c
+++ b/we_opt.c
@@ -985,7 +985,7 @@ int WpeWriteLanguage(ECNT *cn, char *section, FILE *opt_file)
    fprintf(opt_file, "FileExtension : %s\n", e_prog.comp[i]->filepostfix[j - 1]);
   str_tmp = WpeStringToValue(e_prog.comp[i]->intstr);
   fprintf(opt_file, "MessageString : %s\n", str_tmp);
-  WpeFree(str_tmp);
+  free(str_tmp);
   fprintf(opt_file, "CompilerSwitch : %d\n", e_prog.comp[i]->comp_sw);
   fprintf(opt_file, "Key : %c\n", e_prog.comp[i]->key);
   fprintf(opt_file, "X : %d\n", e_prog.comp[i]->x);
@@ -1097,12 +1097,12 @@ int e_opt_read(ECNT *cn)
    if (*option == '[')
    {
     if (section)
-     WpeFree(section);
+     free(section);
     for (value = option + 1; (*value) && (*value != ']'); value++)
      ;
     if (*value != ']')
     {
-     WpeFree(str_line);
+     free(str_line);
      return ERR_READ_OPF;
     }
     *value = 0;
@@ -1113,7 +1113,7 @@ int e_opt_read(ECNT *cn)
     value = strchr(option, ':');
     if ((value == NULL) || (value == option))
     {
-     WpeFree(str_line);
+     free(str_line);
      return ERR_READ_OPF;
     }
     for (str_tmp = value - 1; isspace(*str_tmp); str_tmp--)
@@ -1842,7 +1842,7 @@ int e_edt_options(FENSTER *f)
     (o->sstr[3]->num ? ED_OLD_TILE_METHOD : 0) +
     (o->sstr[0]->num ? ED_SHOW_ENDMARKS : 0);
   if (f->ed->print_cmd)
-   WpeFree(f->ed->print_cmd);
+   free(f->ed->print_cmd);
   f->ed->print_cmd = WpeStrdup(o->wstr[0]->txt);
   if (edopt != f->ed->edopt)
   {

--- a/we_opt.c
+++ b/we_opt.c
@@ -233,7 +233,7 @@ int e_sys_info(FENSTER *f)
 int e_ad_colors(FENSTER *f)
 {
  int n, xa = 48, ya = 2, num = 4;
- OPTK *opt = MALLOC(num * sizeof(OPTK));
+ OPTK *opt = malloc(num * sizeof(OPTK));
 
  opt[0].t = "Editor Colors";     opt[0].x = 0;  opt[0].o = 'E';
  opt[1].t = "Desk Colors";       opt[1].x = 0;  opt[1].o = 'D';
@@ -575,7 +575,7 @@ int e_opt_save(FENSTER *f)
  ret = e_add_arguments(tmp, "Save Option File", f, 0, AltS, NULL);
  if (ret)
  {
-  f->ed->optfile = REALLOC(f->ed->optfile, (strlen(tmp)+1)*sizeof(char));
+  f->ed->optfile = realloc(f->ed->optfile, (strlen(tmp)+1)*sizeof(char));
   strcpy(f->ed->optfile, tmp);
   e_save_opt(f);
  }
@@ -903,8 +903,8 @@ int WpeReadLanguage(ECNT *cn, char *section, char *option, char *value)
  if (i == e_prog.num)
  {
   e_prog.num++;
-  e_prog.comp = REALLOC(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
-  e_prog.comp[i] = MALLOC(sizeof(struct e_s_prog));
+  e_prog.comp = realloc(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
+  e_prog.comp[i] = malloc(sizeof(struct e_s_prog));
   e_prog.comp[i]->language = WpeStrdup(section + strlen(OPT_SECTION_LANGUAGE) + 1);
   e_prog.comp[i]->compiler = WpeStrdup("");
   e_prog.comp[i]->comp_str = WpeStrdup("");
@@ -1001,7 +1001,7 @@ int e_save_opt(FENSTER *f)
  int i;
  char *str_line;
 
- str_line = MALLOC((strlen(cn->optfile)+1)*sizeof(char));
+ str_line = malloc((strlen(cn->optfile)+1)*sizeof(char));
  strcpy(str_line, cn->optfile);
  for (i = strlen(str_line); i > 0 && str_line[i] != DIRC; i--);
  str_line[i] = '\0';
@@ -1016,7 +1016,7 @@ int e_save_opt(FENSTER *f)
  str_line = OPT_SECTION_GENERAL;
  fprintf(fp, "[%s]\n", str_line);
  WpeWriteGeneral(cn, str_line, fp);
- str_line = MALLOC(strlen(OPT_SECTION_COLOR) + 10);
+ str_line = malloc(strlen(OPT_SECTION_COLOR) + 10);
  strcpy(str_line, OPT_SECTION_COLOR);
  if (u_fb)
  {
@@ -1034,12 +1034,12 @@ int e_save_opt(FENSTER *f)
  str_line = OPT_SECTION_PROGRAMMING;
  fprintf(fp, "[%s]\n", str_line);
  WpeWriteProgramming(cn, str_line, fp);
- str_line = MALLOC(strlen(OPT_SECTION_LANGUAGE) + 2);
+ str_line = malloc(strlen(OPT_SECTION_LANGUAGE) + 2);
  strcpy(str_line, OPT_SECTION_LANGUAGE);
  strcat(str_line, "/");
  for (i = 0; i < e_prog.num; i++)
  {
-  str_line = REALLOC(str_line, strlen(OPT_SECTION_LANGUAGE) + strlen(e_prog.comp[i]->language) + 2);
+  str_line = realloc(str_line, strlen(OPT_SECTION_LANGUAGE) + strlen(e_prog.comp[i]->language) + 2);
   strcpy(str_line + strlen(OPT_SECTION_LANGUAGE) + 1, e_prog.comp[i]->language);
   fprintf(fp, "[%s]\n", str_line);
   WpeWriteLanguage(cn, str_line, fp);
@@ -1143,7 +1143,7 @@ int e_add_arguments(char *str, char *head, FENSTER *f, int n, int sw,
   struct dirfile **df)
 {
  int ret;
- char *tmp = MALLOC((strlen(head)+2) * sizeof(char));
+ char *tmp = malloc((strlen(head)+2) * sizeof(char));
  W_OPTSTR *o = e_init_opt_kst(f);
 
  if (!o || !tmp)
@@ -1167,13 +1167,13 @@ int e_add_arguments(char *str, char *head, FENSTER *f, int n, int sw,
 W_O_TXTSTR **e_add_txtstr(int x, int y, char *txt, W_OPTSTR *o)
 {
  if (o->tn == 0)
-  o->tstr = MALLOC(1);
+  o->tstr = malloc(1);
  (o->tn)++;
- if (!(o->tstr = REALLOC(o->tstr, o->tn * sizeof(W_O_TXTSTR *))))
+ if (!(o->tstr = realloc(o->tstr, o->tn * sizeof(W_O_TXTSTR *))))
   return(NULL);
- if (!(o->tstr[o->tn-1] = MALLOC(sizeof(W_O_TXTSTR))))
+ if (!(o->tstr[o->tn-1] = malloc(sizeof(W_O_TXTSTR))))
   return(NULL);
- if (!(o->tstr[o->tn-1]->txt = MALLOC((strlen(txt)+1) * sizeof(char))))
+ if (!(o->tstr[o->tn-1]->txt = malloc((strlen(txt)+1) * sizeof(char))))
   return(NULL);
  o->tstr[o->tn-1]->x = x;
  o->tstr[o->tn-1]->y = y;
@@ -1185,15 +1185,15 @@ W_O_WRSTR **e_add_wrstr(int xt, int yt, int xw, int yw, int nw, int wmx,
    int nc, int sw, char *header, char *txt, struct dirfile **df, W_OPTSTR *o)
 {
  if (o->wn == 0)
-  o->wstr = MALLOC(1);
+  o->wstr = malloc(1);
  (o->wn)++;
- if (!(o->wstr = REALLOC(o->wstr, o->wn * sizeof(W_O_WRSTR *))))
+ if (!(o->wstr = realloc(o->wstr, o->wn * sizeof(W_O_WRSTR *))))
   return(NULL);
- if (!(o->wstr[o->wn-1] = MALLOC(sizeof(W_O_WRSTR))))
+ if (!(o->wstr[o->wn-1] = malloc(sizeof(W_O_WRSTR))))
   return(NULL);
- if (!(o->wstr[o->wn-1]->txt = MALLOC((wmx+1) * sizeof(char))))
+ if (!(o->wstr[o->wn-1]->txt = malloc((wmx+1) * sizeof(char))))
   return(NULL);
- if (!(o->wstr[o->wn-1]->header = MALLOC((strlen(header)+1) * sizeof(char))))
+ if (!(o->wstr[o->wn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
   return(NULL);
  o->wstr[o->wn-1]->xt = xt;
  o->wstr[o->wn-1]->yt = yt;
@@ -1213,13 +1213,13 @@ W_O_NUMSTR **e_add_numstr(int xt, int yt, int xw, int yw, int nw, int wmx,
    int nc, int sw, char *header, int num, W_OPTSTR *o)
 {
  if (o->nn == 0)
-  o->nstr = MALLOC(1);
+  o->nstr = malloc(1);
  (o->nn)++;
- if (!(o->nstr = REALLOC(o->nstr, o->nn * sizeof(W_O_NUMSTR *))))
+ if (!(o->nstr = realloc(o->nstr, o->nn * sizeof(W_O_NUMSTR *))))
   return(NULL);
- if (!(o->nstr[o->nn-1] = MALLOC(sizeof(W_O_NUMSTR))))
+ if (!(o->nstr[o->nn-1] = malloc(sizeof(W_O_NUMSTR))))
   return(NULL);
- if (!(o->nstr[o->nn-1]->header = MALLOC((strlen(header)+1) * sizeof(char))))
+ if (!(o->nstr[o->nn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
   return(NULL);
  o->nstr[o->nn-1]->xt = xt;
  o->nstr[o->nn-1]->yt = yt;
@@ -1238,13 +1238,13 @@ W_O_SSWSTR **e_add_sswstr(int x, int y, int nc, int sw, int num,
    char *header, W_OPTSTR *o)
 {
  if (o->sn == 0)
-  o->sstr = MALLOC(1);
+  o->sstr = malloc(1);
  (o->sn)++;
- if (!(o->sstr = REALLOC(o->sstr, o->sn * sizeof(W_O_SSWSTR *))))
+ if (!(o->sstr = realloc(o->sstr, o->sn * sizeof(W_O_SSWSTR *))))
   return(NULL);
- if (!(o->sstr[o->sn-1] = MALLOC(sizeof(W_O_SSWSTR))))
+ if (!(o->sstr[o->sn-1] = malloc(sizeof(W_O_SSWSTR))))
   return(NULL);
- if (!(o->sstr[o->sn-1]->header = MALLOC((strlen(header)+1) * sizeof(char))))
+ if (!(o->sstr[o->sn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
   return(NULL);
  o->sstr[o->sn-1]->x = x;
  o->sstr[o->sn-1]->y = y;
@@ -1263,13 +1263,13 @@ W_O_SPSWSTR **e_add_spswstr(int n, int x, int y, int nc, int sw,
  if (n < 0)
   n = 0;
  if (o->pstr[n]->np == 0)
-  o->pstr[n]->ps = MALLOC(1);
+  o->pstr[n]->ps = malloc(1);
  (o->pstr[n]->np)++;
- if (!(o->pstr[n]->ps = REALLOC(o->pstr[n]->ps, o->pstr[n]->np * sizeof(W_O_SPSWSTR *))))
+ if (!(o->pstr[n]->ps = realloc(o->pstr[n]->ps, o->pstr[n]->np * sizeof(W_O_SPSWSTR *))))
   return(NULL);
- if (!(o->pstr[n]->ps[o->pstr[n]->np-1] = MALLOC(sizeof(W_O_SPSWSTR))))
+ if (!(o->pstr[n]->ps[o->pstr[n]->np-1] = malloc(sizeof(W_O_SPSWSTR))))
   return(NULL);
- if (!(o->pstr[n]->ps[o->pstr[n]->np-1]->header = MALLOC((strlen(header)+1) * sizeof(char))))
+ if (!(o->pstr[n]->ps[o->pstr[n]->np-1]->header = malloc((strlen(header)+1) * sizeof(char))))
   return(NULL);
  o->pstr[n]->ps[o->pstr[n]->np-1]->x = x;
  o->pstr[n]->ps[o->pstr[n]->np-1]->y = y;
@@ -1283,14 +1283,14 @@ W_O_PSWSTR **e_add_pswstr(int n, int x, int y, int nc, int sw, int num,
    char *header, W_OPTSTR *o)
 {
  if (o->pn == 0)
-  o->pstr = MALLOC(1);
+  o->pstr = malloc(1);
  if (n >= o->pn)
  {
   n = o->pn;
   (o->pn)++;
-  if (!(o->pstr = REALLOC(o->pstr, o->pn * sizeof(W_O_PSWSTR *))))
+  if (!(o->pstr = realloc(o->pstr, o->pn * sizeof(W_O_PSWSTR *))))
    return(NULL);
-  if (!(o->pstr[o->pn-1] = MALLOC(sizeof(W_O_PSWSTR))))
+  if (!(o->pstr[o->pn-1] = malloc(sizeof(W_O_PSWSTR))))
    return(NULL);
   o->pstr[o->pn-1]->np = 0;
  }
@@ -1304,13 +1304,13 @@ W_O_BTTSTR **e_add_bttstr(int x, int y, int nc, int sw, char *header,
    int (*fkt)(FENSTER *f), W_OPTSTR *o)
 {
  if (o->bn == 0)
-  o->bstr = MALLOC(1);
+  o->bstr = malloc(1);
  (o->bn)++;
- if (!(o->bstr = REALLOC(o->bstr, o->bn * sizeof(W_O_BTTSTR *))))
+ if (!(o->bstr = realloc(o->bstr, o->bn * sizeof(W_O_BTTSTR *))))
   return(NULL);
- if (!(o->bstr[o->bn-1] = MALLOC(sizeof(W_O_BTTSTR))))
+ if (!(o->bstr[o->bn-1] = malloc(sizeof(W_O_BTTSTR))))
   return(NULL);
- if (!(o->bstr[o->bn-1]->header = MALLOC((strlen(header)+1) * sizeof(char))))
+ if (!(o->bstr[o->bn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
   return(NULL);
  o->bstr[o->bn-1]->x = x;
  o->bstr[o->bn-1]->y = y;
@@ -1375,7 +1375,7 @@ int freeostr(W_OPTSTR *o)
 
 W_OPTSTR *e_init_opt_kst(FENSTER *f)
 {
- W_OPTSTR *o = MALLOC(sizeof(W_OPTSTR));
+ W_OPTSTR *o = malloc(sizeof(W_OPTSTR));
  if (!o)
   return(NULL);
  o->frt = f->fb->nr.fb;
@@ -1618,7 +1618,7 @@ int e_opt_kst(W_OPTSTR *o)
          if(o->wstr[i]->sw == c || (o->wstr[i]->nc >= 0 &&
          toupper(c) == o->wstr[i]->header[o->wstr[i]->nc]))
       {  cold = c;
-         tmp = MALLOC((o->wstr[i]->wmx + 1) * sizeof(char));
+         tmp = malloc((o->wstr[i]->wmx + 1) * sizeof(char));
          strcpy(tmp, o->wstr[i]->txt);
 #if MOUSE
          if(!o->wstr[i]->df && (c = e_schreib_leiste(tmp,
@@ -1869,7 +1869,7 @@ int e_read_help_str()
  sprintf(str, "%s/help.key", LIBRARY_DIR);
  for (i = 0; i < E_HLP_NUM; i++)
  {
-  e_hlp_str[i] = MALLOC(sizeof(char));
+  e_hlp_str[i] = malloc(sizeof(char));
   *e_hlp_str[i] = '\0';
  }
  if (!(fp = fopen(str, "rb")))
@@ -1879,7 +1879,7 @@ int e_read_help_str()
   len = strlen(str);
   if (str[len-1] == '\n')
    str[--len] = '\0';
-  e_hlp_str[i] = REALLOC(e_hlp_str[i], (len+1)*sizeof(char));
+  e_hlp_str[i] = realloc(e_hlp_str[i], (len+1)*sizeof(char));
   strcpy(e_hlp_str[i], str);
  }
  fclose(fp);

--- a/we_prog.c
+++ b/we_prog.c
@@ -156,9 +156,9 @@ int e_p_make(FENSTER *f)
  f = cn->f[cn->mxedt-1];
  if (!e__project)
  {
-  e_arg = MALLOC(6 * sizeof(char *));
+  e_arg = malloc(6 * sizeof(char *));
   e_argc = e_make_arg(&e_arg, e_s_prog.libraries);
-  e_arg[1] = MALLOC(3);
+  e_arg[1] = malloc(3);
   strcpy(e_arg[1], "-o");
   strcpy(mstr, f->datnam);
   WpeStringCutChar(mstr, '.');
@@ -339,7 +339,7 @@ int e_comp(FENSTER *f)
  if (e_new_message(f))
   return(WPE_ESC);
  argc = e_make_arg(&arg, e_s_prog.comp_str);
- arg[1] = MALLOC(3);
+ arg[1] = malloc(3);
  strcpy(arg[1], "-c");
  len = strlen(f->dirct) - 1;
  if (!strcmp(f->ed->dirct, f->dirct))
@@ -404,7 +404,7 @@ int e_exec_inf(FENSTER *f, char **argv, int n)
   e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
   return(0);
  }
- efile = MALLOC((strlen(tstr)+1)*sizeof(char));
+ efile = malloc((strlen(tstr)+1)*sizeof(char));
  strcpy(efile, tstr);
  sprintf(tstr, "%s/we_112", e_tmp_dir);
  if((wfildes[1] = creat(tstr, 0777)) < 0)
@@ -417,7 +417,7 @@ int e_exec_inf(FENSTER *f, char **argv, int n)
   e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
   return(0);
  }
- wfile = MALLOC((strlen(tstr)+1)*sizeof(char));
+ wfile = malloc((strlen(tstr)+1)*sizeof(char));
  strcpy(wfile, tstr);
 
  if((e_save_pid = pid = fork()) > 0)
@@ -474,11 +474,11 @@ int e_p_exec(int file, FENSTER *f, PIC *pic)
  ret = 0;
  for (is = b->mxlines-1, fd = efildes[0]; fd > 0; fd = wfildes[0])
  {
-  buff=MALLOC(1);
+  buff=malloc(1);
   buff[0]='\0';
   while( e_line_read(fd, str, 128) == 0 )
   {
-   buff=REALLOC(buff, strlen(buff) + strlen(str) + 1);
+   buff=realloc(buff, strlen(buff) + strlen(str) + 1);
    strcat(buff, str);
 
    fflush(stdout);
@@ -656,7 +656,7 @@ int e_make_error_list(FENSTER *f)
   }
   FREE(err_li);
  }
- err_li = MALLOC(sizeof(struct ERR_LI) * b->mxlines);
+ err_li = malloc(sizeof(struct ERR_LI) * b->mxlines);
  err_num = 0;
  for (i = 0; i < b->mxlines; i++)
  {
@@ -669,7 +669,7 @@ int e_make_error_list(FENSTER *f)
   else if (!strncmp((char *)b->bf[i].s, "makefile:", 9) ||
     !strncmp((char *)b->bf[i].s, "Makefile:", 9))
   {
-   err_li[k].file = MALLOC(9);
+   err_li[k].file = malloc(9);
    for (j = 0; j < 8; j++)
     err_li[k].file[j] = b->bf[i].s[j];
    err_li[k].file[8] = '\0';
@@ -677,7 +677,7 @@ int e_make_error_list(FENSTER *f)
    err_li[k].y = i;
    err_li[k].x = 0;
    err_li[k].srch = NULL;
-   err_li[k].text = MALLOC(strlen((char *)b->bf[i].s) + 1);
+   err_li[k].text = malloc(strlen((char *)b->bf[i].s) + 1);
    strcpy(err_li[k].text, (char *)b->bf[i].s);
    err_li[k].text[b->bf[i].len] = '\0';
    k++;
@@ -690,14 +690,14 @@ int e_make_error_list(FENSTER *f)
     (spt = strstr((char *)b->bf[i].s, "Makefile")) ) &&
     (err_li[k].line = atoi(spt+14)) > 0 )
   {
-   err_li[k].file = MALLOC(9);
+   err_li[k].file = malloc(9);
    for (j = 0; j < 8; j++)
     err_li[k].file[j] = spt[j];
    err_li[k].file[8] = '\0';
    err_li[k].y = i;
    err_li[k].x = 0;
    err_li[k].srch = NULL;
-   err_li[k].text = MALLOC(strlen((char *)b->bf[i].s) + 1);
+   err_li[k].text = malloc(strlen((char *)b->bf[i].s) + 1);
    strcpy(err_li[k].text, (char *)b->bf[i].s);
    err_li[k].text[b->bf[i].len] = '\0';
    k++;
@@ -791,13 +791,13 @@ int e_arguments(FENSTER *f)
 
  if (!e_prog.arguments)
  {
-  e_prog.arguments = MALLOC(1);
+  e_prog.arguments = malloc(1);
   e_prog.arguments[0] = '\0';
  }
  strcpy(str, e_prog.arguments);
  if (e_add_arguments(str, "Arguments", f, 0 , AltA, NULL))
  {
-  e_prog.arguments = REALLOC(e_prog.arguments, strlen(str) + 1);
+  e_prog.arguments = realloc(e_prog.arguments, strlen(str) + 1);
   strcpy(e_prog.arguments, str);
  }
  return(0);
@@ -892,10 +892,10 @@ char *e_cat_string(char *p, char *str)
  if(str == NULL) return(p = NULL);
  if(p == NULL)
  {
-  if((p = MALLOC(strlen(str)+2)) == NULL) return(NULL);
+  if((p = malloc(strlen(str)+2)) == NULL) return(NULL);
   p[0] = '\0';
  }
- else if ((p = REALLOC(p, strlen(p) + strlen(str)+2)) == NULL)
+ else if ((p = realloc(p, strlen(p) + strlen(str)+2)) == NULL)
   return(NULL);
  strcat(p, " ");
  strcat(p, str);
@@ -908,10 +908,10 @@ int e_make_arg(char ***arg, char *str)
  char tmp[128], *p = tmp;
 
  if (!(*arg))
-  *arg = (char **) MALLOC(4*sizeof(char *));
+  *arg = (char **) malloc(4*sizeof(char *));
  else
-  *arg = (char **) REALLOC(*arg, 4*sizeof(char *));
- (*arg)[0] = MALLOC(strlen(e_s_prog.compiler) + 1);
+  *arg = (char **) realloc(*arg, 4*sizeof(char *));
+ (*arg)[0] = malloc(strlen(e_s_prog.compiler) + 1);
  strcpy((*arg)[0], e_s_prog.compiler);
  if (!str)
  {
@@ -924,10 +924,10 @@ int e_make_arg(char ***arg, char *str)
  {
   for (; p[i] != '\0' && p[i] != ' '; i++)
    ;
-  (*arg)[j] = MALLOC(i + 1);
+  (*arg)[j] = malloc(i + 1);
   strncpy((*arg)[j], p, i);
   (*arg)[j][i] = '\0';
-  *arg = (char **) REALLOC(*arg, (j + 3)*sizeof(char *));
+  *arg = (char **) realloc(*arg, (j + 3)*sizeof(char *));
   if (p[i] != '\0')
   {
    p += (i + 1);
@@ -943,10 +943,10 @@ int e_add_arg(char ***arg, char *str, int n, int argc)
  int i;
 
  argc++;
- *arg = (char **) REALLOC(*arg, (argc+1)*sizeof(char *));
+ *arg = (char **) realloc(*arg, (argc+1)*sizeof(char *));
  for(i = argc; i > n; i--)
   (*arg)[i] = (*arg)[i-1];
- (*arg)[n] = MALLOC(strlen(str) + 1);
+ (*arg)[n] = malloc(strlen(str) + 1);
  strcpy((*arg)[n], str);
  return(argc);
 }
@@ -966,11 +966,11 @@ int e_ini_prog(ECNT *cn)
  e_prog.sys_include =
    WpeStrdup("/usr/include:/usr/local/include:/usr/include/X11");
  if (e_prog.comp == NULL)
-  e_prog.comp = MALLOC(e_prog.num * sizeof(struct e_s_prog *));
+  e_prog.comp = malloc(e_prog.num * sizeof(struct e_s_prog *));
  else
-  e_prog.comp = REALLOC(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
+  e_prog.comp = realloc(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
  for (i = 0; i < e_prog.num; i++)
-  e_prog.comp[i] = MALLOC(sizeof(struct e_s_prog));
+  e_prog.comp[i] = malloc(sizeof(struct e_s_prog));
  e_prog.comp[0]->compiler = WpeStrdup("gcc");
  e_prog.comp[0]->language = WpeStrdup("C");
  e_prog.comp[0]->filepostfix = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
@@ -1218,7 +1218,7 @@ int e_run_c_options(FENSTER *f)
 int e_run_options(FENSTER *f)
 {
  int i, n, xa = 48, ya = 2, num = 2 + e_prog.num;
- OPTK *opt = MALLOC(num * sizeof(OPTK));
+ OPTK *opt = malloc(num * sizeof(OPTK));
  char tmp[80];
 
  tmp[0] = '\0';
@@ -1237,8 +1237,8 @@ int e_run_options(FENSTER *f)
   if (!e_run_c_options(f))
   {
    e_prog.num++;
-   e_prog.comp = REALLOC(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
-   e_prog.comp[e_prog.num - 1] = MALLOC(sizeof(struct e_s_prog));
+   e_prog.comp = realloc(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
+   e_prog.comp[e_prog.num - 1] = malloc(sizeof(struct e_s_prog));
    e_prog.comp[e_prog.num - 1]->language = (char *)malloc(1);
    e_prog.comp[e_prog.num - 1]->language[0] = 0;
    e_prog.comp[e_prog.num - 1]->compiler = (char *)malloc(1);
@@ -1300,13 +1300,13 @@ int e_project_name(FENSTER *f)
 
  if (!e_prog.project)
  {
-  e_prog.project = MALLOC(1);
+  e_prog.project = malloc(1);
   e_prog.project[0] = '\0';
  }
  strcpy(str, e_prog.project);
  if (e_add_arguments(str, "Project", f, 0, AltP, NULL))
  {
-  e_prog.project = REALLOC(e_prog.project, strlen(str) + 1);
+  e_prog.project = realloc(e_prog.project, strlen(str) + 1);
   strcpy(e_prog.project, str);
   return(0);
  }
@@ -1360,9 +1360,9 @@ int e_cl_project(FENSTER *f)
  int i;
 
  if (!e_prog.project)
-  e_prog.project = MALLOC(sizeof(char));
+  e_prog.project = malloc(sizeof(char));
  else
-  e_prog.project = REALLOC(e_prog.project, sizeof(char));
+  e_prog.project = realloc(e_prog.project, sizeof(char));
  e_prog.project[0] = '\0';
  for (i = cn->mxedt; i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4);
    i--)
@@ -1520,9 +1520,9 @@ int print_to_end_of_buffer(BUFFER * b,char * str,int wrap_limit)
 /* copy char from string (str) to buffer */
 
   if (str[j + k]!='\0')
-   b->bf[i].s = REALLOC(b->bf[i].s, j + 2);
+   b->bf[i].s = realloc(b->bf[i].s, j + 2);
   else
-   b->bf[i].s = REALLOC(b->bf[i].s, j + 1);
+   b->bf[i].s = realloc(b->bf[i].s, j + 1);
   strncpy(b->bf[i].s,str + k,j);
 
 /* if this is not end of string, then we created substring
@@ -1640,7 +1640,7 @@ int e_exec_make(FENSTER *f)
  e_sys_ini();
  if (e_s_prog.compiler)
   FREE(e_s_prog.compiler);
- e_s_prog.compiler = MALLOC(5*sizeof(char));
+ e_s_prog.compiler = malloc(5*sizeof(char));
  strcpy(e_s_prog.compiler, "make");
  argc = e_make_arg(&arg, e_prog.arguments);
  if (argc == 0)
@@ -1753,7 +1753,7 @@ char *e_expand_var(char *string, FENSTER *f)
    }
    if (string[i+1] == '(' || string[i+1] == '{')
    {
-    if (!(var = MALLOC((j-i-1) * sizeof(char))))
+    if (!(var = malloc((j-i-1) * sizeof(char))))
     {
      e_error(e_msg[ERR_LOWMEM], 0, f->fb);
      return(string);
@@ -1763,7 +1763,7 @@ char *e_expand_var(char *string, FENSTER *f)
    }
    else
    {
-    if (!(var = MALLOC(2 * sizeof(char))))
+    if (!(var = malloc(2 * sizeof(char))))
     {  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(string);  }
     var[0] = string[i+1];  var[1] = '\0';
    }
@@ -1780,7 +1780,7 @@ char *e_expand_var(char *string, FENSTER *f)
    if (!v_string)
    {
     for(k = i; (string[k] = string[k+len]) != '\0'; k++);
-    if (!(string = REALLOC(tmp = string, (strlen(string) + 1) * sizeof(char))))
+    if (!(string = realloc(tmp = string, (strlen(string) + 1) * sizeof(char))))
     {  FREE(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
    }
    else
@@ -1788,7 +1788,7 @@ char *e_expand_var(char *string, FENSTER *f)
     len = strlen(v_string) - len;
     if (len >= 0)
     {
-     if (!(string = REALLOC(tmp = string, (k = strlen(string) + len + 1) * sizeof(char))))
+     if (!(string = realloc(tmp = string, (k = strlen(string) + len + 1) * sizeof(char))))
      {  FREE(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
      for (k--; k > j + len; k--) string[k] = string[k-len];
      for (k = i; v_string[k-i]; k++) string[k] = v_string[k-i];
@@ -1797,7 +1797,7 @@ char *e_expand_var(char *string, FENSTER *f)
     {
      for (k = i; (string[k] = string[k-len]) != '\0'; k++);
      for (k = i; v_string[k-i]; k++) string[k] = v_string[k-i];
-     if (!(string = REALLOC(tmp = string, (strlen(string) + 1) * sizeof(char))))
+     if (!(string = realloc(tmp = string, (strlen(string) + 1) * sizeof(char))))
      {  FREE(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
     }
    }
@@ -1829,7 +1829,7 @@ int e_read_var(FENSTER *f)
   FREE(p_v);
  }
  p_v_n = 0;
- if (!(p_v = MALLOC(sizeof(struct proj_var *))))
+ if (!(p_v = malloc(sizeof(struct proj_var *))))
  {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
  while (fgets(str, 256, fp))
  {
@@ -1849,21 +1849,21 @@ int e_read_var(FENSTER *f)
   *stmp = 0;
   for (sp2++; isspace(*sp2) && *sp2 != '\n'; sp2++);
   p_v_n++;
-  if (!(p_v = REALLOC(tmp = p_v, sizeof(struct proj_var *) * p_v_n)))
+  if (!(p_v = realloc(tmp = p_v, sizeof(struct proj_var *) * p_v_n)))
   {  p_v = tmp;  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-  if (!(p_v[p_v_n-1] = MALLOC(sizeof(struct proj_var))))
+  if (!(p_v[p_v_n-1] = malloc(sizeof(struct proj_var))))
   {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-  if (!(p_v[p_v_n-1]->var = MALLOC((strlen(sp1)+1) * sizeof(char))))
+  if (!(p_v[p_v_n-1]->var = malloc((strlen(sp1)+1) * sizeof(char))))
   {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
   strcpy(p_v[p_v_n-1]->var, sp1);
-  if (!(p_v[p_v_n-1]->string = MALLOC((strlen(sp2)+1) * sizeof(char))))
+  if (!(p_v[p_v_n-1]->string = malloc((strlen(sp2)+1) * sizeof(char))))
   {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
   strcpy(p_v[p_v_n-1]->string, sp2);
   while (p_v[p_v_n-1]->string[i = strlen(p_v[p_v_n-1]->string) - 1] != '\n' || (i && p_v[p_v_n-1]->string[i-1] == '\\'))
   {
    if (p_v[p_v_n-1]->string[i-1] == '\\') p_v[p_v_n-1]->string[i-1] = '\0';
    if (!fgets(str, 256, fp)) break;
-   if (!(p_v[p_v_n-1]->string = REALLOC(stmp = p_v[p_v_n-1]->string,
+   if (!(p_v[p_v_n-1]->string = realloc(stmp = p_v[p_v_n-1]->string,
 		(strlen(p_v[p_v_n-1]->string)+strlen(str)+1) * sizeof(char))))
    {
     p_v[p_v_n-1]->string = stmp;
@@ -1924,7 +1924,7 @@ int e_install(FENSTER *f)
   }
   if (text[0] != '\t')
    break;
-  if (!(string = MALLOC(strlen(sp) + 1)))
+  if (!(string = malloc(strlen(sp) + 1)))
   {
    fclose(fp);
    e_error(e_msg[ERR_LOWMEM], 0, f->fb);
@@ -1936,7 +1936,7 @@ int e_install(FENSTER *f)
    tp = fgets(text, 256, fp);
    if (tp)
    {
-    if (!(string = REALLOC(tmp = string, strlen(string) + strlen(text) + 1)))
+    if (!(string = realloc(tmp = string, strlen(string) + strlen(text) + 1)))
     {
      fclose(fp);
      FREE(tmp);
@@ -1960,13 +1960,13 @@ int e_install(FENSTER *f)
 
 struct dirfile *e_p_get_args(char *string)
 {
- struct dirfile *df = MALLOC(sizeof(struct dirfile));
+ struct dirfile *df = malloc(sizeof(struct dirfile));
  char **tmp;
  int i, j, k;
 
  if (!df)
   return(NULL);
- if (!(df->name = MALLOC(sizeof(char *))))
+ if (!(df->name = malloc(sizeof(char *))))
  {
   FREE(df);
   return(NULL);
@@ -1981,13 +1981,13 @@ struct dirfile *e_p_get_args(char *string)
   if (j == i)
    break;
   df->anz++;
-  if (!(df->name = REALLOC(tmp = df->name, df->anz * sizeof(char *))))
+  if (!(df->name = realloc(tmp = df->name, df->anz * sizeof(char *))))
   {
    df->anz--;
    df->name = tmp;
    return(df);
   }
-  if (!(df->name[df->anz-1] = MALLOC((j-i+1)*sizeof(char))))
+  if (!(df->name[df->anz-1] = malloc((j-i+1)*sizeof(char))))
   {
    df->anz--;
    return(df);
@@ -2049,8 +2049,8 @@ int e_c_project(FENSTER *f)
   e_error(ofile, 0, f->fb);
   return(-1);
  }
- e_arg = (char **) MALLOC(e_argc*sizeof(char *));
- arg = (char **) MALLOC(argc*sizeof(char *));
+ e_arg = (char **) malloc(e_argc*sizeof(char *));
+ arg = (char **) malloc(argc*sizeof(char *));
  df = e_p_get_var("CMP");
  if (!df)
  {
@@ -2061,19 +2061,19 @@ int e_c_project(FENSTER *f)
  for (k = 0; k < df->anz; k++, e_argc++, argc++)
  {
   j = e_argc == 1 ? 1 : 0;
-  e_arg = REALLOC(e_arg, (e_argc+2)*sizeof(char *));
-  e_arg[e_argc-j] = MALLOC(strlen(df->name[k]) + 1);
+  e_arg = realloc(e_arg, (e_argc+2)*sizeof(char *));
+  e_arg[e_argc-j] = malloc(strlen(df->name[k]) + 1);
   strcpy(e_arg[e_argc-j], df->name[k]);
-  arg = REALLOC(arg, (argc+2)*sizeof(char *));
-  arg[argc-j] = MALLOC(strlen(df->name[k]) + 1);
+  arg = realloc(arg, (argc+2)*sizeof(char *));
+  arg[argc-j] = malloc(strlen(df->name[k]) + 1);
   strcpy(arg[argc-j], df->name[k]);
   if (e_argc > 1)
    e_s_prog.comp_str = e_cat_string(e_s_prog.comp_str, e_arg[e_argc-j]);
  }
  freedf(df);
- arg[1] = MALLOC(3);
+ arg[1] = malloc(3);
  strcpy(arg[1], "-c");
- e_arg[1] = MALLOC(3);
+ e_arg[1] = malloc(3);
  strcpy(e_arg[1], "-o");
  df = e_p_get_var("CMPFLAGS");
  if (df)
@@ -2081,11 +2081,11 @@ int e_c_project(FENSTER *f)
   for (k = 0; k < df->anz; k++, e_argc++, argc++)
   {
    j = e_argc == 1 ? 1 : 0;
-   e_arg = REALLOC(e_arg, (e_argc+2)*sizeof(char *));
-   e_arg[e_argc-j] = MALLOC(strlen(df->name[k]) + 1);
+   e_arg = realloc(e_arg, (e_argc+2)*sizeof(char *));
+   e_arg[e_argc-j] = malloc(strlen(df->name[k]) + 1);
    strcpy(e_arg[e_argc-j], df->name[k]);
-   arg = REALLOC(arg, (argc+2)*sizeof(char *));
-   arg[argc-j] = MALLOC(strlen(df->name[k]) + 1);
+   arg = realloc(arg, (argc+2)*sizeof(char *));
+   arg[argc-j] = malloc(strlen(df->name[k]) + 1);
    strcpy(arg[argc-j], df->name[k]);
    if (e_argc > 1)
     e_s_prog.comp_str = e_cat_string(e_s_prog.comp_str, e_arg[e_argc-j]);
@@ -2124,11 +2124,11 @@ int e_c_project(FENSTER *f)
  df = e_p_get_var("CMPMESSAGE");
  if (df)
  {
-  char *tmpstr = MALLOC(1);
+  char *tmpstr = malloc(1);
   tmpstr[0] = '\0';
   for (k = 0; k < df->anz; k++)
   {
-   tmpstr = REALLOC(tmpstr,
+   tmpstr = realloc(tmpstr,
      (strlen(tmpstr)+strlen(df->name[k])+2)*sizeof(char));
    if (k) strcat(tmpstr, " ");
    strcat(tmpstr, df->name[k]);
@@ -2275,8 +2275,8 @@ gt_library:
   e_s_prog.libraries = NULL;
   for (k = 0; k < df->anz; k++, e_argc++)
   {
-   e_arg = REALLOC(e_arg, (e_argc+2)*sizeof(char *));
-   e_arg[e_argc] = MALLOC(strlen(df->name[k]) + 1);
+   e_arg = realloc(e_arg, (e_argc+2)*sizeof(char *));
+   e_arg[e_argc] = malloc(strlen(df->name[k]) + 1);
    strcpy(e_arg[e_argc], df->name[k]);
    e_s_prog.libraries = e_cat_string(e_s_prog.libraries, e_arg[e_argc]);
   }
@@ -2358,7 +2358,7 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
 				     || !f->ed->f[i]->save); i--);
  if (i > 0) {  save_df = e_p_df[0];  e_p_df[0] = NULL;  }
  if (e_p_df) freedfN(e_p_df, 3);
- e_p_df = MALLOC(3 * sizeof(struct dirfile *));
+ e_p_df = malloc(3 * sizeof(struct dirfile *));
  if (!e_p_df) return(e_p_df);
  for (i = 0; i < 3; i++) e_p_df[i] = NULL;
  e_s_prog.comp_sw = 0;
@@ -2381,20 +2381,20 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
   strcpy(library, "");
   for (i = !save_df ? 0 : 1; i < 3; i++)
   {
-   e_p_df[i] = MALLOC(sizeof(struct dirfile));
-   e_p_df[i]->name = MALLOC(sizeof(char *));
-   e_p_df[i]->name[0] = MALLOC(2 * sizeof(char));
+   e_p_df[i] = malloc(sizeof(struct dirfile));
+   e_p_df[i]->name = malloc(sizeof(char *));
+   e_p_df[i]->name[0] = malloc(2 * sizeof(char));
    *e_p_df[i]->name[0] = ' '; *(e_p_df[i]->name[0] + 1) = '\0';
    e_p_df[i]->anz = 1;
   }
   if (save_df) e_p_df[0] = save_df;
   return(e_p_df);
  }
- if (!(e_p_df[1] = MALLOC(sizeof(struct dirfile)))) return(e_p_df);
- if (!(e_p_df[1]->name = MALLOC(sizeof(char *)))) return(e_p_df);
+ if (!(e_p_df[1] = malloc(sizeof(struct dirfile)))) return(e_p_df);
+ if (!(e_p_df[1]->name = malloc(sizeof(char *)))) return(e_p_df);
  e_p_df[1]->anz = 0;
- if (!(e_p_df[2] = MALLOC(sizeof(struct dirfile)))) return(e_p_df);
- if (!(e_p_df[2]->name = MALLOC(sizeof(char *)))) return(e_p_df);
+ if (!(e_p_df[2] = malloc(sizeof(struct dirfile)))) return(e_p_df);
+ if (!(e_p_df[2]->name = malloc(sizeof(char *)))) return(e_p_df);
  e_p_df[2]->anz = 0;
  for (i = 0; i < p_v_n; i++)
  {
@@ -2450,10 +2450,10 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
   else
   {
    e_p_df[1]->anz++;
-   if (!(e_p_df[1]->name = REALLOC(tmp =
+   if (!(e_p_df[1]->name = realloc(tmp =
 				e_p_df[1]->name, e_p_df[1]->anz * sizeof(char *))))
    {  e_p_df[1]->anz--;  e_p_df[1]->name = tmp;  return(e_p_df);  }
-   if (!(e_p_df[1]->name[e_p_df[1]->anz-1] = MALLOC((strlen(p_v[i]->var)
+   if (!(e_p_df[1]->name[e_p_df[1]->anz-1] = malloc((strlen(p_v[i]->var)
 			+ strlen(p_v[i]->string) + 2)*sizeof(char))))
    {  e_p_df[1]->anz--;  return(e_p_df);  }
    sprintf(e_p_df[1]->name[e_p_df[1]->anz-1], "%s=%s",
@@ -2477,7 +2477,7 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
   e_s_prog.intstr = WpeStrdup(cc_intstr);
  if (!e_p_df[0])
  {
-  e_p_df[0] = MALLOC(sizeof(struct dirfile));
+  e_p_df[0] = malloc(sizeof(struct dirfile));
   e_p_df[0]->anz = 0;
  }
  if ((fp = fopen(e_prog.project, "r")) == NULL)
@@ -2511,10 +2511,10 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
   if (text[0] != '\t') break;
   if (sp[0] == '\0') continue;
   e_p_df[2]->anz++;
-  if (!(e_p_df[2]->name = REALLOC(tmp =
+  if (!(e_p_df[2]->name = realloc(tmp =
 				e_p_df[2]->name, e_p_df[2]->anz * sizeof(char *))))
   {  e_p_df[2]->anz--;  e_p_df[2]->name = tmp;  fclose(fp);  return(e_p_df);  }
-  if (!(e_p_df[2]->name[e_p_df[2]->anz-1] = MALLOC((strlen(sp) + 1))))
+  if (!(e_p_df[2]->name[e_p_df[2]->anz-1] = malloc((strlen(sp) + 1))))
   {  e_p_df[2]->anz--;  fclose(fp);  return(e_p_df);  }
 
   strcpy(e_p_df[2]->name[e_p_df[2]->anz-1], sp);
@@ -2526,7 +2526,7 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
     j = strlen(e_p_df[2]->name[e_p_df[2]->anz-1]);
     *(e_p_df[2]->name[e_p_df[2]->anz-1]+j-2) = '\0';
     if (!(e_p_df[2]->name[e_p_df[2]->anz-1] =
-		    REALLOC(sp = e_p_df[2]->name[e_p_df[2]->anz-1],
+		    realloc(sp = e_p_df[2]->name[e_p_df[2]->anz-1],
 			strlen(e_p_df[2]->name[e_p_df[2]->anz-1])
 			+ strlen(text) + 1)))
     {  fclose(fp);  FREE(sp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);
@@ -2544,13 +2544,13 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
  {
   if (!e_p_df[i])
   {
-   e_p_df[i] = MALLOC(sizeof(struct dirfile));
-   e_p_df[i]->name = MALLOC(sizeof(char *));
+   e_p_df[i] = malloc(sizeof(struct dirfile));
+   e_p_df[i]->name = malloc(sizeof(char *));
    e_p_df[i]->anz = 0;
   }
-  e_p_df[i]->name = REALLOC(e_p_df[i]->name,
+  e_p_df[i]->name = realloc(e_p_df[i]->name,
 				(e_p_df[i]->anz + 1) * sizeof(char *));
-  e_p_df[i]->name[e_p_df[i]->anz] = MALLOC(2*sizeof(char));
+  e_p_df[i]->name[e_p_df[i]->anz] = malloc(2*sizeof(char));
   *e_p_df[i]->name[e_p_df[i]->anz] = ' ';
   *(e_p_df[i]->name[e_p_df[i]->anz] + 1) = '\0';
   e_p_df[i]->anz++;
@@ -2685,10 +2685,10 @@ int e_p_add_df(FLWND *fw, int sw)
  if (e_add_arguments(str, title, fw->f, 0, AltA, NULL))
  {
   fw->df->anz++;
-  fw->df->name = REALLOC(fw->df->name, fw->df->anz * sizeof(char *));
+  fw->df->name = realloc(fw->df->name, fw->df->anz * sizeof(char *));
   for (i = fw->df->anz - 1; i > fw->nf; i--)
    fw->df->name[i] = fw->df->name[i-1];
-  fw->df->name[i] = MALLOC(strlen(str)+1);
+  fw->df->name[i] = malloc(strlen(str)+1);
   strcpy(fw->df->name[i], str);
  }
  return(0);
@@ -2717,12 +2717,12 @@ int e_p_edit_df(FLWND *fw, int sw)
   {
    fw->nf = fw->df->anz-1;
    fw->df->anz++;
-   fw->df->name = REALLOC(fw->df->name, fw->df->anz * sizeof(char *));
+   fw->df->name = realloc(fw->df->name, fw->df->anz * sizeof(char *));
    fw->df->name[fw->df->anz-1] = fw->df->name[fw->df->anz-2];
   }
   if (!new)
    FREE(fw->df->name[fw->nf]);
-  fw->df->name[fw->nf] = MALLOC(strlen(str)+1);
+  fw->df->name[fw->nf] = malloc(strlen(str)+1);
   if (fw->df->name[fw->nf])
    strcpy(fw->df->name[fw->nf], str);
  }
@@ -2743,14 +2743,14 @@ int e_p_del_df(FLWND *fw, int sw)
 
 int e_p_mess_win(char *header, int argc, char **argv, PIC **pic, FENSTER *f)
 {
- char *tmp = MALLOC(sizeof(char));
+ char *tmp = malloc(sizeof(char));
  int i, ret;
 
  fk_cursor(0);
  tmp[0] = '\0';
  for (i = 0; i < argc && argv[i] != NULL; i++)
  {
-  if(!(tmp = REALLOC(tmp, (strlen(tmp)+strlen(argv[i])+2)*sizeof(char))))
+  if(!(tmp = realloc(tmp, (strlen(tmp)+strlen(argv[i])+2)*sizeof(char))))
    return(-2);
   strcat(tmp, argv[i]);
   strcat(tmp, " ");
@@ -2911,7 +2911,7 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
  if (a[0] == '$' && a[1] == '{')
  {
   for (k = 2; a[k] && a[k] != '}'; k++);
-  var = MALLOC((k-1) * sizeof(char));
+  var = malloc((k-1) * sizeof(char));
   for (i = 2; i < k; i++)
    var[i-2] = a[i];
   var[k-2] = '\0';
@@ -2935,7 +2935,7 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
  {
   if (a[k] == '?')
   {
-   cp = MALLOC((strlen(a)+1)*sizeof(char));
+   cp = malloc((strlen(a)+1)*sizeof(char));
    for (i = 0; i < k && (cp[i] = a[i]); i++);
    for (i++; (cp[i-1] = a[i]) != '\0'; i++);
    FREE(var);
@@ -2952,7 +2952,7 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
     return(0);
    if (a[0] == '$')
    {
-    str = MALLOC((i+1)*sizeof(char));
+    str = malloc((i+1)*sizeof(char));
     for (k = 0; k < i; k++)
      str[k] = b[k];
     str[i] = '\0';
@@ -2963,7 +2963,7 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
    return(n);
   }
   n -= k;
-  ctmp = MALLOC(n+1);
+  ctmp = malloc(n+1);
   for (i = 0; i < n; i++)
    ctmp[i] = a[i+k];
   ctmp[n] = '\0';
@@ -2974,7 +2974,7 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
   if (a[0] == '$')
   {
    for (i = 0; c + i < cp; i++);
-   str = MALLOC((i+1)*sizeof(char));
+   str = malloc((i+1)*sizeof(char));
    for (i = 0; c + i < cp; i++)
     str[i] = c[i];
    str[i] = '\0';
@@ -3040,8 +3040,8 @@ int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret)
  int *wn = NULL;
 
  cmp[0] = search[0] = file[0] = '\0';
- wtxt = MALLOC(1);
- wn = MALLOC(1);
+ wtxt = malloc(1);
+ wn = malloc(1);
  for (j = 0, n = 0; n < 4 && srch[j]; n++)
  {
   for (l = 0; (tmp[n][l] = srch[j]); j++, l++)
@@ -3049,8 +3049,8 @@ int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret)
    if (j > 1 && srch[j] == '?' && srch[j-1] == '{' && srch[j-2] == '$')
    {
     wnum++;
-    wn = REALLOC(wn, wnum * sizeof(int));
-    wtxt = REALLOC(wtxt, wnum * sizeof(char *));
+    wn = realloc(wn, wnum * sizeof(int));
+    wtxt = realloc(wtxt, wnum * sizeof(char *));
     if (srch[j+1] == '*')
      wn[wnum-1] = -1;
     else
@@ -3062,7 +3062,7 @@ int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret)
      break;
     }
     for (m = 0; srch[j+m] && srch[j+m] != '}'; m++);
-    wtxt[wnum-1] = MALLOC((m+1) * sizeof(char));
+    wtxt[wnum-1] = malloc((m+1) * sizeof(char));
     for (m = 0, j++; (wtxt[wnum-1][m] = srch[j]) && srch[j] != '}'; j++, m++);
     wtxt[wnum-1][m] = '\0';
     l -= 3;
@@ -3111,7 +3111,7 @@ int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret)
     l = 1;
    if (file[0] && y >= 0 && l != 0)
    {
-    err_li[k].file = MALLOC((strlen(file)+1)*sizeof(char));
+    err_li[k].file = malloc((strlen(file)+1)*sizeof(char));
     strcpy(err_li[k].file, file);
     err_li[k].line = y;
     if (search[0] == 'P')
@@ -3124,20 +3124,20 @@ int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret)
       for (m = 0; b->bf[iy].s + m < (unsigned char *)cp; m++);
       x -= m;
      }
-     err_li[k].srch = MALLOC((strlen(cmp)+2)*sizeof(char));
+     err_li[k].srch = malloc((strlen(cmp)+2)*sizeof(char));
      err_li[k].srch[0] = 'P';
      strcpy(err_li[k].srch+1, cmp);
     }
     else if (search[0])
     {
-     err_li[k].srch = MALLOC((strlen(search)+1)*sizeof(char));
+     err_li[k].srch = malloc((strlen(search)+1)*sizeof(char));
      strcpy(err_li[k].srch, search);
     }
     else
      err_li[k].srch = NULL;
     err_li[k].x = x;
     err_li[k].y = iorig;
-    err_li[k].text = MALLOC(strlen((char *)b->bf[i].s) + 1);
+    err_li[k].text = malloc(strlen((char *)b->bf[i].s) + 1);
     strcpy(err_li[k].text, (char *)b->bf[i].s);
     err_li[k].text[b->bf[i].len] = '\0';
     k++;

--- a/we_prog.c
+++ b/we_prog.c
@@ -1201,7 +1201,7 @@ int e_run_c_options(FENSTER *f)
     continue;
    for (j = i; (o->wstr[5]->txt[j]) && (!isspace(o->wstr[5]->txt[j])); j++)
     ;
-   newpostfix = (char *)WpeMalloc(sizeof(char) * j - i + 1);
+   newpostfix = (char *)malloc(sizeof(char) * j - i + 1);
    strncpy(newpostfix, o->wstr[5]->txt + i, j - i);
    newpostfix[j - i] = 0;
    WpeExpArrayAdd((void **)&e_s_prog.filepostfix, &newpostfix);
@@ -1239,17 +1239,17 @@ int e_run_options(FENSTER *f)
    e_prog.num++;
    e_prog.comp = REALLOC(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
    e_prog.comp[e_prog.num - 1] = MALLOC(sizeof(struct e_s_prog));
-   e_prog.comp[e_prog.num - 1]->language = (char *)WpeMalloc(1);
+   e_prog.comp[e_prog.num - 1]->language = (char *)malloc(1);
    e_prog.comp[e_prog.num - 1]->language[0] = 0;
-   e_prog.comp[e_prog.num - 1]->compiler = (char *)WpeMalloc(1);
+   e_prog.comp[e_prog.num - 1]->compiler = (char *)malloc(1);
    e_prog.comp[e_prog.num - 1]->compiler[0] = 0;
-   e_prog.comp[e_prog.num - 1]->comp_str = (char *)WpeMalloc(1);
+   e_prog.comp[e_prog.num - 1]->comp_str = (char *)malloc(1);
    e_prog.comp[e_prog.num - 1]->comp_str[0] = 0;
-   e_prog.comp[e_prog.num - 1]->libraries = (char *)WpeMalloc(1);
+   e_prog.comp[e_prog.num - 1]->libraries = (char *)malloc(1);
    e_prog.comp[e_prog.num - 1]->libraries[0] = 0;
-   e_prog.comp[e_prog.num - 1]->exe_name = (char *)WpeMalloc(1);
+   e_prog.comp[e_prog.num - 1]->exe_name = (char *)malloc(1);
    e_prog.comp[e_prog.num - 1]->exe_name[0] = 0;
-   e_prog.comp[e_prog.num - 1]->intstr = (char *)WpeMalloc(1);
+   e_prog.comp[e_prog.num - 1]->intstr = (char *)malloc(1);
    e_prog.comp[e_prog.num - 1]->intstr[0] = 0;
    e_prog.comp[e_prog.num - 1]->filepostfix =
      (char **)WpeExpArrayCreate(0, sizeof(char *), 1);

--- a/we_prog.c
+++ b/we_prog.c
@@ -1022,7 +1022,7 @@ int e_copy_prog(struct e_s_prog *out, struct e_s_prog *in)
  if (out->filepostfix)
  {
   for (i = WpeExpArrayGetSize(out->filepostfix); i; i--)
-   WpeFree(out->filepostfix[i - 1]);
+   free(out->filepostfix[i - 1]);
   WpeExpArrayDestroy(out->filepostfix);
  }
  out->filepostfix = (char **)WpeExpArrayCreate(WpeExpArrayGetSize(in->filepostfix), sizeof(char *), 1);
@@ -1108,7 +1108,7 @@ int e_project_options(FENSTER *f)
  e_add_wrstr(4, 10, 22, 10, 36, 128, 2, AltB, "LiBrary:", library, NULL, o);
  messagestring = WpeStringToValue(e_s_prog.intstr);
  e_add_wrstr(22, 12, 22, 13, 36, 256, 0, AltM, "Message-String:", messagestring, NULL, o);
- WpeFree(messagestring);
+ free(messagestring);
  e_add_pswstr(0, 5, 13, 0, AltG, 0, "GNU       ", o);
  e_add_pswstr(0, 5, 14, 1, AltT, e_s_prog.comp_sw, "OTher     ", o);
  e_add_bttstr(9, 18, 0, AltS, "Save", NULL, o);
@@ -1173,7 +1173,7 @@ int e_run_c_options(FENSTER *f)
  e_add_wrstr(4, 12, 22, 12, 36, 128, 0, AltF, "File-Postfix:", filepostfix, NULL, o);
  messagestring = WpeStringToValue(e_s_prog.intstr);
  e_add_wrstr(22, 14, 22, 15, 36, 128, 0, AltM, "Message-String:", messagestring, NULL, o);
- WpeFree(messagestring);
+ free(messagestring);
  e_add_pswstr(0, 5, 15, 0, AltG, 0, "GNU      ", o);
  e_add_pswstr(0, 5, 16, 1, AltT, e_s_prog.comp_sw, "OTher    ", o);
  e_add_bttstr(16, 18, 1, AltO, " Ok ", NULL, o);
@@ -1192,7 +1192,7 @@ int e_run_c_options(FENSTER *f)
   if (e_s_prog.exe_name) FREE(e_s_prog.exe_name);
   e_s_prog.exe_name = WpeStrdup(o->wstr[4]->txt);
   for (i = 0; i < j; i++)
-   WpeFree(e_s_prog.filepostfix[i]);
+   free(e_s_prog.filepostfix[i]);
   WpeExpArrayDestroy(e_s_prog.filepostfix);
   e_s_prog.filepostfix = (char **)WpeExpArrayCreate(0, sizeof(char *), 1);
   for (i = 0; o->wstr[5]->txt[i]; i++)

--- a/we_prog.c
+++ b/we_prog.c
@@ -484,7 +484,7 @@ int e_p_exec(int file, FENSTER *f, PIC *pic)
    fflush(stdout);
   }
   print_to_end_of_buffer(b, buff, b->mx.x);
-  FREE(buff);
+  free(buff);
 
   if( fd == wfildes[0] )
     break;
@@ -501,13 +501,13 @@ int e_p_exec(int file, FENSTER *f, PIC *pic)
  if (wfile)
  {
   remove(wfile);
-  FREE(wfile);
+  free(wfile);
   wfile = NULL;
  }
  if (efile)
  {
   remove(efile);
-  FREE(efile);
+  free(efile);
   efile = NULL;
  }
  efildes[0] = efildes[1] = -1;
@@ -555,7 +555,7 @@ int e_show_error(int n, FENSTER *f)
   {
    if (filename != cn->f[i+1]->datnam)
    {
-    FREE(filename);
+    free(filename);
     filename = e_mkfilename(cn->f[i]->dirct, cn->f[i]->datnam);
    }
    else
@@ -563,7 +563,7 @@ int e_show_error(int n, FENSTER *f)
    if (!strcmp(err_li[n].file+bg, filename))
    {
     if (filename != cn->f[i]->datnam)
-     FREE(filename);
+     free(filename);
     e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
     break;  
    }
@@ -571,13 +571,13 @@ int e_show_error(int n, FENSTER *f)
   if (i <= 0)
   {
    if (filename != cn->f[i+1]->datnam)
-    FREE(filename); 
+    free(filename); 
    if (e_edit(cn, err_li[n].file))
     return(WPE_ESC);
   }
  }
  else if (filename != f->datnam)
-  FREE(filename);
+  free(filename);
  e_pr_str_wsd(1, MAXSLNS - 1, err_li[n].text, f->fb->mt.fb, -1, 0,
    f->fb->mt.fb, 1, MAXSCOL-2);
 /*   e_pr_nstr(2, MAXSLNS - 1, MAXSCOL-2, err_li[n].text,
@@ -650,11 +650,11 @@ int e_make_error_list(FENSTER *f)
  {
   for (i = 0; i < err_num; i++)
   {
-   if(err_li[i].file) FREE(err_li[i].file);
-   if(err_li[i].text) FREE(err_li[i].text);
-   if(err_li[i].srch) FREE(err_li[i].srch);
+   if(err_li[i].file) free(err_li[i].file);
+   if(err_li[i].text) free(err_li[i].text);
+   if(err_li[i].srch) free(err_li[i].srch);
   }
-  FREE(err_li);
+  free(err_li);
  }
  err_li = malloc(sizeof(struct ERR_LI) * b->mxlines);
  err_num = 0;
@@ -838,9 +838,9 @@ int e_check_header(char *file, M_TIME otime, ECNT *cn, int sw)
   else
    p = cn->f[i]->datnam;
   if (!strcmp(p, file) && cn->f[i]->save)
-  {  e_save(cn->f[i]);  if(p != cn->f[i]->datnam) FREE(p);  break;  }
+  {  e_save(cn->f[i]);  if(p != cn->f[i]->datnam) free(p);  break;  }
   if (p != cn->f[i]->datnam)
-   FREE(p);
+   free(p);
  }
  if ((fp = fopen(file, "r")) == NULL)
   return(sw);
@@ -956,13 +956,13 @@ int e_ini_prog(ECNT *cn)
  int i;
 
  e_prog.num = 4;
- if (e_prog.arguments) FREE(e_prog.arguments);
+ if (e_prog.arguments) free(e_prog.arguments);
  e_prog.arguments = WpeStrdup("");
- if (e_prog.project) FREE(e_prog.project);
+ if (e_prog.project) free(e_prog.project);
  e_prog.project = WpeStrdup("project.prj");
- if (e_prog.exedir) FREE(e_prog.exedir);
+ if (e_prog.exedir) free(e_prog.exedir);
  e_prog.exedir = WpeStrdup(".");
- if (e_prog.sys_include) FREE(e_prog.sys_include);
+ if (e_prog.sys_include) free(e_prog.sys_include);
  e_prog.sys_include =
    WpeStrdup("/usr/include:/usr/local/include:/usr/include/X11");
  if (e_prog.comp == NULL)
@@ -1017,7 +1017,7 @@ int e_copy_prog(struct e_s_prog *out, struct e_s_prog *in)
 {
  int i;
 
- if (out->language) FREE(out->language);
+ if (out->language) free(out->language);
  out->language = WpeStrdup(in->language);
  if (out->filepostfix)
  {
@@ -1028,15 +1028,15 @@ int e_copy_prog(struct e_s_prog *out, struct e_s_prog *in)
  out->filepostfix = (char **)WpeExpArrayCreate(WpeExpArrayGetSize(in->filepostfix), sizeof(char *), 1);
  for (i = WpeExpArrayGetSize(out->filepostfix); i; i--)
   out->filepostfix[i - 1] = WpeStrdup(in->filepostfix[i - 1]);
- if (out->compiler) FREE(out->compiler);
+ if (out->compiler) free(out->compiler);
  out->compiler = WpeStrdup(in->compiler);
- if (out->comp_str) FREE(out->comp_str);
+ if (out->comp_str) free(out->comp_str);
  out->comp_str = WpeStrdup(in->comp_str);
- if (out->libraries) FREE(out->libraries);
+ if (out->libraries) free(out->libraries);
  out->libraries = WpeStrdup(in->libraries);
- if (out->exe_name) FREE(out->exe_name);
+ if (out->exe_name) free(out->exe_name);
  out->exe_name = WpeStrdup(in->exe_name);
- if (out->intstr) FREE(out->intstr);
+ if (out->intstr) free(out->intstr);
  out->intstr = WpeStrdup(in->intstr);
  out->key = in->key;
  out->comp_sw = in->comp_sw;
@@ -1120,15 +1120,15 @@ int e_project_options(FENSTER *f)
  ret = e_opt_kst(o);
  if (ret != WPE_ESC)
  {
-  if (e_s_prog.compiler) FREE(e_s_prog.compiler);
+  if (e_s_prog.compiler) free(e_s_prog.compiler);
   e_s_prog.compiler = WpeStrdup(o->wstr[0]->txt);
-  if (e_s_prog.comp_str) FREE(e_s_prog.comp_str);
+  if (e_s_prog.comp_str) free(e_s_prog.comp_str);
   e_s_prog.comp_str = WpeStrdup(o->wstr[1]->txt);
-  if (e_s_prog.libraries) FREE(e_s_prog.libraries);
+  if (e_s_prog.libraries) free(e_s_prog.libraries);
   e_s_prog.libraries = WpeStrdup(o->wstr[2]->txt);
-  if (e_s_prog.exe_name) FREE(e_s_prog.exe_name);
+  if (e_s_prog.exe_name) free(e_s_prog.exe_name);
   e_s_prog.exe_name = WpeStrdup(o->wstr[3]->txt);
-  if (e_s_prog.intstr) FREE(e_s_prog.intstr);
+  if (e_s_prog.intstr) free(e_s_prog.intstr);
   e_s_prog.intstr = WpeValueToString(o->wstr[5]->txt);
   strcpy(library, o->wstr[4]->txt);
   e_s_prog.comp_sw = o->pstr[0]->num;
@@ -1181,15 +1181,15 @@ int e_run_c_options(FENSTER *f)
  ret = e_opt_kst(o);
  if (ret != WPE_ESC)
  {
-  if (e_s_prog.language) FREE(e_s_prog.language);
+  if (e_s_prog.language) free(e_s_prog.language);
   e_s_prog.language = WpeStrdup(o->wstr[0]->txt);
-  if (e_s_prog.compiler) FREE(e_s_prog.compiler);
+  if (e_s_prog.compiler) free(e_s_prog.compiler);
   e_s_prog.compiler = WpeStrdup(o->wstr[1]->txt);
-  if (e_s_prog.comp_str) FREE(e_s_prog.comp_str);
+  if (e_s_prog.comp_str) free(e_s_prog.comp_str);
   e_s_prog.comp_str = WpeStrdup(o->wstr[2]->txt);
-  if (e_s_prog.libraries) FREE(e_s_prog.libraries);
+  if (e_s_prog.libraries) free(e_s_prog.libraries);
   e_s_prog.libraries = WpeStrdup(o->wstr[3]->txt);
-  if (e_s_prog.exe_name) FREE(e_s_prog.exe_name);
+  if (e_s_prog.exe_name) free(e_s_prog.exe_name);
   e_s_prog.exe_name = WpeStrdup(o->wstr[4]->txt);
   for (i = 0; i < j; i++)
    free(e_s_prog.filepostfix[i]);
@@ -1207,7 +1207,7 @@ int e_run_c_options(FENSTER *f)
    WpeExpArrayAdd((void **)&e_s_prog.filepostfix, &newpostfix);
    i = j - 1;
   }
-  if (e_s_prog.intstr) FREE(e_s_prog.intstr);
+  if (e_s_prog.intstr) free(e_s_prog.intstr);
   e_s_prog.intstr = WpeValueToString(o->wstr[6]->txt);
   e_s_prog.comp_sw = o->pstr[0]->num;
  }
@@ -1276,10 +1276,10 @@ int e_run_options(FENSTER *f)
    if (i >= e_prog.num)
    {
     e_error(e_p_msg[ERR_NO_COMPILER], 0, f->fb);
-    FREE(opt);
+    free(opt);
     return(0);
    }
-   FREE(e_prog.comp[i]);
+   free(e_prog.comp[i]);
    for(; i < e_prog.num-1; i++) e_prog.comp[i] = e_prog.comp[i+1];
     e_prog.num--;
   }
@@ -1290,7 +1290,7 @@ int e_run_options(FENSTER *f)
   e_run_c_options(f);
   e_copy_prog(e_prog.comp[n-2], &e_s_prog);
  }
- FREE(opt);
+ free(opt);
  return(n < 0 ? WPE_ESC : 0);
 }
 
@@ -1639,7 +1639,7 @@ int e_exec_make(FENSTER *f)
  f = cn->f[cn->mxedt];
  e_sys_ini();
  if (e_s_prog.compiler)
-  FREE(e_s_prog.compiler);
+  free(e_s_prog.compiler);
  e_s_prog.compiler = malloc(5*sizeof(char));
  strcpy(e_s_prog.compiler, "make");
  argc = e_make_arg(&arg, e_prog.arguments);
@@ -1781,7 +1781,7 @@ char *e_expand_var(char *string, FENSTER *f)
    {
     for(k = i; (string[k] = string[k+len]) != '\0'; k++);
     if (!(string = realloc(tmp = string, (strlen(string) + 1) * sizeof(char))))
-    {  FREE(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
+    {  free(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
    }
    else
    {
@@ -1789,7 +1789,7 @@ char *e_expand_var(char *string, FENSTER *f)
     if (len >= 0)
     {
      if (!(string = realloc(tmp = string, (k = strlen(string) + len + 1) * sizeof(char))))
-     {  FREE(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
+     {  free(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
      for (k--; k > j + len; k--) string[k] = string[k-len];
      for (k = i; v_string[k-i]; k++) string[k] = v_string[k-i];
     }
@@ -1798,10 +1798,10 @@ char *e_expand_var(char *string, FENSTER *f)
      for (k = i; (string[k] = string[k-len]) != '\0'; k++);
      for (k = i; v_string[k-i]; k++) string[k] = v_string[k-i];
      if (!(string = realloc(tmp = string, (strlen(string) + 1) * sizeof(char))))
-     {  FREE(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
+     {  free(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
     }
    }
-   FREE(var);
+   free(var);
   }
  }
  return(string);
@@ -1821,12 +1821,12 @@ int e_read_var(FENSTER *f)
   {
    if (p_v[i])
    {
-    if (p_v[i]->var) FREE(p_v[i]->var);
-    if (p_v[i]->string) FREE(p_v[i]->string);
-    FREE(p_v[i]);
+    if (p_v[i]->var) free(p_v[i]->var);
+    if (p_v[i]->string) free(p_v[i]->string);
+    free(p_v[i]);
    }
   }
-  FREE(p_v);
+  free(p_v);
  }
  p_v_n = 0;
  if (!(p_v = malloc(sizeof(struct proj_var *))))
@@ -1939,7 +1939,7 @@ int e_install(FENSTER *f)
     if (!(string = realloc(tmp = string, strlen(string) + strlen(text) + 1)))
     {
      fclose(fp);
-     FREE(tmp);
+     free(tmp);
      e_error(e_msg[ERR_LOWMEM], 0, f->fb);
      return(-1);
     }
@@ -1952,7 +1952,7 @@ int e_install(FENSTER *f)
   if (p_v_n) p_v_n--;
   e_d_p_message(string, f, 1);
   system(string);
-  FREE(string);
+  free(string);
  }
  fclose(fp);
  return(0);
@@ -1968,7 +1968,7 @@ struct dirfile *e_p_get_args(char *string)
   return(NULL);
  if (!(df->name = malloc(sizeof(char *))))
  {
-  FREE(df);
+  free(df);
   return(NULL);
  }
  df->anz = 0;
@@ -2033,7 +2033,7 @@ int e_c_project(FENSTER *f)
  f = cn->f[cn->mxedt];
  if (e_s_prog.comp_str)
  {
-  FREE(e_s_prog.comp_str);
+  free(e_s_prog.comp_str);
   e_s_prog.comp_str = NULL;
  }
  e_s_prog.comp_sw &= ~1;
@@ -2101,7 +2101,7 @@ int e_c_project(FENSTER *f)
   sprintf(ofile, "%s/%s", e_prog.exedir,
     (df && df->anz > 0 && df->name[0][0]) ? df->name[0] : "a.out");
  if (df) freedf(df);
- if (e_s_prog.exe_name) FREE(e_s_prog.exe_name);
+ if (e_s_prog.exe_name) free(e_s_prog.exe_name);
  e_s_prog.exe_name = WpeStrdup(ofile);
  e_argc = e_add_arg(&e_arg, e_s_prog.exe_name, 2, e_argc);
  df = e_p_get_var("LIBNAME");
@@ -2133,14 +2133,14 @@ int e_c_project(FENSTER *f)
    if (k) strcat(tmpstr, " ");
    strcat(tmpstr, df->name[k]);
   }
-  if (e_s_prog.intstr) FREE(e_s_prog.intstr);
+  if (e_s_prog.intstr) free(e_s_prog.intstr);
   e_s_prog.intstr = WpeStrdup(tmpstr);
-  FREE(tmpstr);
+  free(tmpstr);
   freedf(df);
  }
  else
  {
-  if (e_s_prog.intstr) FREE(e_s_prog.intstr);
+  if (e_s_prog.intstr) free(e_s_prog.intstr);
   e_s_prog.intstr = WpeStrdup(cc_intstr);
  }
  df = e_p_get_var("FILES");
@@ -2220,7 +2220,7 @@ int e_c_project(FENSTER *f)
    }
    else libsw = 1;
   }
-  for (j = 0; j < 3; j++) FREE(arg[argc-j-1])
+  for (j = 0; j < 3; j++) free(arg[argc-j-1])
    ;
   argc -= 3;
 gt_library:
@@ -2271,7 +2271,7 @@ gt_library:
  df = e_p_get_var("LDFLAGS");
  if (df)
  {
-  FREE(e_s_prog.libraries);
+  free(e_s_prog.libraries);
   e_s_prog.libraries = NULL;
   for (k = 0; k < df->anz; k++, e_argc++)
   {
@@ -2294,8 +2294,8 @@ int e_free_arg(char **arg, int argc)
 
  for(i = 0; i < argc; i++)
   if(arg[i])
-   FREE(arg[i]);
- FREE(arg);
+   free(arg[i]);
+ free(arg);
  return(i);
 }
 
@@ -2365,18 +2365,18 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
  ret = e_read_var(f);
  if (ret)
  {
-  if (e_s_prog.compiler) FREE(e_s_prog.compiler);
+  if (e_s_prog.compiler) free(e_s_prog.compiler);
   e_s_prog.compiler = WpeStrdup("gcc");
-  if (e_s_prog.comp_str) FREE(e_s_prog.comp_str);
+  if (e_s_prog.comp_str) free(e_s_prog.comp_str);
   e_s_prog.comp_str = WpeStrdup("-g");
-  if (e_s_prog.libraries) FREE(e_s_prog.libraries);
+  if (e_s_prog.libraries) free(e_s_prog.libraries);
   e_s_prog.libraries = WpeStrdup("");
-  if (e_s_prog.exe_name) FREE(e_s_prog.exe_name);
+  if (e_s_prog.exe_name) free(e_s_prog.exe_name);
   /* Project my_prog.prj defaults to an executable of my_prog BD */
   strcpy(text, e_prog.project);
   e_s_prog.exe_name = WpeStrdup(WpeStringCutChar(text, '.'));
   /*e_s_prog.exe_name = WpeStrdup("a.out");*/
-  if (e_s_prog.intstr) FREE(e_s_prog.intstr);
+  if (e_s_prog.intstr) free(e_s_prog.intstr);
   e_s_prog.intstr = WpeStrdup(cc_intstr);
   strcpy(library, "");
   for (i = !save_df ? 0 : 1; i < 3; i++)
@@ -2400,27 +2400,27 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
  {
   if (!strcmp(p_v[i]->var, "CMP"))
   {
-   if (e_s_prog.compiler) FREE(e_s_prog.compiler);
+   if (e_s_prog.compiler) free(e_s_prog.compiler);
    e_s_prog.compiler = WpeStrdup(p_v[i]->string);
   }
   else if (!strcmp(p_v[i]->var, "CMPFLAGS"))
   {
-   if (e_s_prog.comp_str) FREE(e_s_prog.comp_str);
+   if (e_s_prog.comp_str) free(e_s_prog.comp_str);
    e_s_prog.comp_str = WpeStrdup(p_v[i]->string);
   }
   else if (!strcmp(p_v[i]->var, "LDFLAGS"))
   {
-   if (e_s_prog.libraries) FREE(e_s_prog.libraries);
+   if (e_s_prog.libraries) free(e_s_prog.libraries);
    e_s_prog.libraries = WpeStrdup(p_v[i]->string);
   }
   else if (!strcmp(p_v[i]->var, "EXENAME"))
   {
-   if (e_s_prog.exe_name) FREE(e_s_prog.exe_name);
+   if (e_s_prog.exe_name) free(e_s_prog.exe_name);
    e_s_prog.exe_name = WpeStrdup(p_v[i]->string);
   }
   else if (!strcmp(p_v[i]->var, "CMPMESSAGE"))
   {
-   if (e_s_prog.intstr) FREE(e_s_prog.intstr);
+   if (e_s_prog.intstr) free(e_s_prog.intstr);
    e_s_prog.intstr = WpeStrdup(e_interpr_var(p_v[i]->string));
   }
 
@@ -2529,7 +2529,7 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
 		    realloc(sp = e_p_df[2]->name[e_p_df[2]->anz-1],
 			strlen(e_p_df[2]->name[e_p_df[2]->anz-1])
 			+ strlen(text) + 1)))
-    {  fclose(fp);  FREE(sp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);
+    {  fclose(fp);  free(sp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);
 	       return(e_p_df);
     }
     strcat(e_p_df[2]->name[e_p_df[2]->anz-1], text);
@@ -2566,7 +2566,7 @@ int freedfN(struct dirfile **df, int n)
  for(i = 0; i < n; i++)
   if(df[i])
    freedf(df[i]);
- FREE(df);
+ free(df);
  return(0);
 }
 
@@ -2721,7 +2721,7 @@ int e_p_edit_df(FLWND *fw, int sw)
    fw->df->name[fw->df->anz-1] = fw->df->name[fw->df->anz-2];
   }
   if (!new)
-   FREE(fw->df->name[fw->nf]);
+   free(fw->df->name[fw->nf]);
   fw->df->name[fw->nf] = malloc(strlen(str)+1);
   if (fw->df->name[fw->nf])
    strcpy(fw->df->name[fw->nf], str);
@@ -2756,7 +2756,7 @@ int e_p_mess_win(char *header, int argc, char **argv, PIC **pic, FENSTER *f)
   strcat(tmp, " ");
  }
  ret = e_mess_win(header, tmp, pic, f);
- FREE(tmp);
+ free(tmp);
  fk_cursor(1);
  return(ret);
 }
@@ -2769,7 +2769,7 @@ int e_p_red_buffer(BUFFER *b)
 
  for (i = 1; i < b->mxlines; i++)
   if (b->bf[i].s != NULL)
-   FREE( b->bf[i].s );
+   free( b->bf[i].s );
  if (b->mxlines==0) e_new_line(0,b);
  b->bf[0].s[0] = WPE_WR;
  b->bf[0].s[1] = '\0';
@@ -2938,9 +2938,9 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
    cp = malloc((strlen(a)+1)*sizeof(char));
    for (i = 0; i < k && (cp[i] = a[i]); i++);
    for (i++; (cp[i-1] = a[i]) != '\0'; i++);
-   FREE(var);
+   free(var);
    n = e_p_comp_mess(cp, ++b, ++c, txt, file, cmp, y, x);
-   FREE(cp);
+   free(cp);
    return(n);
   }
   if (a[k] == '[')
@@ -2957,8 +2957,8 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
      str[k] = b[k];
     str[i] = '\0';
     e_p_konv_mess(var, str, txt, file, cmp, y, x);
-    FREE(var);
-    FREE(str);
+    free(var);
+    free(str);
    }
    return(n);
   }
@@ -2968,7 +2968,7 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
    ctmp[i] = a[i+k];
   ctmp[n] = '\0';
   cp = strstr(b, ctmp);
-  FREE(ctmp);
+  free(ctmp);
   if (cp == NULL)
    return(0);
   if (a[0] == '$')
@@ -2979,8 +2979,8 @@ int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
     str[i] = c[i];
    str[i] = '\0';
    i = e_p_konv_mess(var, str, txt, file, cmp, y, x);
-   FREE(var);  
-   FREE(str);
+   free(var);  
+   free(str);
    if (i)
     return(0);
   }
@@ -3168,9 +3168,9 @@ int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret)
  *ii = i;
  *kk = k;
  for (m = 0; m < wnum; m++)
-  FREE(wtxt[m]);
- FREE(wn);
- FREE(wtxt);
+  free(wtxt[m]);
+ free(wn);
+ free(wtxt);
  return(ret);
 }
 

--- a/we_progn.c
+++ b/we_progn.c
@@ -319,7 +319,7 @@ int e_sc_all(FENSTER *f, int sw)
   for (i = 0; i <= f->ed->mxedt; i++)
   if (f->ed->f[i]->c_sw)
   {
-   FREE(f->ed->f[i]->c_sw);
+   free(f->ed->f[i]->c_sw);
    f->ed->f[i]->c_sw = NULL;
   }
  }
@@ -328,12 +328,12 @@ int e_sc_all(FENSTER *f, int sw)
   for (i = 0; i <= f->ed->mxedt; i++)
   {
    if (f->ed->f[i]->c_sw)
-    FREE(f->ed->f[i]->c_sw);
+    free(f->ed->f[i]->c_sw);
    e_add_synt_tl(f->ed->f[i]->datnam, f->ed->f[i]);
    if (f->ed->f[i]->c_st)
    {
     if (f->ed->f[i]->c_sw)
-     FREE(f->ed->f[i]->c_sw);
+     free(f->ed->f[i]->c_sw);
     f->ed->f[i]->c_sw = e_sc_txt(NULL, f->ed->f[i]->b);
    }
   }
@@ -370,10 +370,10 @@ int e_program_opt(FENSTER *f)
  if (ret != WPE_ESC)
  {
   if (e_prog.exedir)
-   FREE(e_prog.exedir);
+   free(e_prog.exedir);
   e_prog.exedir = WpeStrdup(o->wstr[0]->txt);
   if (e_prog.sys_include)
-   FREE(e_prog.sys_include);
+   free(e_prog.sys_include);
   e_prog.sys_include = WpeStrdup(o->wstr[1]->txt);
   f->ed->edopt = (f->ed->edopt & ~ED_PROGRAMMING_OPTIONS) +
     (o->sstr[0]->num ? ED_ERRORS_STOP_AT : 0) +
@@ -656,7 +656,7 @@ E_AFILE *e_aopen(char *name, char *path, int mode)
  }
  if (!ep->b && !ep->fp)
  {
-  FREE(ep);
+  free(ep);
   return NULL;
  }
  return(ep);
@@ -668,7 +668,7 @@ int e_aclose(E_AFILE *ep)
 
  if (ep->fp)
   ret = fclose(ep->fp);
- FREE(ep);
+ free(ep);
  return(ret);
 }
 
@@ -1190,7 +1190,7 @@ int e_show_nm_f(char *name, FENSTER *f, int oldn, char **oldname)
   WpeMouseRestoreShape();
   return(-1);
  }
- if (*oldname) FREE(*oldname);
+ if (*oldname) free(*oldname);
  *oldname = malloc((strlen(file)+1) * sizeof(char));
  strcpy(*oldname, file);
  for (i = strlen(file)-1; i >= 0 && file[i] != '/'; i--)
@@ -1242,12 +1242,12 @@ int e_sh_def(FENSTER *f)
  if (e_add_arguments(str, "Show Definition", f, 0 , AltB, &f->ed->shdf))
  {
   if (sh_df.str)
-   FREE(sh_df.str);
+   free(sh_df.str);
   sh_df.str = malloc((strlen(str)+1)*sizeof(char));
   strcpy(sh_df.str, str);
   if (sh_df.file)
   {
-   FREE(sh_df.file);
+   free(sh_df.file);
    sh_df.file = NULL;
   }
   f->ed->shdf = e_add_df(str, f->ed->shdf);
@@ -1553,7 +1553,7 @@ int e_mbt_str(BUFFER *b, int *ii, int *jj, unsigned char c, int n, int sw,
     e_ins_nchar(b, b->f->s, str, 0, i, m);
    }
    j = -1;
-   FREE(str);
+   free(str);
   }
  }
  *ii = i;
@@ -1585,7 +1585,7 @@ int e_mbt_cnd(BUFFER *b, int *ii, int *jj, int n, int sw, int *cmnd)
      e_ins_nchar(b, b->f->s, str, 0, i, m);
     }
     j = -1;
-    FREE(str);
+    free(str);
     if (*cmnd == 2)
      *cmnd = 1;
    }
@@ -1617,8 +1617,8 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
   ;
  if (i <= 0)
  {
-  FREE(tstr);  FREE(bstr);  FREE(nvek);  FREE(ifvekb);
-  FREE(ifvekr);  FREE(vkcs);  FREE(vkcb);
+  free(tstr);  free(bstr);  free(nvek);  free(ifvekb);
+  free(ifvekr);  free(vkcs);  free(vkcb);
   return(0);
  }
  *ifvekb = 0;
@@ -1788,9 +1788,9 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
     {  n = nvek[brk];  nic--;  brk--;  }
     if (brk < 0)
     {
-     FREE(tstr);  FREE(bstr);  FREE(nvek);
-     FREE(ifvekb);  FREE(ifvekr);
-     FREE(vkcs);  FREE(vkcb);
+     free(tstr);  free(bstr);  free(nvek);
+     free(ifvekb);  free(ifvekr);
+     free(vkcs);  free(vkcb);
      b->b = sb;  s->mark_begin = sa;  s->mark_end = se;
      e_schirm(f, 1);
      WpeMouseRestoreShape();
@@ -1871,9 +1871,9 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
    else if (cmnd == 3 && f->b->bf[i].s[j] == ':') cmnd = 1;
   }
  }
- FREE(nvek);  FREE(tstr);  FREE(bstr);
- FREE(ifvekb);  FREE(ifvekr);
- FREE(vkcs);  FREE(vkcb);
+ free(nvek);  free(tstr);  free(bstr);
+ free(ifvekb);  free(ifvekr);
+ free(vkcs);  free(vkcb);
  s->mark_begin = sa;  s->mark_end = se;
  b->b = sb;
  e_schirm(f, 1);

--- a/we_progn.c
+++ b/we_progn.c
@@ -437,7 +437,7 @@ int *e_sc_txt(int *c_sw, BUFFER *b)
  int i;
 
  if (!c_sw)
-  c_sw = MALLOC(b->mx.y * sizeof(int));
+  c_sw = malloc(b->mx.y * sizeof(int));
  c_sw[0] = 0;
  if (b->f->c_st->continue_column < 0)
  {
@@ -609,7 +609,7 @@ int e_add_synt_tl(char *filename, FENSTER *f)
    {
     f->c_st = WpeSyntaxDef[i]->syntax_rule;
     if (f->ed->edopt & ED_SYNTAX_HIGHLIGHT)
-     f->c_sw = MALLOC(f->b->mx.y*sizeof(int));
+     f->c_sw = malloc(f->b->mx.y*sizeof(int));
    }
   }
  }
@@ -620,7 +620,7 @@ int e_add_synt_tl(char *filename, FENSTER *f)
 E_AFILE *e_aopen(char *name, char *path, int mode)
 {
  ECNT *cn = WpeEditor;
- E_AFILE *ep = MALLOC(sizeof(E_AFILE));
+ E_AFILE *ep = malloc(sizeof(E_AFILE));
  char str[256];
  int i, j;
 
@@ -888,13 +888,13 @@ struct dirfile *e_c_add_df(char *str, struct dirfile *df)
 {
  if (df == NULL)
  {
-  df = MALLOC(sizeof(struct dirfile));
+  df = malloc(sizeof(struct dirfile));
   df->anz = 0;
-  df->name = MALLOC(sizeof(char*));
+  df->name = malloc(sizeof(char*));
  }
  df->anz++;
- df->name = REALLOC(df->name, df->anz * sizeof(char*));
- df->name[df->anz-1] = MALLOC((strlen(str)+1) * sizeof(char));
+ df->name = realloc(df->name, df->anz * sizeof(char*));
+ df->name[df->anz-1] = malloc((strlen(str)+1) * sizeof(char));
  strcpy(df->name[df->anz-1], str);
  return(df);
 }
@@ -1191,7 +1191,7 @@ int e_show_nm_f(char *name, FENSTER *f, int oldn, char **oldname)
   return(-1);
  }
  if (*oldname) FREE(*oldname);
- *oldname = MALLOC((strlen(file)+1) * sizeof(char));
+ *oldname = malloc((strlen(file)+1) * sizeof(char));
  strcpy(*oldname, file);
  for (i = strlen(file)-1; i >= 0 && file[i] != '/'; i--)
   ;
@@ -1243,7 +1243,7 @@ int e_sh_def(FENSTER *f)
  {
   if (sh_df.str)
    FREE(sh_df.str);
-  sh_df.str = MALLOC((strlen(str)+1)*sizeof(char));
+  sh_df.str = malloc((strlen(str)+1)*sizeof(char));
   strcpy(sh_df.str, str);
   if (sh_df.file)
   {
@@ -1515,7 +1515,7 @@ char *e_mbt_mk_sp(char *str, int n, int sw, int *m)
 
  if (!sw) *m = n;
  else *m = n / sw + n % sw;
- str = REALLOC(str, (*m+1)*sizeof(char));
+ str = realloc(str, (*m+1)*sizeof(char));
  if (!sw) k = 0;
  else for (k = 0; k < n / sw; k++) str[k] = '\t';
  for (; k < *m; k++) str[k] = ' ';
@@ -1538,7 +1538,7 @@ int e_mbt_str(BUFFER *b, int *ii, int *jj, unsigned char c, int n, int sw,
    bsp = 0;
   if (j == b->bf[i].len - 1 && bsp && i < b->mxlines-1)
   {
-   char *str = MALLOC(1);
+   char *str = malloc(1);
    int m;
 
    i++;
@@ -1571,7 +1571,7 @@ int e_mbt_cnd(BUFFER *b, int *ii, int *jj, int n, int sw, int *cmnd)
   {
    if (i < b->mxlines-1)
    {
-    char *str = MALLOC(1);
+    char *str = malloc(1);
     int m;
 
     i++;
@@ -1604,13 +1604,13 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
  SCHIRM *s;
  int bg, nd, m, n, i, j, k, brk, cbrk = 0, nif = 0, nic = 0;
  int nstrct = 0, cmnd, cm_sv;
- char *tstr = MALLOC(sizeof(char));
- char *bstr = MALLOC((ndif+1)*sizeof(char));
- int *nvek = MALLOC(sizeof(int));
- int *ifvekb = MALLOC(sizeof(int));
- int *ifvekr = MALLOC(sizeof(int));
- int *vkcs = MALLOC(sizeof(int));
- int *vkcb = MALLOC(sizeof(int));
+ char *tstr = malloc(sizeof(char));
+ char *bstr = malloc((ndif+1)*sizeof(char));
+ int *nvek = malloc(sizeof(int));
+ int *ifvekb = malloc(sizeof(int));
+ int *ifvekr = malloc(sizeof(int));
+ int *vkcs = malloc(sizeof(int));
+ int *vkcb = malloc(sizeof(int));
  POINT sa, se, sb;
 
  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
@@ -1704,8 +1704,8 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
    else if (b->bf[i].s[j] == '#' && ispif(b->bf[i].s))
    {
     nif++;
-    ifvekb = REALLOC(ifvekb, (nif+1)*sizeof(int));
-    ifvekr = REALLOC(ifvekr, (nif+1)*sizeof(int));
+    ifvekb = realloc(ifvekb, (nif+1)*sizeof(int));
+    ifvekr = realloc(ifvekr, (nif+1)*sizeof(int));
     ifvekb[nif] = brk;
     ifvekr[nif] = cbrk;
     cmnd = 2;
@@ -1760,8 +1760,8 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
      }
      nstrct++;
      nic++;
-     vkcb = REALLOC(vkcb, (nic+1)*sizeof(int));
-     vkcs = REALLOC(vkcs, (nic+1)*sizeof(int));
+     vkcb = realloc(vkcb, (nic+1)*sizeof(int));
+     vkcs = realloc(vkcs, (nic+1)*sizeof(int));
      vkcs[nic] = 0;
      vkcb[nic] = brk-1;
     }
@@ -1776,7 +1776,7 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
     }
     n += ndif;
     tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-    nvek = REALLOC(nvek, (brk+1)*sizeof(int));
+    nvek = realloc(nvek, (brk+1)*sizeof(int));
     nvek[brk] = n;
    }
    else if (f->b->bf[i].s[j] == '}')
@@ -1848,7 +1848,7 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
      j--;
     n += ndif;
     tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-    nvek = REALLOC(nvek, (brk+1)*sizeof(int));
+    nvek = realloc(nvek, (brk+1)*sizeof(int));
     nvek[brk] = n;
     cmnd = 3;
     nstrct = 0;
@@ -1857,8 +1857,8 @@ int e_mk_beauty(int sw, int ndif, FENSTER *f)
      (!strncmp(b->bf[i].s+j, "switch", 6) && !isalnum1(b->bf[i].s[j+6])))
    {
     nic++;
-    vkcb = REALLOC(vkcb, (nic+1)*sizeof(int));
-    vkcs = REALLOC(vkcs, (nic+1)*sizeof(int));
+    vkcb = realloc(vkcb, (nic+1)*sizeof(int));
+    vkcs = realloc(vkcs, (nic+1)*sizeof(int));
     vkcs[nic] = 0;
     vkcb[nic] = brk;
    }

--- a/we_term.c
+++ b/we_term.c
@@ -197,7 +197,7 @@ char *init_key(char *key)
   return(NULL);
  else
  {
-  keystr = MALLOC(strlen(tmp)+1);
+  keystr = malloc(strlen(tmp)+1);
   strcpy(keystr, tmp);
  }
  return(keystr);
@@ -214,7 +214,7 @@ char *init_kkey(char *key)
   return(NULL);
  if (!key_key)
  {
-  key_key = MALLOC(2);
+  key_key = malloc(2);
   key_key[0] = tmp[1];
   key_key[1] = '\0';
   return(tmp);
@@ -224,7 +224,7 @@ char *init_kkey(char *key)
   for (i = 0; key_key[i] != '\0'; i++)
    if (key_key[i] == tmp[1])
     return(tmp);
-  key_key = REALLOC(key_key, i + 2);
+  key_key = realloc(key_key, i + 2);
   key_key[i] = tmp[1];
   key_key[i + 1] = '\0';
  }
@@ -243,7 +243,7 @@ char *init_spchr(char c)
   ;
  if (spc_st[i] && spc_st[i+1])
  {
-  pt = MALLOC((strlen(spc_bg)+strlen(spc_nd)+2)*sizeof(char));
+  pt = malloc((strlen(spc_bg)+strlen(spc_nd)+2)*sizeof(char));
   if(pt)
    sprintf(pt, "%s%c%s", spc_bg, spc_st[i+1], spc_nd);
  }
@@ -490,10 +490,10 @@ int e_t_initscr()
  }
 #endif
  e_begscr();
- schirm = MALLOC(2 * MAXSCOL * MAXSLNS);
- altschirm = MALLOC(2 * MAXSCOL * MAXSLNS);
+ schirm = malloc(2 * MAXSCOL * MAXSLNS);
+ altschirm = malloc(2 * MAXSCOL * MAXSLNS);
 #if !defined(NO_XWINDOWS) && defined(NEWSTYLE)
- extbyte = MALLOC(MAXSCOL * MAXSLNS);
+ extbyte = malloc(MAXSCOL * MAXSLNS);
 #endif
  e_abs_refr();
  if(init_cursor())

--- a/we_unix.c
+++ b/we_unix.c
@@ -422,7 +422,7 @@ int e_compstr(char *a, char *b)
    strcpy(cp, a);
    cp[0] = '*';
    n = e_compstr(cp, ++b);
-   FREE(cp);
+   free(cp);
    return(n);
   }
   else if (a[0] == '[')
@@ -436,7 +436,7 @@ int e_compstr(char *a, char *b)
    ctmp[k] = a[k];
   ctmp[n] = '\0';
   cp = strstr(b, ctmp);
-  FREE(ctmp);
+  free(ctmp);
   if (cp == NULL)
    return((a[0] - b[0]) ? a[0] - b[0] : -1);
   if (!a[n] && !cp[n])
@@ -512,7 +512,7 @@ struct dirfile *e_find_files(char *sufile, int sw)
  }
  if (!(dirp = opendir(sdir)))
  {
-  FREE(sdir);
+  free(sdir);
   return(df);
  }
  sizeStmp = 256;
@@ -603,7 +603,7 @@ struct dirfile *e_find_dir(char *sufile, int sw)
  }
  if (!(dirp = opendir(sdir)))
  {
-  FREE(sdir);
+  free(sdir);
   return(df);
  }
  sizeStmp = 256;
@@ -635,7 +635,7 @@ struct dirfile *e_find_dir(char *sufile, int sw)
     {
      df->anz = 0;
      closedir(dirp);
-     FREE(sdir);
+     free(sdir);
      free(stmp);
      return(df);
     }
@@ -648,7 +648,7 @@ struct dirfile *e_find_dir(char *sufile, int sw)
   }
  }
  closedir(dirp);
- FREE(sdir);
+ free(sdir);
  free(stmp);
  return(df);
 }

--- a/we_unix.c
+++ b/we_unix.c
@@ -554,8 +554,8 @@ struct dirfile *e_find_files(char *sufile, int sw)
     {
      df->anz = 0;
      closedir(dirp);
-     WpeFree(stmp);
-     WpeFree(sdir);
+     free(stmp);
+     free(sdir);
      return(df);
     }
     strcpy(tmpst, dp->d_name);
@@ -567,8 +567,8 @@ struct dirfile *e_find_files(char *sufile, int sw)
   }
  }
  closedir(dirp);
- WpeFree(stmp);
- WpeFree(sdir);
+ free(stmp);
+ free(sdir);
  return(df);
 }
 
@@ -636,7 +636,7 @@ struct dirfile *e_find_dir(char *sufile, int sw)
      df->anz = 0;
      closedir(dirp);
      FREE(sdir);
-     WpeFree(stmp);
+     free(stmp);
      return(df);
     }
     strcpy(tmpst, dp->d_name);
@@ -649,7 +649,7 @@ struct dirfile *e_find_dir(char *sufile, int sw)
  }
  closedir(dirp);
  FREE(sdir);
- WpeFree(stmp);
+ free(stmp);
  return(df);
 }
 

--- a/we_unix.c
+++ b/we_unix.c
@@ -498,14 +498,14 @@ struct dirfile *e_find_files(char *sufile, int sw)
  if (n <= 0)
  {
   sizeSdir = 2;
-  sdir = (char *)WpeMalloc(2 * sizeof(char));
+  sdir = (char *)malloc(2 * sizeof(char));
   sdir[0] = n ? '.' : DIRC;
   sdir[1] = '\0';
  }
  else
  {
   sizeSdir = n + 1;
-  sdir = (char *)WpeMalloc((n + 1) * sizeof(char));
+  sdir = (char *)malloc((n + 1) * sizeof(char));
   for (i = 0; i < n; i++)
    sdir[i] = sufile[i];
   sdir[n] = '\0';
@@ -516,7 +516,7 @@ struct dirfile *e_find_files(char *sufile, int sw)
   return(df);
  }
  sizeStmp = 256;
- stmp = (char *)WpeMalloc(sizeStmp);
+ stmp = (char *)malloc(sizeStmp);
  while((dp = readdir(dirp)) != NULL)
  {
   if (!(sw & 1) && dp->d_name[0] == '.' && sfile[0] != '.')
@@ -607,7 +607,7 @@ struct dirfile *e_find_dir(char *sufile, int sw)
   return(df);
  }
  sizeStmp = 256;
- stmp = (char *)WpeMalloc(sizeStmp);
+ stmp = (char *)malloc(sizeStmp);
  while ((dp = readdir(dirp)) != NULL)
  {
   if (!sw && dp->d_name[0] == '.' && sfile[0] != '.')

--- a/we_unix.c
+++ b/we_unix.c
@@ -527,7 +527,7 @@ struct dirfile *e_find_files(char *sufile, int sw)
    {
     while (sizeSdir + strlen(dp->d_name) + 10 > sizeStmp)
      sizeStmp <<= 1;
-    stmp = (char *)WpeRealloc(stmp, sizeStmp);
+    stmp = (char *)realloc(stmp, sizeStmp);
    }
 
    e_mkfilepath(sdir, dp->d_name, stmp);
@@ -619,7 +619,7 @@ struct dirfile *e_find_dir(char *sufile, int sw)
    {
     while (sizeSdir + strlen(dp->d_name) + 10 > sizeStmp)
      sizeStmp <<= 1;
-    stmp = (char *)WpeRealloc(stmp, sizeStmp);
+    stmp = (char *)realloc(stmp, sizeStmp);
    }
    stat(e_mkfilepath(sdir, dp->d_name, stmp), &buf);
 

--- a/we_unix.c
+++ b/we_unix.c
@@ -418,7 +418,7 @@ int e_compstr(char *a, char *b)
   a++;
   if (a[0] == '?')
   {
-   cp = MALLOC((strlen(a)+1)*sizeof(char));
+   cp = malloc((strlen(a)+1)*sizeof(char));
    strcpy(cp, a);
    cp[0] = '*';
    n = e_compstr(cp, ++b);
@@ -431,7 +431,7 @@ int e_compstr(char *a, char *b)
     b++;
    return(n);
   }
-  ctmp = MALLOC(n+1);
+  ctmp = malloc(n+1);
   for (k = 0; k < n; k++)
    ctmp[k] = a[k];
   ctmp[n] = '\0';
@@ -484,7 +484,7 @@ int e_compstr(char *a, char *b)
 struct dirfile *e_find_files(char *sufile, int sw)
 {
  char           *stmp, *tmpst, *sfile, *sdir;
- struct dirfile *df = MALLOC(sizeof(struct dirfile));
+ struct dirfile *df = malloc(sizeof(struct dirfile));
  DIR            *dirp;
  struct dirent  *dp;
  struct stat     buf;
@@ -547,10 +547,10 @@ struct dirfile *e_find_files(char *sufile, int sw)
      (!(sw & 2) || (buf.st_mode & 0111)) )
    {
     if (df->anz == 0)
-     df->name = MALLOC((df->anz + 1) * sizeof(char *));
+     df->name = malloc((df->anz + 1) * sizeof(char *));
     else
-     df->name = REALLOC(df->name, (df->anz + 1) * sizeof(char *));
-    if (df->name == NULL || !(tmpst = MALLOC(strlen(dp->d_name) + 1)))
+     df->name = realloc(df->name, (df->anz + 1) * sizeof(char *));
+    if (df->name == NULL || !(tmpst = malloc(strlen(dp->d_name) + 1)))
     {
      df->anz = 0;
      closedir(dirp);
@@ -575,7 +575,7 @@ struct dirfile *e_find_files(char *sufile, int sw)
 struct dirfile *e_find_dir(char *sufile, int sw)
 {
  char           *stmp, *tmpst, *sfile, *sdir;
- struct dirfile *df = MALLOC(sizeof(struct dirfile));
+ struct dirfile *df = malloc(sizeof(struct dirfile));
  DIR            *dirp;
  struct dirent  *dp;
  struct stat     buf;
@@ -589,14 +589,14 @@ struct dirfile *e_find_dir(char *sufile, int sw)
  if (n <= 0)
  {
   sizeSdir = 2;
-  sdir = MALLOC(2 * sizeof(char));
+  sdir = malloc(2 * sizeof(char));
   sdir[0] = n ? '.' : DIRC;
   sdir[1] = '\0';
  }
  else
  {
   sizeSdir = n + 1;
-  sdir = MALLOC((n + 1) * sizeof(char));
+  sdir = malloc((n + 1) * sizeof(char));
   for (i = 0; i < n; i++)
    sdir[i] = sufile[i];
   sdir[n] = '\0';
@@ -628,10 +628,10 @@ struct dirfile *e_find_dir(char *sufile, int sw)
    {
 
     if (df->anz == 0)
-     df->name = MALLOC((df->anz + 1) * sizeof(char *));
+     df->name = malloc((df->anz + 1) * sizeof(char *));
     else
-     df->name = REALLOC(df->name, (df->anz + 1) * sizeof(char *));
-    if (df->name == NULL || !(tmpst = MALLOC(strlen(dp->d_name) + 1)))
+     df->name = realloc(df->name, (df->anz + 1) * sizeof(char *));
+    if (df->name == NULL || !(tmpst = malloc(strlen(dp->d_name) + 1)))
     {
      df->anz = 0;
      closedir(dirp);

--- a/we_wind.c
+++ b/we_wind.c
@@ -136,9 +136,9 @@ int e_message(int sw, char *str, FENSTER *f)
  for (i = 0; i < anz; i++)
  {
   e_add_txtstr((o->xe-o->xa-strlen(s[i]))/2, 2+i, s[i], o);
-  FREE(s[i]);
+  free(s[i]);
  }
- FREE(s);
+ free(s);
  if (!sw)
  {
   o->crsw = AltO;
@@ -215,7 +215,7 @@ PIC *e_open_view(int xa, int ya, int xe, int ye, int col, int sw)
 #else
   pic->p = malloc((pic->e.x - pic->a.x + 1) * 2 * (pic->e.y - pic->a.y + 1));
 #endif
-  if (pic->p == NULL) {  FREE(pic);  return(NULL);  }
+  if (pic->p == NULL) {  free(pic);  return(NULL);  }
   for (j = pic->a.y; j <= pic->e.y; ++j)
    for (i = 2*pic->a.x; i <= 2*pic->e.x+1; ++i)
     *( pic->p + (j-pic->a.y)*2*(pic->e.x-pic->a.x+1) + (i-2*pic->a.x) ) = e_gt_byte(i, j);
@@ -274,8 +274,8 @@ int e_close_view(PIC *pic, int sw)
  }
  if (sw < 2)
  {
-  if (pic->p != NULL) FREE(pic->p);
-  FREE(pic);
+  if (pic->p != NULL) free(pic->p);
+  free(pic);
  }
  e_refresh();
  return(sw);
@@ -559,7 +559,7 @@ PIC *e_change_pic(int xa, int ya, int xe, int ye, PIC *pic, int sw, int frb)
       newpic->p = malloc( (newpic->e.x - newpic->a.x + 1) * 2
 				* (newpic->e.y - newpic->a.y + 1) );
 #endif
-      if (newpic->p == NULL) {  FREE(newpic);  return(NULL);  }
+      if (newpic->p == NULL) {  free(newpic);  return(NULL);  }
       ax = pic->a.x > newpic->a.x ? pic->a.x : newpic->a.x;
       ay = pic->a.y > newpic->a.y ? pic->a.y : newpic->a.y;
       ex = pic->e.x < newpic->e.x ? pic->e.x : newpic->e.x;
@@ -625,8 +625,8 @@ PIC *e_change_pic(int xa, int ya, int xe, int ye, PIC *pic, int sw, int frb)
       						e_pt_col(i, ye+1, SHDCOL);
       }
 #endif
-      FREE(pic->p);
-      FREE(pic);
+      free(pic->p);
+      free(pic);
    }
 #ifndef NO_XWINDOWS
    if (WpeIsXwin()) (*e_u_setlastpic)(newpic);
@@ -655,12 +655,12 @@ int e_close_buffer(BUFFER *b)
    for (i = 0; i < b->mxlines; i++)
    {
     if (b->bf[i].s != NULL)
-     FREE( b->bf[i].s );
+     free( b->bf[i].s );
     b->bf[i].s = NULL;
    }
-   FREE(b->bf);
+   free(b->bf);
   }
-  FREE(b);
+  free(b);
  }
  return(0);
 }
@@ -679,20 +679,20 @@ int e_close_window(FENSTER *f)
  {
   FLBFFR *b = (FLBFFR *)f->b;
 
-  FREE(f->dirct);
-  FREE(b->rdfile);
+  free(f->dirct);
+  free(b->rdfile);
   freedf(b->df);  freedf(b->fw->df);
   freedf(b->dd);  freedf(b->cd);  freedf(b->dw->df);
-  FREE(b->fw);
-  FREE(b->dw);
-  FREE(b);
+  free(b->fw);
+  free(b->dw);
+  free(b);
   (cn->mxedt)--;
   cn->curedt = cn->edt[cn->mxedt];
   e_close_view(f->pic, 1);
   if (f != f0 && f != NULL)
   {
    e_free_find(&f->fd);
-   FREE(f);
+   free(f);
   }
   if (cn->mxedt > 0)
   {
@@ -711,17 +711,17 @@ int e_close_window(FENSTER *f)
    e_p_update_prj_fl(f);
 #endif
   if (f->dirct)
-   FREE(f->dirct);
+   free(f->dirct);
   if (swt == 7)
    freedf(fw->df);
-  FREE(fw);
+  free(fw);
   (cn->mxedt)--;
   cn->curedt = cn->edt[cn->mxedt];
   e_close_view(f->pic, 1);
   if (f != f0 && f != NULL)
   {
    e_free_find(&f->fd);
-   FREE(f);
+   free(f);
   }
   if (cn->mxedt > 0 && (swt < 5 || swt == 7))
   {
@@ -756,11 +756,11 @@ int e_close_window(FENSTER *f)
   if (f->dtmd == DTMD_HELP && f->ins == 8)
    e_help_free(f);
   if (f->datnam != NULL)
-   FREE(f->datnam);
+   free(f->datnam);
   if (f->dirct != NULL)
-   FREE(f->dirct);
+   free(f->dirct);
   if (f && f->s != NULL)
-   FREE(f->s);
+   free(f->s);
  }
  (cn->mxedt)--;
  cn->curedt = cn->edt[cn->mxedt];
@@ -768,7 +768,7 @@ int e_close_window(FENSTER *f)
  if (f != f0 && f != NULL)
  {
   e_free_find(&f->fd);
-  FREE(f);
+  free(f);
  }
  if (cn->mxedt > 0)
  {
@@ -808,8 +808,8 @@ void e_switch_window(int num, FENSTER *f)
  if (n >= cn->mxedt) return;
  for (i = cn->mxedt; i >= 1; i--)
  {
-  FREE(cn->f[i]->pic->p);
-  FREE(cn->f[i]->pic);
+  free(cn->f[i]->pic->p);
+  free(cn->f[i]->pic);
  }
  ft = cn->f[n];
  te = cn->edt[n];
@@ -861,8 +861,8 @@ int e_ed_cascade(FENSTER *f)
   return 0; /* no windows open */
  for (i = cn->mxedt; i >= 1; i--)
  {
-  FREE(cn->f[i]->pic->p);
-  FREE(cn->f[i]->pic);
+  free(cn->f[i]->pic->p);
+  free(cn->f[i]->pic);
   cn->f[i]->a = e_set_pnt(i-1, i);
   cn->f[i]->e = e_set_pnt(MAXSCOL-1-cn->mxedt+i, MAXSLNS-2-cn->mxedt+i);
  }
@@ -912,8 +912,8 @@ int e_ed_tile(FENSTER *f)
  }
  for (i = cn->mxedt; i >= 1; i--)
  {
-  FREE(cn->f[i]->pic->p);
-  FREE(cn->f[i]->pic);
+  free(cn->f[i]->pic->p);
+  free(cn->f[i]->pic);
  }
  for (ni = editwin, nj = 1; ni > 1; ni--)
  {
@@ -1285,7 +1285,7 @@ struct dirfile *e_add_df(char *str, struct dirfile *df)
    }
    for(n = 0; n < df->anz && *df->name[n] && strcmp(df->name[n], str); n++);
    if(n == df->anz)
-   {  if(df->anz == MAXSVSTR - 1) FREE(df->name[df->anz-1]);
+   {  if(df->anz == MAXSVSTR - 1) free(df->name[df->anz-1]);
       else
       {  df->anz++;
 	 df->name = realloc(df->name, df->anz * sizeof(char*));
@@ -1298,7 +1298,7 @@ struct dirfile *e_add_df(char *str, struct dirfile *df)
    {  tmp = df->name[n];
       for(i = n; i > 0; i--) df->name[i] = df->name[i-1];
       if(!tmp[0])
-      {  FREE(tmp);
+      {  free(tmp);
 	 df->name[0] = malloc((strlen(str) + 1) * sizeof(char));
 	 strcpy(df->name[0], str);
       }
@@ -1348,8 +1348,8 @@ int e_sv_window(int xa, int ya, int *n, struct dirfile *df, FENSTER *f)
  } while(ret != WPE_CR && ret != WPE_ESC);
  *n = fw->nf;
  e_close_view(f->pic, 1);
- FREE(fw);
- FREE(f);
+ free(fw);
+ free(f);
  return(ret);
 }
 
@@ -1457,8 +1457,8 @@ int e_mess_win(char *header, char *str, PIC **pic, FENSTER *f)
   for (i = xa + 1; i < xe; i++)
    e_pr_char(i, j, ' ', cn->fb->nt.fb);
  for (i = 0; i < anz; i++)
-  FREE(s[i]);
- FREE(s);
+  free(s[i]);
+ free(s);
 #ifndef NO_XWINDOWS
  if (WpeIsXwin())
  {
@@ -1528,7 +1528,7 @@ struct dirfile *e_make_win_list(FENSTER *f)
  df->anz = f->ed->mxedt;
  if (!(df->name = malloc(df->anz * sizeof(char *))))
  {
-  FREE(df);
+  free(df);
   return(NULL);
  }
  for (i = 0; i < df->anz; i++)

--- a/we_wind.c
+++ b/we_wind.c
@@ -336,12 +336,12 @@ void e_ed_rahmen(FENSTER *f, int sw)
     f->dtmd == DTMD_HELP || strcmp(f->datnam, BUFFER_NAME) == 0 ||
     NUM_COLS_ON_SCREEN < 40)
   {
-   header = (char *)WpeMalloc(strlen(f->datnam) + 1);
+   header = (char *)malloc(strlen(f->datnam) + 1);
    strcpy(header, f->datnam);
   }
   else
   {
-   header = (char *)WpeMalloc(strlen(f->dirct) + strlen(f->datnam) + 1);
+   header = (char *)malloc(strlen(f->dirct) + strlen(f->datnam) + 1);
    strcpy(header, f->dirct);
    strcat(header, f->datnam);
   }

--- a/we_wind.c
+++ b/we_wind.c
@@ -349,7 +349,7 @@ void e_ed_rahmen(FENSTER *f, int sw)
  e_std_rahmen(f->a.x, f->a.y, f->e.x, f->e.y, header, sw, f->fb->er.fb,
    f->fb->es.fb);
  if (header)
-  WpeFree(header);
+  free(header);
  if (sw > 0)
  {
   e_mouse_bar(f->e.x, f->a.y+1, NUM_LINES_ON_SCREEN - 1, 0, f->fb->em.fb);

--- a/we_wind.c
+++ b/we_wind.c
@@ -18,7 +18,7 @@ int e_make_xr_rahmen(int xa, int ya, int xe, int ye, int sw);
 char **StringToStringArray(char *str, int *maxLen, int minWidth, int *anzahl)
 {
  int i, j, k, anz = 0, mxlen = 0, max = 0.8 * MAXSCOL;
- char **s = MALLOC(sizeof(char*));
+ char **s = malloc(sizeof(char*));
 
  for (k = 0, i = 0; str[i]; i++)
  {
@@ -31,8 +31,8 @@ char **StringToStringArray(char *str, int *maxLen, int minWidth, int *anzahl)
    if(j > k)
     i = j;
    anz++;
-   s = REALLOC(s, anz * sizeof(char *));
-   s[anz-1] = MALLOC((i - k + 2) * sizeof(char));
+   s = realloc(s, anz * sizeof(char *));
+   s[anz-1] = malloc((i - k + 2) * sizeof(char));
    for (j = k; j <= i; j++)
     s[anz-1][j-k] = str[j];
    if (isspace(str[j-1]))
@@ -44,8 +44,8 @@ char **StringToStringArray(char *str, int *maxLen, int minWidth, int *anzahl)
   }
  }
  anz++;
- s = REALLOC(s, anz * sizeof(char *));
- s[anz-1] = MALLOC((i - k + 2) * sizeof(char));
+ s = realloc(s, anz * sizeof(char *));
+ s[anz-1] = malloc((i - k + 2) * sizeof(char));
  for (j = k; j <= i; j++)
   s[anz-1][j-k] = str[j];
  if (mxlen < (j-k))
@@ -187,7 +187,7 @@ int e_pr_filetype(FENSTER *f)
 /*   open section of screen and save background  */
 PIC *e_open_view(int xa, int ya, int xe, int ye, int col, int sw)
 {
- PIC *pic = MALLOC(sizeof(PIC));
+ PIC *pic = malloc(sizeof(PIC));
  int i, j;
 
  if (pic == NULL) return(NULL);
@@ -211,9 +211,9 @@ PIC *e_open_view(int xa, int ya, int xe, int ye, int col, int sw)
  if (sw!=0)
  {
 #if defined(NEWSTYLE) && !defined(NO_XWINDOWS)
-  pic->p = MALLOC((pic->e.x - pic->a.x + 1) * 3 * (pic->e.y - pic->a.y + 1));
+  pic->p = malloc((pic->e.x - pic->a.x + 1) * 3 * (pic->e.y - pic->a.y + 1));
 #else
-  pic->p = MALLOC((pic->e.x - pic->a.x + 1) * 2 * (pic->e.y - pic->a.y + 1));
+  pic->p = malloc((pic->e.x - pic->a.x + 1) * 2 * (pic->e.y - pic->a.y + 1));
 #endif
   if (pic->p == NULL) {  FREE(pic);  return(NULL);  }
   for (j = pic->a.y; j <= pic->e.y; ++j)
@@ -535,7 +535,7 @@ PIC *e_change_pic(int xa, int ya, int xe, int ye, PIC *pic, int sw, int frb)
    }
    else
    {
-      newpic = MALLOC(sizeof(PIC));
+      newpic = malloc(sizeof(PIC));
       if(newpic == NULL)  return(NULL);
       newpic->a.x = xa;
       newpic->a.y = ya;
@@ -553,10 +553,10 @@ PIC *e_change_pic(int xa, int ya, int xe, int ye, PIC *pic, int sw, int frb)
       newpic->e.y = ye;
 #endif
 #if !defined(NO_XWINDOWS) && defined(NEWSTYLE)
-      newpic->p = MALLOC( (newpic->e.x - newpic->a.x + 1) * 3
+      newpic->p = malloc( (newpic->e.x - newpic->a.x + 1) * 3
 				* (newpic->e.y - newpic->a.y + 1) );
 #else
-      newpic->p = MALLOC( (newpic->e.x - newpic->a.x + 1) * 2
+      newpic->p = malloc( (newpic->e.x - newpic->a.x + 1) * 2
 				* (newpic->e.y - newpic->a.y + 1) );
 #endif
       if (newpic->p == NULL) {  FREE(newpic);  return(NULL);  }
@@ -1279,19 +1279,19 @@ struct dirfile *e_add_df(char *str, struct dirfile *df)
    char *tmp;
 
    if (df == NULL)
-   {  df = MALLOC(sizeof(struct dirfile));
+   {  df = malloc(sizeof(struct dirfile));
       df->anz = 0;
-      df->name = MALLOC(sizeof(char*));
+      df->name = malloc(sizeof(char*));
    }
    for(n = 0; n < df->anz && *df->name[n] && strcmp(df->name[n], str); n++);
    if(n == df->anz)
    {  if(df->anz == MAXSVSTR - 1) FREE(df->name[df->anz-1]);
       else
       {  df->anz++;
-	 df->name = REALLOC(df->name, df->anz * sizeof(char*));
+	 df->name = realloc(df->name, df->anz * sizeof(char*));
       }
       for(i = df->anz-1; i > 0; i--) df->name[i] = df->name[i-1];
-      df->name[0] = MALLOC((strlen(str)+1) * sizeof(char));
+      df->name[0] = malloc((strlen(str)+1) * sizeof(char));
       strcpy(df->name[0], str);
    }
    else
@@ -1299,7 +1299,7 @@ struct dirfile *e_add_df(char *str, struct dirfile *df)
       for(i = n; i > 0; i--) df->name[i] = df->name[i-1];
       if(!tmp[0])
       {  FREE(tmp);
-	 df->name[0] = MALLOC((strlen(str) + 1) * sizeof(char));
+	 df->name[0] = malloc((strlen(str) + 1) * sizeof(char));
 	 strcpy(df->name[0], str);
       }
       else df->name[0] = tmp;
@@ -1312,9 +1312,9 @@ int e_sv_window(int xa, int ya, int *n, struct dirfile *df, FENSTER *f)
  ECNT *cn = f->ed;
  int ret, ye = ya + 6;
  int xe = xa +21;
- FLWND *fw = MALLOC(sizeof(FLWND));
+ FLWND *fw = malloc(sizeof(FLWND));
 
- if ((f = (FENSTER *) MALLOC(sizeof(FENSTER))) == NULL)
+ if ((f = (FENSTER *) malloc(sizeof(FENSTER))) == NULL)
   e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
  if (xe > MAXSCOL-3) {  xe = MAXSCOL - 3;  xa = xe - 21;  }
  if (ye > MAXSLNS-3) {  ye = MAXSLNS - 3;  ya = ye - 6;  }
@@ -1524,9 +1524,9 @@ struct dirfile *e_make_win_list(FENSTER *f)
  int i;
  struct dirfile *df;
 
- if (!(df = MALLOC(sizeof(struct dirfile)))) return(NULL);
+ if (!(df = malloc(sizeof(struct dirfile)))) return(NULL);
  df->anz = f->ed->mxedt;
- if (!(df->name = MALLOC(df->anz * sizeof(char *))))
+ if (!(df->name = malloc(df->anz * sizeof(char *))))
  {
   FREE(df);
   return(NULL);
@@ -1536,7 +1536,7 @@ struct dirfile *e_make_win_list(FENSTER *f)
   if (f->ed->f[df->anz-i]->datnam)
   {
    if (!(df->name[i] =
-     MALLOC((strlen(f->ed->f[df->anz-i]->datnam)+1) * sizeof(char))))
+     malloc((strlen(f->ed->f[df->anz-i]->datnam)+1) * sizeof(char))))
    {
     df->anz = i;
     freedf(df);
@@ -1546,7 +1546,7 @@ struct dirfile *e_make_win_list(FENSTER *f)
   }
   else
   {
-   if (!(df->name[i] = MALLOC(sizeof(char))))
+   if (!(df->name[i] = malloc(sizeof(char))))
    {
     df->anz = i;
     freedf(df);

--- a/we_xterm.c
+++ b/we_xterm.c
@@ -1053,7 +1053,7 @@ int e_x_paste_X_buffer(FENSTER *f)
    return(0);
   n = s0->mark_end.x - s0->mark_begin.x;
 #if SELECTION
-  WpeXInfo.selection = WpeMalloc(n + 1);
+  WpeXInfo.selection = malloc(n + 1);
   strncpy(WpeXInfo.selection, b0->bf[s0->mark_begin.y].s+s0->mark_begin.x,
     n);
   WpeXInfo.selection[n] = 0;
@@ -1065,7 +1065,7 @@ int e_x_paste_X_buffer(FENSTER *f)
 #endif
   return(0);
  }
- WpeXInfo.selection = WpeMalloc(b0->bf[s0->mark_begin.y].nrc * sizeof(char));
+ WpeXInfo.selection = malloc(b0->bf[s0->mark_begin.y].nrc * sizeof(char));
  for (n = 0, j = s0->mark_begin.x; j < b0->bf[s0->mark_begin.y].nrc; j++, n++)
   WpeXInfo.selection[n] = b0->bf[s0->mark_begin.y].s[j];
  for (i = s0->mark_begin.y+1; i < s0->mark_end.y; i++)

--- a/we_xterm.c
+++ b/we_xterm.c
@@ -1070,11 +1070,11 @@ int e_x_paste_X_buffer(FENSTER *f)
   WpeXInfo.selection[n] = b0->bf[s0->mark_begin.y].s[j];
  for (i = s0->mark_begin.y+1; i < s0->mark_end.y; i++)
  {
-  WpeXInfo.selection = WpeRealloc(WpeXInfo.selection, (n + b0->bf[i].nrc)*sizeof(char));
+  WpeXInfo.selection = realloc(WpeXInfo.selection, (n + b0->bf[i].nrc)*sizeof(char));
   for (j = 0; j < b0->bf[i].nrc; j++, n++)
    WpeXInfo.selection[n] = b0->bf[i].s[j];
  }
- WpeXInfo.selection = WpeRealloc(WpeXInfo.selection, (n + s0->mark_end.x + 1)*sizeof(char));
+ WpeXInfo.selection = realloc(WpeXInfo.selection, (n + s0->mark_end.x + 1)*sizeof(char));
  for (j = 0; j < s0->mark_end.x; j++, n++)
   WpeXInfo.selection[n] = b0->bf[i].s[j];
  WpeXInfo.selection[n] = 0;

--- a/we_xterm.c
+++ b/we_xterm.c
@@ -314,15 +314,15 @@ int e_ini_size()
   FREE(schirm);
  if(altschirm)
   FREE(altschirm);
- schirm = MALLOC(2 * MAXSCOL * MAXSLNS);
- altschirm = MALLOC(2 * MAXSCOL * MAXSLNS);
+ schirm = malloc(2 * MAXSCOL * MAXSLNS);
+ altschirm = malloc(2 * MAXSCOL * MAXSLNS);
 #ifdef NEWSTYLE
  if (extbyte)
   FREE(extbyte);
  if (altextbyte)
   FREE(altextbyte);
- extbyte = MALLOC(MAXSCOL * MAXSLNS);
- altextbyte = MALLOC(MAXSCOL * MAXSLNS);
+ extbyte = malloc(MAXSCOL * MAXSLNS);
+ altextbyte = malloc(MAXSCOL * MAXSLNS);
  if (!schirm || !altschirm || !extbyte || !altextbyte)
   return(-1);
 #else
@@ -823,7 +823,7 @@ int e_x_system(const char *exe)
  char *string;
 
  sprintf(file, "%s/we_sys_tmp", e_tmp_dir);
- string = MALLOC(strlen(XTERM_CMD) + strlen(exe) + strlen(file) +
+ string = malloc(strlen(XTERM_CMD) + strlen(exe) + strlen(file) +
    strlen(user_shell) + 40);
  if (!(fp = fopen(file, "w+")))
  {

--- a/we_xterm.c
+++ b/we_xterm.c
@@ -311,16 +311,16 @@ int e_ini_size()
  old_cursor_y = cur_y;
 
  if (schirm)
-  FREE(schirm);
+  free(schirm);
  if(altschirm)
-  FREE(altschirm);
+  free(altschirm);
  schirm = malloc(2 * MAXSCOL * MAXSLNS);
  altschirm = malloc(2 * MAXSCOL * MAXSLNS);
 #ifdef NEWSTYLE
  if (extbyte)
-  FREE(extbyte);
+  free(extbyte);
  if (altextbyte)
-  FREE(altextbyte);
+  free(altextbyte);
  extbyte = malloc(MAXSCOL * MAXSLNS);
  altextbyte = malloc(MAXSCOL * MAXSLNS);
  if (!schirm || !altschirm || !extbyte || !altextbyte)
@@ -827,7 +827,7 @@ int e_x_system(const char *exe)
    strlen(user_shell) + 40);
  if (!(fp = fopen(file, "w+")))
  {
-  FREE(string);
+  free(string);
   return(-1);
  }
  fputs("$*\necho type \\<Return\\> to continue\nread i\n", fp);
@@ -841,7 +841,7 @@ int e_x_system(const char *exe)
     user_shell, file, exe);
  ret = system(string);
  remove(file);
- FREE(string);
+ free(string);
  return(ret);
 }
 
@@ -874,8 +874,8 @@ int e_x_repaint_desk(FENSTER *f)
  e_abs_refr();
  for (i = cn->mxedt; i >= 1; i--)
  {
-  FREE(cn->f[i]->pic->p);
-  FREE(cn->f[i]->pic);
+  free(cn->f[i]->pic->p);
+  free(cn->f[i]->pic);
  }
  for (i = 0; i <= cn->mxedt; i++)
  {
@@ -948,7 +948,7 @@ int e_x_cp_X_to_buffer(FENSTER *f)
  long nitems, bytes_left;
 
  for (i = 1; i < b0->mxlines; i++)
-  FREE(b0->bf[i].s);
+  free(b0->bf[i].s);
  b0->mxlines = 1;
  *(b0->bf[0].s) = WPE_WR;
  *(b0->bf[0].s+1) = '\0';

--- a/we_xterm.c
+++ b/we_xterm.c
@@ -731,7 +731,7 @@ int e_x_getch()
    case SelectionClear:
     if (WpeXInfo.selection)
     {
-     WpeFree(WpeXInfo.selection);
+     free(WpeXInfo.selection);
      WpeXInfo.selection = NULL;
     }
     break;
@@ -1016,7 +1016,7 @@ int e_x_cp_X_to_buffer(FENSTER *f)
  s0->mark_end.x = b0->bf[b0->mxlines-1].len;
 #if SELECTION
  if (WpeXInfo.selection)
-  WpeFree(str);
+  free(str);
  else
 #endif
   XFree(str);
@@ -1040,7 +1040,7 @@ int e_x_paste_X_buffer(FENSTER *f)
 #if SELECTION
  if (WpeXInfo.selection)
  {
-  WpeFree(WpeXInfo.selection);
+  free(WpeXInfo.selection);
   WpeXInfo.selection = NULL;
  }
 #endif
@@ -1083,7 +1083,7 @@ int e_x_paste_X_buffer(FENSTER *f)
    WpeXInfo.window, CurrentTime);
 #else
  XStoreBytes(WpeXInfo.display, WpeXInfo.selection, n);
- WpeFree(WpeXInfo.selection);
+ free(WpeXInfo.selection);
  WpeXInfo.selection = NULL;
 #endif
  return(0);


### PR DESCRIPTION
Hi Alessandro,

I replaced several macros that were all calling malloc, realloc and free, with no benefit: they did none other than calling the relevant function, like:

`#define MALLOC(x) malloc(x)`

I tested them lightly by opening, editing and saving a file. Please review and let me know your comment.