### PR TITLE
adapt call to access to use F_OK, R_OK, W_OK, X_OK.

### DIFF
--- a/we_debug.c
+++ b/we_debug.c
@@ -2481,7 +2481,7 @@ int e_d_goto_break(char *file, int line, FENSTER *f)
  free(ftmp.datnam);
  if (i <= 0)
  {
-  if (access(file, 0))
+  if (access(file, F_OK))
   {
    sprintf(str, e_d_msg[ERR_CANTFILE], file);
    return(e_error(str, 0, f->fb));

--- a/we_edit.c
+++ b/we_edit.c
@@ -303,7 +303,7 @@ int e_edit(ECNT *cn, char *filename)
 #endif
  if (ftype != 1)
   fp = fopen(complete_fname, "rb");
- if (fp != NULL && access(complete_fname, 2) != 0) f->ins = 8;
+ if (fp != NULL && access(complete_fname, W_OK) != 0) f->ins = 8;
 #ifdef UNIX
  if (fp != NULL)
  {

--- a/we_fl_fkt.c
+++ b/we_fl_fkt.c
@@ -268,10 +268,13 @@ int e_write(int xa, int ya, int xe, int ye, FENSTER *f, int backup)
  if (f->ins == 8)
   return(WPE_ESC);
  ptmp = e_mkfilename(f->dirct, f->datnam);
- if ((backup == WPE_BACKUP) && (access(ptmp, 0) == 0))
+// F_OK means: test for existance and has the value zero.
+// Use R_OK, W_OK and X_OK for Read, Write or execute permissions
+// FIXME: man page discourage use of access: switch to real user and test open, then switch back.
+ if ((backup == WPE_BACKUP) && (access(ptmp, F_OK) == 0))
  {
   tmp = e_bakfilename(ptmp);
-  if (access(tmp, 0) == 0)
+  if (access(tmp, F_OK) == 0)
    remove(tmp);
   WpeRenameCopy(ptmp, tmp, f, 1);
   free(tmp);
@@ -559,7 +562,7 @@ int e_mkdir_path(char *path)
  if (i > 0)
  {
   tmp[i] = '\0';
-  if (access(tmp, 0))
+  if (access(tmp, F_OK))
   {
    e_mkdir_path(tmp);
    mkdir(tmp, 0700);
@@ -644,19 +647,19 @@ IFILE *e_i_fopen(char *path, char *stat)
  }
  strcpy(tmp2, path);
  strcat(tmp2, ".gz");
- if (access(tmp2, 0))
+ if (access(tmp2, F_OK))
  {
   strcpy(tmp2, path);
   strcat(tmp2, ".Z");
-  if (access(tmp2, 0))
+  if (access(tmp2, F_OK))
   {
    strcpy(tmp2, path);
    strcat(tmp2, ".info.gz");
-   if (access(tmp2, 0))
+   if (access(tmp2, F_OK))
    {
     strcpy(tmp2, path);
     strcat(tmp2, ".info.Z");
-    if (access(tmp2, 0))
+    if (access(tmp2, F_OK))
     {
      free(fp);
      free(tmp2);

--- a/we_fl_unix.c
+++ b/we_fl_unix.c
@@ -1100,7 +1100,7 @@ int WpeHandleFileManager(ECNT * cn)
               c = cold;
               break;
             }
-            if(access(filen, 2) != 0)
+            if(access(filen, W_OK) != 0)
               f->ins = 8;
             e_close_window(f);
             e_switch_window(winnum, fe);
@@ -2554,7 +2554,7 @@ int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
     sprintf(ntmp, "%s%c%s", newname, DIRC, dd->name[i]);
     ret = 'Y';
 
-    if(access(ntmp, 0) == 0)
+    if(access(ntmp, F_OK) == 0)
     {
       if(f->ed->flopt & FM_MOVE_PROMPT)
       {
@@ -2698,7 +2698,7 @@ int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
  else
  {
   /* check whether file exist */
-  if (access(newname, 0) == 0)
+  if (access(newname, F_OK) == 0)
   {
    if (f->ed->flopt & FM_MOVE_OVERWRITE)
    {

--- a/we_opt.c
+++ b/we_opt.c
@@ -1013,7 +1013,7 @@ int e_save_opt(FENSTER *f)
  strcpy(str_line, cn->optfile);
  for (i = strlen(str_line); i > 0 && str_line[i] != DIRC; i--);
  str_line[i] = '\0';
- if (access(str_line, 0)) mkdir(str_line, 0700);
+ if (access(str_line, F_OK)) mkdir(str_line, 0700);
  free(str_line);
  fp = fopen(cn->optfile, "w");
  if (fp == NULL)

--- a/we_prog.c
+++ b/we_prog.c
@@ -1433,7 +1433,7 @@ int e_make_library(char *library, char *ofile, FENSTER *f)
  PIC *pic = NULL;
 
  ar_arg[0] = "ar";
- if (access(library, 0))
+ if (access(library, F_OK))
   ar_arg[1] = "-cr";
  else
   ar_arg[1] = "-r";
@@ -2116,7 +2116,7 @@ int e_c_project(FENSTER *f)
  if (df)
  {
   strcpy(library, df->name[0]);
-  if (access(library, 0)) exlib = 1;
+  if (access(library, F_OK)) exlib = 1;
   else stat(library, lbuf);
   freedf(df);
  }
@@ -2799,7 +2799,7 @@ int e_new_message(FENSTER *f)
    e_switch_window(f->ed->edt[i], f->ed->f[f->ed->mxedt]);
    e_close_window(f->ed->f[f->ed->mxedt]);
   }
- if (access("Messages", 0) == 0)
+ if (access("Messages", F_OK) == 0)
   remove("Messages");
  if (e_edit(f->ed, "Messages"))
   return(WPE_ESC);

--- a/we_progn.c
+++ b/we_progn.c
@@ -1163,7 +1163,7 @@ int e_show_nm_f(char *name, FENSTER *f, int oldn, char **oldname)
  struct dirfile *df, *fdf = NULL;
 
 #ifndef TESTSDEF
- if (!access(e_prog.project, 0))
+ if (!access(e_prog.project, F_OK))
  {
   WpeMouseChangeShape(WpeWorkingShape);
   if (e_read_var(f)) ret = -1;


### PR DESCRIPTION
The call to access was coded in absolutes like `access(filename, 0)` for F_OK and `access(filename, 2)` for W_OK (write access). I altered the constants to use the designated constants from unistd.h. The same definitions occur in fcntl.h (no differences). The include file unistd.h shows:

> `#define R_OK    4               /* Test for read permission.  */`
> `#define W_OK    2               /* Test for write permission.  */`
> `#define X_OK    1               /* Test for execute permission.  */`
> `#define F_OK    0               /* Test for existence.  */`

Using the defines makes reading the source code simpeler. The man page warns that it uses the *real id* in stead of the *effective id*. For future consideration.

P.S. Alessandro, I will just merge this with experimental. That way we have quick updates, but still traceability.