### PR TITLE
started solving warnings, mainly signedness warnings.

### DIFF
--- a/edit.h
+++ b/edit.h
@@ -136,7 +136,7 @@ typedef struct undo {
 typedef struct STR {
  unsigned char *s;
  int len; /* Length of string not counting '\n' at the end */
- int nrc;
+ size_t nrc;
  /*int size;*/ /* Memory allocated for the string */
 } STRING;
 
@@ -226,7 +226,7 @@ typedef struct CNT {
  int maxcol, tabn;
  int maxchg, numundo;
  int flopt, edopt;
- int mxedt;           /* max number of exiting windows */
+ int mxedt;           /* max number of editing windows */
  int curedt;          /* currently active window */
  int edt[MAXEDT + 1]; /* 1 <= window IDs <= MAXEDT, arbitrary order */
  int autoindent;

--- a/unixkeys.h
+++ b/unixkeys.h
@@ -4,6 +4,9 @@
 /* modify it under the terms of the                       */
 /* GNU General Public License, see the file COPYING.      */
 
+#ifndef UNIXKEYS_H
+#define UNIXKEYS_H
+
 #ifndef LIBRARY_DIR
 #define LIBRARY_DIR "/usr/local/lib/xwpe"
 #endif
@@ -67,6 +70,7 @@ extern char RE1, RE2, RE3, RE4, RE5, RE6, WBT;
 #define DGZ 25       /*  ctrl y  */
 
 #define WPE_CR 13
+//extern const unsigned char WPE_WR;
 #define WPE_WR 10
 #define WPE_ESC 27
 #define WPE_DC 8
@@ -78,3 +82,4 @@ extern char RE1, RE2, RE3, RE4, RE5, RE6, WBT;
 #define SCUP CUP+512
 #define SCDO CDO+512
 
+#endif // ifndef UNIXKEYS_H

--- a/we_block.c
+++ b/we_block.c
@@ -11,6 +11,7 @@
 #include "edit.h"
 #include "we_block.h"
 #include "we_progn.h"
+#include "we_edit.h"
 #include <ctype.h>
 
 extern int e_undo_sw;
@@ -34,7 +35,7 @@ int e_blck_del(FENSTER *f)
  {
   return(0);
  }
- if (f->ins == 8)
+ if (f->ins == (char) 8)
   return(WPE_ESC);
  if (s->mark_begin.y == s->mark_end.y)
  {
@@ -88,7 +89,7 @@ int e_blck_dup(char *dup, FENSTER *f)
  {
   return(0);
  }
- strncpy(dup, &b->bf[s->mark_begin.y].s[s->mark_begin.x], i);
+ strncpy(dup, (const char *)&b->bf[s->mark_begin.y].s[s->mark_begin.x], i);
  dup[i]=0;
  return(i);
 }

--- a/we_block.h
+++ b/we_block.h
@@ -1,7 +1,6 @@
 #ifndef WE_BLOCK_H
 #define WE_BLOCK_H
 
-#include "we_edit.h"
 #include "we_fl_unix.h"
 #include "we_opt.h"
 #include "we_debug.h"

--- a/we_edit.c
+++ b/we_edit.c
@@ -1269,7 +1269,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
 {
  int a_indent = b->cn->autoindent;
  int line, x, k, char_to_ins;
- char *str;
+ unsigned char *str;
  int do_auto_indent = 0;
  int first_nospace_k;
 
@@ -1329,7 +1329,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
  if (!do_auto_indent)
  {
   /* insert TAB char */
-  str = malloc(sizeof(char));
+  str = malloc(sizeof(unsigned char));
   str[0] = '\t';
   char_to_ins = 1;
  }
@@ -1354,7 +1354,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
    /* indent to x with spaces */
    /* insert chars */
    k = x - b->b.x;
-   str = malloc(k * sizeof(char));
+   str = malloc(k * sizeof(unsigned char));
    for (x = 0; x < k; x++)
     str[x] = ' ';
    char_to_ins = k;
@@ -1364,7 +1364,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
    /* indent to x + a_indent with spaces */
    /* insert chars */
    k = x + a_indent - b->b.x;
-   str = malloc(k * sizeof(char));
+   str = malloc(k * sizeof(unsigned char));
    for (x = 0; x < k; x++)
     str[x] = ' ';
    char_to_ins = k;
@@ -1372,7 +1372,7 @@ int e_tab_a_ind(BUFFER *b, SCHIRM *s)
   else
   {
    /* insert TAB char */
-   str = malloc(sizeof(char));
+   str = malloc(sizeof(unsigned char));
    str[0] = '\t';
    char_to_ins = 1;
   }
@@ -1401,7 +1401,7 @@ int e_del_a_ind(BUFFER *b, SCHIRM *s)
    }
    if (i != j)
    {
-    char *str = malloc(i * sizeof(char));
+    unsigned char *str = malloc(i * sizeof(unsigned char));
     e_del_nchar(b, s, 0, b->b.y, j);
     for (j = 0; j < i; j++)
      str[j] = ' ';
@@ -1483,7 +1483,7 @@ int e_car_ret(BUFFER *b, SCHIRM *s)
               *(b->bf[b->b.y+1].s + i) = *(b->bf[b->b.y].s+b->b.x+i);
       *(b->bf[b->b.y+1].s+i)='\0';
       b->bf[b->b.y+1].len = e_str_len(b->bf[b->b.y+1].s);
-      b->bf[b->b.y+1].nrc = strlen(b->bf[b->b.y+1].s);
+      b->bf[b->b.y+1].nrc = strlen((const char *)b->bf[b->b.y+1].s);
       if(s->mark_begin.y > b->b.y) (s->mark_begin.y)++;
       else if(s->mark_begin.y == b->b.y && s->mark_begin.x > b->b.x)
       {  (s->mark_begin.y)++;  (s->mark_begin.x) -= (b->b.x);  }
@@ -1494,7 +1494,7 @@ int e_car_ret(BUFFER *b, SCHIRM *s)
    *(b->bf[b->b.y].s+b->b.x) = WPE_WR;
    *(b->bf[b->b.y].s+b->b.x+1) = '\0';
    b->bf[b->b.y].len = e_str_len(b->bf[b->b.y].s);
-   b->bf[b->b.y].nrc = strlen(b->bf[b->b.y].s);
+   b->bf[b->b.y].nrc = strlen((const char *)b->bf[b->b.y].s);
    sc_txt_3(b->b.y, b, 1);
 /***************************/   
    if(b->b.x>0) e_brk_recalc(b->f,b->b.y+1,1);
@@ -1673,7 +1673,7 @@ int e_del_nchar(BUFFER *b, SCHIRM *s, int x, int y, int n)
  if (y < b->mxlines)
  {
   b->bf[y].len = e_str_len(b->bf[y].s);
-  b->bf[y].nrc = strlen(b->bf[y].s);
+  b->bf[y].nrc = strlen((const char *)b->bf[y].s);
  }
  e_undo_sw--;
  sc_txt_4(y, b, 0);
@@ -1861,7 +1861,7 @@ int e_put_char(int c, BUFFER *b, SCHIRM *s)
 }
 
 /*   search right (left end of word) */
-int e_su_lblk(int xa, char *s)
+int e_su_lblk(int xa, unsigned char *s)
 {
  int len = strlen(s);
 
@@ -1875,7 +1875,7 @@ int e_su_lblk(int xa, char *s)
 }
 
 /*     Search left (left end of word)     */
-int e_su_rblk(int xa, char *s)
+int e_su_rblk(int xa, unsigned char *s)
 {
  int len = strlen(s);
 
@@ -2110,6 +2110,25 @@ Undo *e_remove_undo(Undo *ud, int sw)
  return(ud);
 }
 
+/**
+ * Function to add undo information to the list of things to undo.
+ * What the function does depends on the value of the integer sw.
+ *
+ * sw  action
+ * --  ------
+ *  d	Uses d to remember delete characters in a block
+ *  c	Uses c to remember a copy of a block
+ *  v   Guess: ?? paste block TODO: verify meaning
+ *  a	Guess: ?? add characters TODO: verify meaning
+ *  l	Guess: ?? Delete line TODO: verify meaning
+ *  r	Uses r to remember deleted characters on one line
+ *  p	Guess: ?? put char over another char (replace) TODO: verify meaning
+ *  y	Guess: ?? redo a previous undo TODO: verify meaning
+ *  s	Guess: ?? replace a string of characters TODO: verify meaning
+ *  
+ *  Remark: the **global** e_undo_sw is a disabler for this function.
+ *  if e_undo_sw is true, this function does nothing.
+ */
 int e_add_undo(int sw, BUFFER *b, int x, int y, int n)
 {
  Undo *next;

--- a/we_edit.h
+++ b/we_edit.h
@@ -28,8 +28,8 @@ int e_ins_nchar(BUFFER *b, SCHIRM *sch, unsigned char *s, int xa, int ya,
   int n);
 int e_new_line(int yd, BUFFER *b);
 int e_put_char(int c, BUFFER *b, SCHIRM *s);
-int e_su_lblk(int xa, char *s);
-int e_su_rblk(int xa, char *s);
+int e_su_lblk(int xa, unsigned char *s);
+int e_su_rblk(int xa, unsigned char *s);
 void e_zlsplt(FENSTER *f);
 void WpeFilenameToPathFile(char *filename, char **path, char **file);
 int e_lst_zeichen(int x, int y, int n, int sw, int frb, int max, int iold,

--- a/we_fl_unix.h
+++ b/we_fl_unix.h
@@ -3,7 +3,6 @@
 
 #include "we_block.h"
 #include "we_wind.h"
-#include "we_edit.h"
 #include "we_fl_fkt.h"
 #include "we_mouse.h"
 #include "we_opt.h"

--- a/we_hfkt.h
+++ b/we_hfkt.h
@@ -11,9 +11,6 @@ int e_urstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn);
 int e_rstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn);
 int e_str_len(unsigned char *s);
 
-//#define e_str_nrc(s) strlen(s)
-//#define e_toupper(c) toupper(c)
-
 int e_num_kst(char *s, int num, int max, FENSTER *f, int n, int sw);
 COLOR e_s_x_clr(int f, int b);
 COLOR e_n_x_clr(int fb);


### PR DESCRIPTION
Mostly signedness warnings. Solved by recasting, mainly.

Some exceptions:

* Changed `int` in STRING to `size_t` because the item (`nrc`) really is the size of a string and I checked the use: all warrent use of size_t. The warning refers to `nrc` being obtained through a sizeof, which returns a size_t. According to the standard size_t is an unsigned form of integer. I expect no problems from this one.
* in 2 functions (e_tab_a_ind and `e_del_a_ind` I changed a local string definition to unsigned char * from char *. The local strings were being used as parameter into an unsigned char * function param.
* In use of strlen, I had to recast unsigned char * to const char * as per definition of strlen.

The next batch will be redefining some `#define CONST 10` to `extern const unsigned int CONST` plus a definition in a c file.  

EDIT: No it won't. C doesn't allow variable constants to be used as a constant expression. You learn a little every day. For now I will stay with the defines as they appear to be the way to go in C.