### PR TITLE
Renamed type OPTK variable from opt to optk

### DIFF
--- a/edit.h
+++ b/edit.h
@@ -663,7 +663,7 @@ int e_schr_nchar_wsv(char *str, int x, int y, int n, int max, int col,
 int e_schr_lst_wsv(char *str, int xa, int ya, int n, int strlen, int ft,
   int fz, struct dirfile **df, FENSTER *f);
 int e_rep_win_tree(ECNT *cn);
-int e_opt_sec_box(int xa, int ya, int num, OPTK *opt, FENSTER *f, int sw);
+int e_opt_sec_box(int xa, int ya, int num, OPTK *optk, FENSTER *f, int sw);
 int e_close_buffer(BUFFER *b);
 int e_list_all_win(FENSTER *f);
 

--- a/we_fl_unix.c
+++ b/we_fl_unix.c
@@ -3937,37 +3937,37 @@ int e_get_funct_in(char *nstr, FENSTER * f)
 int e_funct_in(FENSTER * f)
 {
   int             n, xa = 37, ya = 2, num = 8;
-  OPTK           *opt = malloc(num * sizeof(OPTK));
+  OPTK           *optk = malloc(num * sizeof(OPTK));
   char            nstr[2];
 
-  opt[0].t = "User Commands";
-  opt[0].x = 0;
-  opt[0].o = 'U';
-  opt[1].t = "System Calls";
-  opt[1].x = 0;
-  opt[1].o = 'S';
-  opt[2].t = "C-Lib.-Functions";
-  opt[2].x = 0;
-  opt[2].o = 'C';
-  opt[3].t = "Devices & Netw. I.";
-  opt[3].x = 0;
-  opt[3].o = 'D';
-  opt[4].t = "File Formats";
-  opt[4].x = 0;
-  opt[4].o = 'F';
-  opt[5].t = "Games & Demos";
-  opt[5].x = 0;
-  opt[5].o = 'G';
-  opt[6].t = "Environment, ...";
-  opt[6].x = 0;
-  opt[6].o = 'E';
-  opt[7].t = "Maintenance Com.";
-  opt[7].x = 0;
-  opt[7].o = 'M';
+  optk[0].t = "User Commands";
+  optk[0].x = 0;
+  optk[0].o = 'U';
+  optk[1].t = "System Calls";
+  optk[1].x = 0;
+  optk[1].o = 'S';
+  optk[2].t = "C-Lib.-Functions";
+  optk[2].x = 0;
+  optk[2].o = 'C';
+  optk[3].t = "Devices & Netw. I.";
+  optk[3].x = 0;
+  optk[3].o = 'D';
+  optk[4].t = "File Formats";
+  optk[4].x = 0;
+  optk[4].o = 'F';
+  optk[5].t = "Games & Demos";
+  optk[5].x = 0;
+  optk[5].o = 'G';
+  optk[6].t = "Environment, ...";
+  optk[6].x = 0;
+  optk[6].o = 'E';
+  optk[7].t = "Maintenance Com.";
+  optk[7].x = 0;
+  optk[7].o = 'M';
 
-  n = e_opt_sec_box(xa, ya, num, opt, f, 1);
+  n = e_opt_sec_box(xa, ya, num, optk, f, 1);
 
-  free(opt);
+  free(optk);
   if(n < 0)
     return(WPE_ESC);
 

--- a/we_menue.c
+++ b/we_menue.c
@@ -651,12 +651,13 @@ int WpeHandleSubmenu(int xa, int ya, int xe, int ye, int nm, OPTK * fopt, FENSTE
 /*      fill "options" struct */
 OPTK WpeFillSubmenuItem(char *t, int x, char o, int(*fkt) ())
 {
-  OPTK            opt;
+  // FIXME: returning a locally allocated automatic variable !
+  OPTK            optk;
 
-  opt.t = t;
-  opt.x = x;
-  opt.o = o;
-  opt.fkt = fkt;
-  return(opt);
+  optk.t = t;
+  optk.x = x;
+  optk.o = o;
+  optk.fkt = fkt;
+  return(optk);
 }
 

--- a/we_opt.c
+++ b/we_opt.c
@@ -233,16 +233,16 @@ int e_sys_info(FENSTER *f)
 int e_ad_colors(FENSTER *f)
 {
  int n, xa = 48, ya = 2, num = 4;
- OPTK *opt = malloc(num * sizeof(OPTK));
+ OPTK *optk = malloc(num * sizeof(OPTK));
 
- opt[0].t = "Editor Colors";     opt[0].x = 0;  opt[0].o = 'E';
- opt[1].t = "Desk Colors";       opt[1].x = 0;  opt[1].o = 'D';
- opt[2].t = "Option Colors";     opt[2].x = 0;  opt[2].o = 'O';
- opt[3].t = "Progr. Colors";     opt[3].x = 0;  opt[3].o = 'P';
+ optk[0].t = "Editor Colors";     optk[0].x = 0;  optk[0].o = 'E';
+ optk[1].t = "Desk Colors";       optk[1].x = 0;  optk[1].o = 'D';
+ optk[2].t = "optkion Colors";     optk[2].x = 0;  optk[2].o = 'O';
+ optk[3].t = "Progr. Colors";     optk[3].x = 0;  optk[3].o = 'P';
 
- n = e_opt_sec_box(xa, ya, num, opt, f, 1);
+ n = e_opt_sec_box(xa, ya, num, optk, f, 1);
 
- free(opt);
+ free(optk);
  if (n < 0)
   return(WPE_ESC);
 

--- a/we_wind.c
+++ b/we_wind.c
@@ -1477,17 +1477,17 @@ int e_mess_win(char *header, char *str, PIC **pic, FENSTER *f)
  return(i == CtrlC ? 1 : 0);
 }
 
-int e_opt_sec_box(int xa, int ya, int num, OPTK *opt, FENSTER *f, int sw)
+int e_opt_sec_box(int xa, int ya, int num, OPTK *optk, FENSTER *f, int sw)
 {
    PIC *pic;
    int n, nold, max = 0, i, c = 0, xe, ye = ya + num + 1;
    for(i = 0; i < num; i++)
-   if((n = strlen(opt[i].t)) > max) max = n;
+   if((n = strlen(optk[i].t)) > max) max = n;
    xe = xa + max + 3;
    pic = e_std_kst(xa, ya, xe, ye, NULL, sw, f->fb->nr.fb, f->fb->nt.fb, f->fb->ne.fb);
    if(pic == NULL)  {  e_error(e_msg[ERR_LOWMEM], 0, f->fb); return(-2);  }
    for (i = 0; i < num; i++)
-   e_pr_str_wsd(xa+2, ya+i+1, opt[i].t, f->fb->mt.fb, opt[i].x,
+   e_pr_str_wsd(xa+2, ya+i+1, optk[i].t, f->fb->mt.fb, optk[i].x,
 		1, f->fb->ms.fb, xa+1, xe-1);
 #if  MOUSE
    while (e_mshit() != 0);
@@ -1495,20 +1495,20 @@ int e_opt_sec_box(int xa, int ya, int num, OPTK *opt, FENSTER *f, int sw)
    n = 0; nold = 1;
    while (c != WPE_ESC && c != WPE_CR)
    {  if (nold != n)
-      {  e_pr_str_wsd(xa+2, nold+ya+1, opt[nold].t, f->fb->mt.fb,
-				opt[nold].x, 1, f->fb->ms.fb, xa+1, xe-1);
-	 e_pr_str_wsd(xa+2, n+ya+1, opt[n].t, f->fb->mz.fb,
-				opt[n].x, 1, f->fb->mz.fb, xa+1, xe-1);
+      {  e_pr_str_wsd(xa+2, nold+ya+1, optk[nold].t, f->fb->mt.fb,
+				optk[nold].x, 1, f->fb->ms.fb, xa+1, xe-1);
+	 e_pr_str_wsd(xa+2, n+ya+1, optk[n].t, f->fb->mz.fb,
+				optk[n].x, 1, f->fb->mz.fb, xa+1, xe-1);
 	 nold = n;
       }
 #if  MOUSE
       if( (c = e_toupper(e_getch())) == -1)
-      c = e_m2_mouse(xa, ya, xe, ye, opt);
+      c = e_m2_mouse(xa, ya, xe, ye, optk);
 #else
       c = e_toupper(e_getch());
 #endif
       for (i = 0; i < ye - ya - 1; i++)
-      if( c == opt[i].o) {  c = WPE_CR;  n = i;  break;  }
+      if( c == optk[i].o) {  c = WPE_CR;  n = i;  break;  }
       if (i > ye - ya) c = WPE_ESC;
       else if ( c == CUP || c == CtrlP ) n = n > 0 ? n-1 : ye - ya - 2 ;
       else if ( c == CDO || c == CtrlN ) n = n < ye-ya-2 ? n+1 : 0 ;


### PR DESCRIPTION
Renamed all variables called opt with type OPTK. This was pretty confusing. There are several OPT types with each a different struct layout. OPTK is one of them, OPT is another. This should hopefully prevent confusion.

The change is not complete, because the involved function names still have -opt- in them. I will change that when I understand what these functions do.

Please ignore the branch, just merge into devel. I will delete the branch after and synchronize with your devel.