### PR TITLE
Reformatted all .c and .h in src directory using indent with default …

### DIFF
--- a/src/WeExpArr.c
+++ b/src/WeExpArr.c
@@ -23,53 +23,56 @@
   elements is listed.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-void *WpeExpArrayCreate(int initial_num, int elem_size, int growth_num)
+void *
+WpeExpArrayCreate (int initial_num, int elem_size, int growth_num)
 {
- int *exp_array;
+  int *exp_array;
 
- exp_array = (int *)malloc(initial_num * elem_size + sizeof(int) * 4);
- *(exp_array) = initial_num;
- *(exp_array + 1) = elem_size;
- *(exp_array + 2) = growth_num;
- *(exp_array + 3) = initial_num;
- return ((void *)(exp_array + 4));
+  exp_array = (int *) malloc (initial_num * elem_size + sizeof (int) * 4);
+  *(exp_array) = initial_num;
+  *(exp_array + 1) = elem_size;
+  *(exp_array + 2) = growth_num;
+  *(exp_array + 3) = initial_num;
+  return ((void *) (exp_array + 4));
 }
 
-void WpeExpArrayAdd(void **exp_array, void *new_elem)
+void
+WpeExpArrayAdd (void **exp_array, void *new_elem)
 {
- int *real_array;
+  int *real_array;
 
- real_array = ((int *)*exp_array) - 4;
- if (*real_array == *(real_array + 3))
- {
-  *(real_array) += *(real_array + 2);
-  real_array = realloc(real_array, (*real_array) * (*(real_array + 1)) +
-                                      sizeof(int) * 4);
-  if (real_array == NULL)
-  {
-   /* Some error handling should be done here */
-   return ;
-  }
-  *exp_array = (void *)(real_array + 4);
- }
- memcpy(((char *)*exp_array) + (*(real_array + 3)) * (*(real_array + 1)),
-        new_elem, (*(real_array + 1)));
- *(real_array + 3) += 1;
+  real_array = ((int *) *exp_array) - 4;
+  if (*real_array == *(real_array + 3))
+    {
+      *(real_array) += *(real_array + 2);
+      real_array = realloc (real_array, (*real_array) * (*(real_array + 1)) +
+			    sizeof (int) * 4);
+      if (real_array == NULL)
+	{
+	  /* Some error handling should be done here */
+	  return;
+	}
+      *exp_array = (void *) (real_array + 4);
+    }
+  memcpy (((char *) *exp_array) + (*(real_array + 3)) * (*(real_array + 1)),
+	  new_elem, (*(real_array + 1)));
+  *(real_array + 3) += 1;
 }
 
-int WpeExpArrayGetSize(void *exp_array)
+int
+WpeExpArrayGetSize (void *exp_array)
 {
- int *real_array;
+  int *real_array;
 
- real_array = ((int *)exp_array) - 4;
- return (*(real_array + 3));
+  real_array = ((int *) exp_array) - 4;
+  return (*(real_array + 3));
 }
 
-void WpeExpArrayDestroy(void *exp_array)
+void
+WpeExpArrayDestroy (void *exp_array)
 {
- int *real_array;
+  int *real_array;
 
- real_array = ((int *)exp_array) - 4;
- free(real_array);
+  real_array = ((int *) exp_array) - 4;
+  free (real_array);
 }
-

--- a/src/WeExpArr.h
+++ b/src/WeExpArr.h
@@ -8,7 +8,8 @@
 \*-------------------------------------------------------------------------*/
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 
@@ -21,7 +22,7 @@ extern "C" {
       growth_num   (In)  Number by which it increases when necessary
     Returns: The new expandable array
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void *WpeExpArrayCreate(int initial_num, int elem_size, int growth_num);
+  void *WpeExpArrayCreate (int initial_num, int elem_size, int growth_num);
 
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -31,7 +32,7 @@ void *WpeExpArrayCreate(int initial_num, int elem_size, int growth_num);
       exp_array    (In & Out) The expandable array
       new_elem     (In)  The new element to add
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeExpArrayAdd(void **exp_array, void *new_elem);
+  void WpeExpArrayAdd (void **exp_array, void *new_elem);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeExpArrayGetSize - Get the number of used elements of an expandable
@@ -41,7 +42,7 @@ array.
       exp_array    (In)  The expandable array
     Returns: Number of used elements
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-int WpeExpArrayGetSize(void *exp_array);
+  int WpeExpArrayGetSize (void *exp_array);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeExpArrayDestroy - Destroys an expandable array.
@@ -49,11 +50,10 @@ int WpeExpArrayGetSize(void *exp_array);
     Parameters:
       exp_array    (In)  Expandable array to be destroyed
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeExpArrayDestroy(void *exp_array);
+  void WpeExpArrayDestroy (void *exp_array);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/src/WeLinux.c
+++ b/src/WeLinux.c
@@ -12,33 +12,33 @@
 #include "config.h"
 #include "WeLinux.h"
 
-int WpeLinuxBioskey(void)
+int
+WpeLinuxBioskey (void)
 {
- char c;
- int status;
+  char c;
+  int status;
 
- c = 6;
- status = 0;
- if (ioctl(0, TIOCLINUX, &c) == 0)
- {
-  if (c & 0x01)
-  {
-   /* Right or left shift is pressed */
-   status |= 0x03;
-  }
-  if (c & 0x04)
-  {
-   /* Control key is pressed */
-   status |= 0x04;
-  }
-  if (c & 0x0A)
-  {
-   /* Alt key is pressed */
-   status |= 0x08;
-  }
- }
- return(status);
+  c = 6;
+  status = 0;
+  if (ioctl (0, TIOCLINUX, &c) == 0)
+    {
+      if (c & 0x01)
+	{
+	  /* Right or left shift is pressed */
+	  status |= 0x03;
+	}
+      if (c & 0x04)
+	{
+	  /* Control key is pressed */
+	  status |= 0x04;
+	}
+      if (c & 0x0A)
+	{
+	  /* Alt key is pressed */
+	  status |= 0x08;
+	}
+    }
+  return (status);
 }
 
 #endif
-

--- a/src/WeLinux.h
+++ b/src/WeLinux.h
@@ -3,7 +3,7 @@
 
 /* WeLinux.c */
 #ifdef __linux__
-int WpeLinuxBioskey(void);
+int WpeLinuxBioskey (void);
 #endif // #ifdef __linux__
 
 #endif

--- a/src/WeProg.h
+++ b/src/WeProg.h
@@ -8,7 +8,8 @@
 \*-------------------------------------------------------------------------*/
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /* needed for the time being to call old routines and data types */
@@ -18,39 +19,41 @@ extern "C" {
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   New Types
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-typedef struct wpeSyntaxRule {
- char **reserved_word;  /* Reserved words */
- char **long_operator;  /* Operators longer than a single character*/
- char *single_operator; /* Single character operators */
- char *begin_comment;   /* Comments begin with this string */
- char *end_comment;     /* Comments end with this string */
- char *line_comment;    /* Comments 'til end of line with this */
- char string_constant;  /* Character denoting string constant */
- char char_constant;    /* Character denoting character constant */
- char preproc_cmd;      /* Character denoting preprocessor commnand*/
- char quoting_char;     /* Quote the next character */
- char continue_char;    /* Line continues if this is last character*/
- unsigned char insensitive;      /* Set when language is not case sensitive */
- int continue_column;            /* Continues previous line if anything in
-                                    the column (works?) */
- int comment_column;             /* Comments from this column on */
+  typedef struct wpeSyntaxRule
+  {
+    char **reserved_word;	/* Reserved words */
+    char **long_operator;	/* Operators longer than a single character */
+    char *single_operator;	/* Single character operators */
+    char *begin_comment;	/* Comments begin with this string */
+    char *end_comment;		/* Comments end with this string */
+    char *line_comment;		/* Comments 'til end of line with this */
+    char string_constant;	/* Character denoting string constant */
+    char char_constant;		/* Character denoting character constant */
+    char preproc_cmd;		/* Character denoting preprocessor commnand */
+    char quoting_char;		/* Quote the next character */
+    char continue_char;		/* Line continues if this is last character */
+    unsigned char insensitive;	/* Set when language is not case sensitive */
+    int continue_column;	/* Continues previous line if anything in
+				   the column (works?) */
+    int comment_column;		/* Comments from this column on */
 
- /* If any character from the special comment string is found in the special
-   column the rest of the line is a comment */
- int special_column;
- char *special_comment;
-} WpeSyntaxRule;
+    /* If any character from the special comment string is found in the special
+       column the rest of the line is a comment */
+    int special_column;
+    char *special_comment;
+  } WpeSyntaxRule;
 
-typedef struct wpeSyntaxExt {
- char **extension;
- WpeSyntaxRule *syntax_rule;
-} WpeSyntaxExt;
+  typedef struct wpeSyntaxExt
+  {
+    char **extension;
+    WpeSyntaxRule *syntax_rule;
+  } WpeSyntaxExt;
 
 /* Necessary for the time being */
-extern WpeSyntaxExt **WpeSyntaxDef;
+  extern WpeSyntaxExt **WpeSyntaxDef;
 
 /* WeSyntax.h */
-void WpeSyntaxReadFile(ECNT *cn);
+  void WpeSyntaxReadFile (ECNT * cn);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   Macros and Machine specific information
@@ -61,4 +64,3 @@ void WpeSyntaxReadFile(ECNT *cn);
 #endif
 
 #endif
-

--- a/src/WeString.c
+++ b/src/WeString.c
@@ -24,121 +24,130 @@
 #include <ctype.h>
 
 
-int WpeStrnccmp(const char *s1, const char *s2, int n)
+int
+WpeStrnccmp (const char *s1, const char *s2, int n)
 {
- /* Added a check for end of string. */
- for (; (n > 0) && (*s1) && (toupper(*s1) == toupper(*s2));
-      n--, s1++, s2++) ;
- return(n > 0 ? toupper(*s1) - toupper(*s2) : 0);
+  /* Added a check for end of string. */
+  for (; (n > 0) && (*s1) && (toupper (*s1) == toupper (*s2));
+       n--, s1++, s2++);
+  return (n > 0 ? toupper (*s1) - toupper (*s2) : 0);
 }
 
-int WpeStrccmp(const char *s1, const char *s2)
+int
+WpeStrccmp (const char *s1, const char *s2)
 {
- for (; (*s1) && (toupper(*s1) == toupper(*s2)); s1++, s2++) ;
- return(toupper(*s1) - toupper(*s2));
+  for (; (*s1) && (toupper (*s1) == toupper (*s2)); s1++, s2++);
+  return (toupper (*s1) - toupper (*s2));
 }
 
-char *WpeStrcstr(char *str, const char *substr)
+char *
+WpeStrcstr (char *str, const char *substr)
 {
- const int len = strlen(substr);
+  const int len = strlen (substr);
 
- for (; *str; str++)
- {
-  if (WpeStrnccmp(str, substr, len) == 0)
-  {
-   return(str);
-  }
- }
- return(NULL);
+  for (; *str; str++)
+    {
+      if (WpeStrnccmp (str, substr, len) == 0)
+	{
+	  return (str);
+	}
+    }
+  return (NULL);
 }
 
-char *WpeStrdup(const char *str)
+char *
+WpeStrdup (const char *str)
 {
- char *newstr;
- 
- newstr = malloc((strlen(str)+1)*sizeof(char));
- if (newstr != NULL)
- {
-  strcpy(newstr, str);
- }
- return(newstr);
+  char *newstr;
+
+  newstr = malloc ((strlen (str) + 1) * sizeof (char));
+  if (newstr != NULL)
+    {
+      strcpy (newstr, str);
+    }
+  return (newstr);
 }
 
-int WpeNumberOfPlaces(int n)
+int
+WpeNumberOfPlaces (int n)
 {
- int i;
+  int i;
 
- if (n == 0)
- {
-  return(1);
- }
- else if (n < 0)
- {
-  n = -n;
- }
- for (i = 0; n > 0; n /= 10, i++) ;
- return(i);
+  if (n == 0)
+    {
+      return (1);
+    }
+  else if (n < 0)
+    {
+      n = -n;
+    }
+  for (i = 0; n > 0; n /= 10, i++);
+  return (i);
 }
 
-char *WpeNumberToString(int n, int len, char *s)
+char *
+WpeNumberToString (int n, int len, char *s)
 {
- int nlen;
+  int nlen;
 
- nlen = WpeNumberOfPlaces(n);
- if (nlen > len)
- {
-  nlen = len;
- }
- else
- {
-  memset(s, ' ', len - nlen);
- }
- s[len] = '\0';
- for (; nlen > 0 ; n /= 10, nlen--)
- {
-  len--;
-  s[len] = (n % 10) + '0';
- }
- return(s);
+  nlen = WpeNumberOfPlaces (n);
+  if (nlen > len)
+    {
+      nlen = len;
+    }
+  else
+    {
+      memset (s, ' ', len - nlen);
+    }
+  s[len] = '\0';
+  for (; nlen > 0; n /= 10, nlen--)
+    {
+      len--;
+      s[len] = (n % 10) + '0';
+    }
+  return (s);
 }
 
-int WpeStringToNumber(const char *s)
+int
+WpeStringToNumber (const char *s)
 {
- /* This checking of blanks is probably not needed. */
- while ((*s) == ' ')
- {
-  s++;
- }
- return(atoi(s));
+  /* This checking of blanks is probably not needed. */
+  while ((*s) == ' ')
+    {
+      s++;
+    }
+  return (atoi (s));
 }
 
-char *WpeStringToUpper(char *s)
+char *
+WpeStringToUpper (char *s)
 {
- char *s2;
+  char *s2;
 
- for (s2 = s; *s2; s2++)
- {
-  *s2 = toupper(*s2);
- }
- return (s);
+  for (s2 = s; *s2; s2++)
+    {
+      *s2 = toupper (*s2);
+    }
+  return (s);
 }
 
-char *WpeStringBlank(char *s, int len)
+char *
+WpeStringBlank (char *s, int len)
 {
- memset(s, ' ', len);
- s[len] = '\0';
- return(s);
+  memset (s, ' ', len);
+  s[len] = '\0';
+  return (s);
 }
 
-char *WpeStringCutChar(char *s, char c)
+char *
+WpeStringCutChar (char *s, char c)
 {
- char *tmp;
+  char *tmp;
 
- tmp = strrchr(s, c);
- if (tmp != NULL)
- {
-  *tmp = '\0';
- }
- return(s);
+  tmp = strrchr (s, c);
+  if (tmp != NULL)
+    {
+      *tmp = '\0';
+    }
+  return (s);
 }
-

--- a/src/WeString.h
+++ b/src/WeString.h
@@ -8,7 +8,8 @@
 \*-------------------------------------------------------------------------*/
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 
@@ -22,7 +23,7 @@ characters.
       n            (In)  Maximum number of characters to compare
     Returns: Zero if equal.  Anything else means not equal.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-int WpeStrnccmp(const char *s1, const char *s2, int n);
+  int WpeStrnccmp (const char *s1, const char *s2, int n);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeStrccmp - Case-insensitive compare of two strings.
@@ -32,7 +33,7 @@ int WpeStrnccmp(const char *s1, const char *s2, int n);
       s2           (In)  Second string
     Returns: Zero if equal.  Anything else means not equal.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-int WpeStrccmp(const char *s1, const char *s2);
+  int WpeStrccmp (const char *s1, const char *s2);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeStrcstr - Case-insensitive substring search.
@@ -43,7 +44,7 @@ int WpeStrccmp(const char *s1, const char *s2);
     Returns: Pointer to the beginning of the substring in the main string.
   NULL if the substring is not found.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-char *WpeStrcstr(char *str, const char *substr);
+  char *WpeStrcstr (char *str, const char *substr);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeStrdup - Duplicate a string.
@@ -53,7 +54,7 @@ char *WpeStrcstr(char *str, const char *substr);
     Returns: Pointer to new string created with malloc().  NULL if
   insufficient memory free to create the string.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-char *WpeStrdup(const char *str);
+  char *WpeStrdup (const char *str);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeNumberOfPlaces - Number of places in a number excluding the sign.
@@ -62,7 +63,7 @@ char *WpeStrdup(const char *str);
       n            (In)  Number
     Returns: The number of places.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-int WpeNumberOfPlaces(int n);
+  int WpeNumberOfPlaces (int n);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeNumberToString - Converts a number to a string.
@@ -73,7 +74,7 @@ int WpeNumberOfPlaces(int n);
       s            (In & Out) Converted number
     Returns: Pointer to the converted number string
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-char *WpeNumberToString(int n, int len, char *s);
+  char *WpeNumberToString (int n, int len, char *s);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeStringToNumber - Converts a string to a number.
@@ -82,7 +83,7 @@ char *WpeNumberToString(int n, int len, char *s);
       s            (In)  String to be converted to a number
     Returns: The string's number value
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-int WpeStringToNumber(const char *s);
+  int WpeStringToNumber (const char *s);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeStringToUpper - Converts a string to all uppercase.
@@ -91,7 +92,7 @@ int WpeStringToNumber(const char *s);
       s            (In & Out) String to be converted to uppercase
     Returns: Pointer to the uppercase string
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-char *WpeStringToUpper(char *s);
+  char *WpeStringToUpper (char *s);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeStringBlank - Fills a string with blank spaces.
@@ -101,7 +102,7 @@ char *WpeStringToUpper(char *s);
       len          (In)  Length of the string (excluding '\0')
     Returns: The blanked string.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-char *WpeStringBlank(char *s, int len);
+  char *WpeStringBlank (char *s, int len);
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeStringCutChar - Cuts a string at the last occurance of a character.
@@ -111,11 +112,10 @@ char *WpeStringBlank(char *s, int len);
       c            (In) Character to cut off
     Returns: The cut string.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-char *WpeStringCutChar(char *s, char c);
+  char *WpeStringCutChar (char *s, char c);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/src/WeSyntax.c
+++ b/src/WeSyntax.c
@@ -26,37 +26,37 @@
 #include "WeSyntax.h"
 
 char *WpeCReservedWord[] = {
- "auto", "break", "case", "char", "const", "continue", "default", "do",
- "double", "else", "enum", "extern", "float", "for", "goto", "if", "int",
- "long", "register", "return", "short", "signed", "sizeof", "static",
- "struct", "switch", "typedef", "union", "unsigned", "void", "volatile",
- "while", NULL
+  "auto", "break", "case", "char", "const", "continue", "default", "do",
+  "double", "else", "enum", "extern", "float", "for", "goto", "if", "int",
+  "long", "register", "return", "short", "signed", "sizeof", "static",
+  "struct", "switch", "typedef", "union", "unsigned", "void", "volatile",
+  "while", NULL
 };
 
 char *WpeCxxReservedWord[] = {
- "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break", "case",
- "catch", "char", "class", "compl", "const", "const_cast", "continue",
- "default", "delete", "do", "double", "dynamic_cast", "else", "enum",
- "explicit", "extern", "false", "float", "for", "friend", "goto", "if",
- "inline", "int", "long", "mutable", "namespace", "new", "not", "not_eq",
- "operator", "or", "or_eq", "private", "protected", "public", "register",
- "reinterpret_cast", "return", "short", "signed", "sizeof", "static",
- "static_cast", "struct", "switch", "template", "this", "throw", "true",
- "try", "typedef", "typeid", "typename", "union", "unsigned", "using",
- "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq", NULL
+  "and", "and_eq", "asm", "auto", "bitand", "bitor", "bool", "break", "case",
+  "catch", "char", "class", "compl", "const", "const_cast", "continue",
+  "default", "delete", "do", "double", "dynamic_cast", "else", "enum",
+  "explicit", "extern", "false", "float", "for", "friend", "goto", "if",
+  "inline", "int", "long", "mutable", "namespace", "new", "not", "not_eq",
+  "operator", "or", "or_eq", "private", "protected", "public", "register",
+  "reinterpret_cast", "return", "short", "signed", "sizeof", "static",
+  "static_cast", "struct", "switch", "template", "this", "throw", "true",
+  "try", "typedef", "typeid", "typename", "union", "unsigned", "using",
+  "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq", NULL
 };
 
 #define WpeCLongOperator NULL
 #define WpeCxxLongOperator NULL
 
 WpeSyntaxRule WpeCSyntaxRule = {
- WpeCReservedWord, WpeCLongOperator, "~^()[]{}<>+-/*%=|&!.?:,;", "/*", "*/",
- "", '\"', '\'', '#', '\\', '\\', '\0', -1, 1000, -1, ""
+  WpeCReservedWord, WpeCLongOperator, "~^()[]{}<>+-/*%=|&!.?:,;", "/*", "*/",
+  "", '\"', '\'', '#', '\\', '\\', '\0', -1, 1000, -1, ""
 };
 
 WpeSyntaxRule WpeCxxSyntaxRule = {
- WpeCxxReservedWord, WpeCxxLongOperator, "~^()[]{}<>+-/*%=|&!.?:,;", "/*",
- "*/", "//", '\"', '\'', '#', '\\', '\\', '\0', -1, 1000, -1, ""
+  WpeCxxReservedWord, WpeCxxLongOperator, "~^()[]{}<>+-/*%=|&!.?:,;", "/*",
+  "*/", "//", '\"', '\'', '#', '\\', '\\', '\0', -1, 1000, -1, ""
 };
 
 /* Definition of all programming language syntax (Note: This is an expandable
@@ -64,9 +64,10 @@ WpeSyntaxRule WpeCxxSyntaxRule = {
 WpeSyntaxExt **WpeSyntaxDef = NULL;
 
 
-int WpeReservedWordCompare(const void *x, const void *y)
+int
+WpeReservedWordCompare (const void *x, const void *y)
 {
- return (strcmp(*((char **)x), *((char **)y)));
+  return (strcmp (*((char **) x), *((char **) y)));
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -75,192 +76,204 @@ int WpeReservedWordCompare(const void *x, const void *y)
     Parameters:
       cn           (In)  Part of old code needed for e_error
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeSyntaxReadFile(ECNT *cn)
+void
+WpeSyntaxReadFile (ECNT * cn)
 {
- FILE *syntax_file;
- WpeSyntaxExt *new_syntax;
- char tmp[128];
- int reserved_num, long_op_num;
- int i, k;
+  FILE *syntax_file;
+  WpeSyntaxExt *new_syntax;
+  char tmp[128];
+  int reserved_num, long_op_num;
+  int i, k;
 
- WpeSyntaxDef = (WpeSyntaxExt **)WpeExpArrayCreate(0, sizeof(WpeSyntaxExt *), 4);
- sprintf(tmp, "%s/%s/%s", getenv("HOME"), XWPE_HOME, SYNTAX_FILE);
+  WpeSyntaxDef =
+    (WpeSyntaxExt **) WpeExpArrayCreate (0, sizeof (WpeSyntaxExt *), 4);
+  sprintf (tmp, "%s/%s/%s", getenv ("HOME"), XWPE_HOME, SYNTAX_FILE);
 
- if ((syntax_file = fopen(tmp, "r")) == NULL)
- {
-  sprintf(tmp, "%s/%s", DATADIR, SYNTAX_FILE);
-  if ((syntax_file = fopen(tmp, "r")) == NULL)
-  {
-   /* C Syntax (".c" extension) */
-   new_syntax = malloc(sizeof(WpeSyntaxExt));
-   new_syntax->extension = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
-   new_syntax->extension[0] = strdup(".c");
-   new_syntax->syntax_rule = &WpeCSyntaxRule;
-   WpeExpArrayAdd((void **)&WpeSyntaxDef, &new_syntax);
-   /* C++ Syntax (".C", ".cpp", ".cxx", ".cc", ".h", and ".hpp" extensions) */
-   new_syntax = malloc(sizeof(WpeSyntaxExt));
-   new_syntax->extension = (char **)WpeExpArrayCreate(6, sizeof(char *), 1);
-   new_syntax->extension[0] = strdup(".C");
-   new_syntax->extension[1] = strdup(".cpp");
-   new_syntax->extension[2] = strdup(".cxx");
-   new_syntax->extension[3] = strdup(".cc");
-   new_syntax->extension[4] = strdup(".h");
-   new_syntax->extension[5] = strdup(".hpp");
-   new_syntax->syntax_rule = &WpeCxxSyntaxRule;
-   WpeExpArrayAdd((void **)&WpeSyntaxDef, &new_syntax);
-   /*WpeSyntaxDef[2] = &WpeHSyntaxExt;*/
-   return ;
-  }
- }
- while (fscanf(syntax_file, "%s", tmp) == 1)
- {
-  new_syntax = malloc(sizeof(WpeSyntaxExt));
-  i = atoi(tmp);
-  if (i > 0)
-  {
-   new_syntax->extension = (char **)WpeExpArrayCreate(i, sizeof(char *), 1);
-   for (k = 0; k < i; k++)
-   {
-    if (fscanf(syntax_file, "%s", tmp) != 1)
+  if ((syntax_file = fopen (tmp, "r")) == NULL)
     {
-     e_error("Error reading syntax_def", 0, cn->fb);
-     return ;
+      sprintf (tmp, "%s/%s", DATADIR, SYNTAX_FILE);
+      if ((syntax_file = fopen (tmp, "r")) == NULL)
+	{
+	  /* C Syntax (".c" extension) */
+	  new_syntax = malloc (sizeof (WpeSyntaxExt));
+	  new_syntax->extension =
+	    (char **) WpeExpArrayCreate (1, sizeof (char *), 1);
+	  new_syntax->extension[0] = strdup (".c");
+	  new_syntax->syntax_rule = &WpeCSyntaxRule;
+	  WpeExpArrayAdd ((void **) &WpeSyntaxDef, &new_syntax);
+	  /* C++ Syntax (".C", ".cpp", ".cxx", ".cc", ".h", and ".hpp" extensions) */
+	  new_syntax = malloc (sizeof (WpeSyntaxExt));
+	  new_syntax->extension =
+	    (char **) WpeExpArrayCreate (6, sizeof (char *), 1);
+	  new_syntax->extension[0] = strdup (".C");
+	  new_syntax->extension[1] = strdup (".cpp");
+	  new_syntax->extension[2] = strdup (".cxx");
+	  new_syntax->extension[3] = strdup (".cc");
+	  new_syntax->extension[4] = strdup (".h");
+	  new_syntax->extension[5] = strdup (".hpp");
+	  new_syntax->syntax_rule = &WpeCxxSyntaxRule;
+	  WpeExpArrayAdd ((void **) &WpeSyntaxDef, &new_syntax);
+	  /*WpeSyntaxDef[2] = &WpeHSyntaxExt; */
+	  return;
+	}
     }
-    new_syntax->extension[k] = WpeStrdup(tmp);
-   }
-  }
-  else
-  {
-   new_syntax->extension = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
-   new_syntax->extension[0] = WpeStrdup(tmp);
-  }
-  new_syntax->syntax_rule = malloc(sizeof(WpeSyntaxRule));
-  if (fscanf(syntax_file, "%d", &reserved_num) != 1)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  new_syntax->syntax_rule->reserved_word = malloc((reserved_num + 1) *
-                                                     sizeof(char *));
-  for (i = 0; i < reserved_num; i++)
-  {
-   if (fscanf(syntax_file, "%s", tmp) != 1)
-   {
-    e_error("Error reading syntax_def", 0, cn->fb);
-    return ;
-   }
-   new_syntax->syntax_rule->reserved_word[i] = WpeStrdup(tmp);
-  }
-  new_syntax->syntax_rule->reserved_word[i] = NULL;
-  if (fscanf(syntax_file, "%d", &long_op_num) != 1)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  new_syntax->syntax_rule->long_operator = malloc((long_op_num + 1) *
-                                                     sizeof(char *));
-  for (i = 0; i < long_op_num; i++)
-  {
-   if (fscanf(syntax_file, "%s", tmp) != 1)
-   {
-    e_error("Error reading syntax_def", 0, cn->fb);
-    return ;
-   }
-   new_syntax->syntax_rule->long_operator[i] = WpeStrdup(tmp);
-  }
-  new_syntax->syntax_rule->long_operator[i] = NULL;
-  if (fscanf(syntax_file, "%s", tmp) != 1)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  new_syntax->syntax_rule->single_operator = WpeStrdup(strcmp(tmp, "NULL") ? tmp : "");
-  if (fscanf(syntax_file, "%s", tmp) != 1)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  new_syntax->syntax_rule->begin_comment = WpeStrdup(strcmp(tmp, "NULL") ? tmp : "");
-  if (fscanf(syntax_file, "%s", tmp) != 1)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  new_syntax->syntax_rule->end_comment = WpeStrdup(strcmp(tmp, "NULL") ? tmp : "");
-  if (fscanf(syntax_file, "%s", tmp) != 1)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  new_syntax->syntax_rule->line_comment = WpeStrdup(strcmp(tmp, "NULL") ? tmp : "");
-  if (fscanf(syntax_file, "%s", tmp) != 1)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  new_syntax->syntax_rule->special_comment = WpeStrdup(strcmp(tmp, "NULL") ? tmp : "");
-  if (fscanf(syntax_file, " %c%c%c%c%c%c",
-             &new_syntax->syntax_rule->string_constant,
-             &new_syntax->syntax_rule->char_constant,
-             &new_syntax->syntax_rule->preproc_cmd,
-             &new_syntax->syntax_rule->quoting_char,
-             &new_syntax->syntax_rule->continue_char,
-             &new_syntax->syntax_rule->insensitive) != 6)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  /* This is currently a mess but this format of syntax_def is unlikely to
-    stay - Dennis */
-  if (new_syntax->syntax_rule->string_constant == ' ')
-  {
-   new_syntax->syntax_rule->string_constant = '\0';
-  }
-  if (new_syntax->syntax_rule->char_constant == ' ')
-  {
-   new_syntax->syntax_rule->char_constant = '\0';
-  }
-  if (new_syntax->syntax_rule->preproc_cmd == ' ')
-  {
-   new_syntax->syntax_rule->preproc_cmd = '\0';
-  }
-  if (new_syntax->syntax_rule->quoting_char == ' ')
-  {
-   new_syntax->syntax_rule->quoting_char = '\0';
-  }
-  if (new_syntax->syntax_rule->continue_char == ' ')
-  {
-   new_syntax->syntax_rule->continue_char = '\0';
-  }
-  if (new_syntax->syntax_rule->insensitive == ' ')
-  {
-   new_syntax->syntax_rule->insensitive = '\0';
-  }
-  else
-  {
-   /* Convert all reserved words to upper case for case insensitive syntax */
-   for (i = 0; new_syntax->syntax_rule->reserved_word[i]; i++)
-   {
-    WpeStringToUpper(new_syntax->syntax_rule->reserved_word[i]);
-   }
-   /* Convert all long operators to upper case for case insensitive syntax */
-   for (i = 0; new_syntax->syntax_rule->long_operator[i]; i++)
-   {
-    WpeStringToUpper(new_syntax->syntax_rule->long_operator[i]);
-   }
-  }
-  if (fscanf(syntax_file, "%d%d%d", &new_syntax->syntax_rule->special_column,
-             &new_syntax->syntax_rule->continue_column,
-             &new_syntax->syntax_rule->comment_column) != 3)
-  {
-   e_error("Error reading syntax_def", 0, cn->fb);
-   return ;
-  }
-  qsort(new_syntax->syntax_rule->reserved_word, reserved_num, sizeof(char *),
-        WpeReservedWordCompare);
-  qsort(new_syntax->syntax_rule->long_operator, long_op_num, sizeof(char *),
-        WpeReservedWordCompare);
-  WpeExpArrayAdd((void **)&WpeSyntaxDef, &new_syntax);
- }
+  while (fscanf (syntax_file, "%s", tmp) == 1)
+    {
+      new_syntax = malloc (sizeof (WpeSyntaxExt));
+      i = atoi (tmp);
+      if (i > 0)
+	{
+	  new_syntax->extension =
+	    (char **) WpeExpArrayCreate (i, sizeof (char *), 1);
+	  for (k = 0; k < i; k++)
+	    {
+	      if (fscanf (syntax_file, "%s", tmp) != 1)
+		{
+		  e_error ("Error reading syntax_def", 0, cn->fb);
+		  return;
+		}
+	      new_syntax->extension[k] = WpeStrdup (tmp);
+	    }
+	}
+      else
+	{
+	  new_syntax->extension =
+	    (char **) WpeExpArrayCreate (1, sizeof (char *), 1);
+	  new_syntax->extension[0] = WpeStrdup (tmp);
+	}
+      new_syntax->syntax_rule = malloc (sizeof (WpeSyntaxRule));
+      if (fscanf (syntax_file, "%d", &reserved_num) != 1)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      new_syntax->syntax_rule->reserved_word = malloc ((reserved_num + 1) *
+						       sizeof (char *));
+      for (i = 0; i < reserved_num; i++)
+	{
+	  if (fscanf (syntax_file, "%s", tmp) != 1)
+	    {
+	      e_error ("Error reading syntax_def", 0, cn->fb);
+	      return;
+	    }
+	  new_syntax->syntax_rule->reserved_word[i] = WpeStrdup (tmp);
+	}
+      new_syntax->syntax_rule->reserved_word[i] = NULL;
+      if (fscanf (syntax_file, "%d", &long_op_num) != 1)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      new_syntax->syntax_rule->long_operator = malloc ((long_op_num + 1) *
+						       sizeof (char *));
+      for (i = 0; i < long_op_num; i++)
+	{
+	  if (fscanf (syntax_file, "%s", tmp) != 1)
+	    {
+	      e_error ("Error reading syntax_def", 0, cn->fb);
+	      return;
+	    }
+	  new_syntax->syntax_rule->long_operator[i] = WpeStrdup (tmp);
+	}
+      new_syntax->syntax_rule->long_operator[i] = NULL;
+      if (fscanf (syntax_file, "%s", tmp) != 1)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      new_syntax->syntax_rule->single_operator =
+	WpeStrdup (strcmp (tmp, "NULL") ? tmp : "");
+      if (fscanf (syntax_file, "%s", tmp) != 1)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      new_syntax->syntax_rule->begin_comment =
+	WpeStrdup (strcmp (tmp, "NULL") ? tmp : "");
+      if (fscanf (syntax_file, "%s", tmp) != 1)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      new_syntax->syntax_rule->end_comment =
+	WpeStrdup (strcmp (tmp, "NULL") ? tmp : "");
+      if (fscanf (syntax_file, "%s", tmp) != 1)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      new_syntax->syntax_rule->line_comment =
+	WpeStrdup (strcmp (tmp, "NULL") ? tmp : "");
+      if (fscanf (syntax_file, "%s", tmp) != 1)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      new_syntax->syntax_rule->special_comment =
+	WpeStrdup (strcmp (tmp, "NULL") ? tmp : "");
+      if (fscanf
+	  (syntax_file, " %c%c%c%c%c%c",
+	   &new_syntax->syntax_rule->string_constant,
+	   &new_syntax->syntax_rule->char_constant,
+	   &new_syntax->syntax_rule->preproc_cmd,
+	   &new_syntax->syntax_rule->quoting_char,
+	   &new_syntax->syntax_rule->continue_char,
+	   &new_syntax->syntax_rule->insensitive) != 6)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      /* This is currently a mess but this format of syntax_def is unlikely to
+         stay - Dennis */
+      if (new_syntax->syntax_rule->string_constant == ' ')
+	{
+	  new_syntax->syntax_rule->string_constant = '\0';
+	}
+      if (new_syntax->syntax_rule->char_constant == ' ')
+	{
+	  new_syntax->syntax_rule->char_constant = '\0';
+	}
+      if (new_syntax->syntax_rule->preproc_cmd == ' ')
+	{
+	  new_syntax->syntax_rule->preproc_cmd = '\0';
+	}
+      if (new_syntax->syntax_rule->quoting_char == ' ')
+	{
+	  new_syntax->syntax_rule->quoting_char = '\0';
+	}
+      if (new_syntax->syntax_rule->continue_char == ' ')
+	{
+	  new_syntax->syntax_rule->continue_char = '\0';
+	}
+      if (new_syntax->syntax_rule->insensitive == ' ')
+	{
+	  new_syntax->syntax_rule->insensitive = '\0';
+	}
+      else
+	{
+	  /* Convert all reserved words to upper case for case insensitive syntax */
+	  for (i = 0; new_syntax->syntax_rule->reserved_word[i]; i++)
+	    {
+	      WpeStringToUpper (new_syntax->syntax_rule->reserved_word[i]);
+	    }
+	  /* Convert all long operators to upper case for case insensitive syntax */
+	  for (i = 0; new_syntax->syntax_rule->long_operator[i]; i++)
+	    {
+	      WpeStringToUpper (new_syntax->syntax_rule->long_operator[i]);
+	    }
+	}
+      if (fscanf
+	  (syntax_file, "%d%d%d", &new_syntax->syntax_rule->special_column,
+	   &new_syntax->syntax_rule->continue_column,
+	   &new_syntax->syntax_rule->comment_column) != 3)
+	{
+	  e_error ("Error reading syntax_def", 0, cn->fb);
+	  return;
+	}
+      qsort (new_syntax->syntax_rule->reserved_word, reserved_num,
+	     sizeof (char *), WpeReservedWordCompare);
+      qsort (new_syntax->syntax_rule->long_operator, long_op_num,
+	     sizeof (char *), WpeReservedWordCompare);
+      WpeExpArrayAdd ((void **) &WpeSyntaxDef, &new_syntax);
+    }
 }
-

--- a/src/WeXterm.c
+++ b/src/WeXterm.c
@@ -36,7 +36,7 @@
 #include "WeXterm.h"
 
 #ifndef DEFAULT_ALTMASK
-#if defined(__linux__) || defined(__osf__)			/* a.r. */
+#if defined(__linux__) || defined(__osf__)	/* a.r. */
 #define DEFAULT_ALTMASK Mod1Mask
 #else
 #define DEFAULT_ALTMASK Mod4Mask
@@ -48,39 +48,40 @@ WpeXStruct WpeXInfo;
 
 /* Standard colors (after initialization pointers may not be valid) */
 static char *WpeXColorNames[16] = {
- "Black",
- "Red3",
- "Forest Green",
- "Brown",
- "Dark Slate Blue",
- "Violet Red",
- "Turquoise3",
- "Light Gray",
- "Dark Slate Grey",
- "Red1",
- "Green",
- "Yellow",
- "Blue",
- "Violet",
- "Turquoise1",
- "White"
+  "Black",
+  "Red3",
+  "Forest Green",
+  "Brown",
+  "Dark Slate Blue",
+  "Violet Red",
+  "Turquoise3",
+  "Light Gray",
+  "Dark Slate Grey",
+  "Red1",
+  "Green",
+  "Yellow",
+  "Blue",
+  "Violet",
+  "Turquoise1",
+  "White"
 };
 
 #define OPTION_TABLE_SIZE 7
 
 /* Translation table for command line option to X resources */
 static XrmOptionDescRec WpeXOptionTable[OPTION_TABLE_SIZE] = {
- {"-display",  ".display",  XrmoptionSepArg, (XPointer) NULL},
- {"-fn",       ".font",     XrmoptionSepArg, (XPointer) NULL},
- {"-font",     ".font",     XrmoptionSepArg, (XPointer) NULL},
- {"-g",        ".geometry", XrmoptionSepArg, (XPointer) NULL},
- {"-geometry", ".geometry", XrmoptionSepArg, (XPointer) NULL},
- {"-iconic",   ".iconic",   XrmoptionNoArg,  (XPointer) "on"},
- {"-pcmap",    ".pcmap",    XrmoptionNoArg,  (XPointer) "on"}
+  {"-display", ".display", XrmoptionSepArg, (XPointer) NULL},
+  {"-fn", ".font", XrmoptionSepArg, (XPointer) NULL},
+  {"-font", ".font", XrmoptionSepArg, (XPointer) NULL},
+  {"-g", ".geometry", XrmoptionSepArg, (XPointer) NULL},
+  {"-geometry", ".geometry", XrmoptionSepArg, (XPointer) NULL},
+  {"-iconic", ".iconic", XrmoptionNoArg, (XPointer) "on"},
+  {"-pcmap", ".pcmap", XrmoptionNoArg, (XPointer) "on"}
 };
 
 /* Shape for mouse in X */
-static int WpeXMouseDefault[WpeLastShape] = {132, 142, 150, 88, 124};
+static int WpeXMouseDefault[WpeLastShape] = { 132, 142, 150, 88, 124 };
+
 static Cursor WpeXMouseCursor[WpeLastShape];
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -91,41 +92,42 @@ static Cursor WpeXMouseCursor[WpeLastShape];
       name_list    (In)  Name quark list (second element unset)
       class_list   (In)  Class quark list (second element unset)
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXFontGet(XrmDatabase xresdb, XrmQuark *name_list,
-                 XrmQuark *class_list)
+void
+WpeXFontGet (XrmDatabase xresdb, XrmQuark * name_list, XrmQuark * class_list)
 {
- char *font_name = "8x13";
- XrmRepresentation return_value;
- XrmValue xval;
+  char *font_name = "8x13";
+  XrmRepresentation return_value;
+  XrmValue xval;
 
- name_list[1] = XrmStringToQuark("font");
- class_list[1] = XrmStringToQuark("Font");
- if (XrmQGetResource(xresdb, name_list, class_list, &return_value, &xval))
- {
-  font_name = (char *)xval.addr;
- }
- if((WpeXInfo.font = XLoadQueryFont(WpeXInfo.display, font_name)) == NULL)
- {
-  fprintf(stderr, "Xwpe: unable to open font \"%s\", exiting ...\n",
-    font_name);
-  exit(-1);
- }
- if (WpeXInfo.font->max_bounds.width != WpeXInfo.font->min_bounds.width)
- {
-  fprintf(stderr, "Xwpe: Font \"%s\" not fixed width using default\n",
-    font_name);
-  font_name = "8x13";
-  if((WpeXInfo.font = XLoadQueryFont(WpeXInfo.display, font_name)) == NULL)
-  {
-   fprintf(stderr, "Xwpe: unable to open font \"%s\", exiting ...\n",
-     font_name);
-   exit(-1);
-  }
- }
- WpeXInfo.font_height = WpeXInfo.font->max_bounds.ascent +
-                        WpeXInfo.font->max_bounds.descent;
- WpeXInfo.font_width = WpeXInfo.font->max_bounds.width;
- return ;
+  name_list[1] = XrmStringToQuark ("font");
+  class_list[1] = XrmStringToQuark ("Font");
+  if (XrmQGetResource (xresdb, name_list, class_list, &return_value, &xval))
+    {
+      font_name = (char *) xval.addr;
+    }
+  if ((WpeXInfo.font = XLoadQueryFont (WpeXInfo.display, font_name)) == NULL)
+    {
+      fprintf (stderr, "Xwpe: unable to open font \"%s\", exiting ...\n",
+	       font_name);
+      exit (-1);
+    }
+  if (WpeXInfo.font->max_bounds.width != WpeXInfo.font->min_bounds.width)
+    {
+      fprintf (stderr, "Xwpe: Font \"%s\" not fixed width using default\n",
+	       font_name);
+      font_name = "8x13";
+      if ((WpeXInfo.font =
+	   XLoadQueryFont (WpeXInfo.display, font_name)) == NULL)
+	{
+	  fprintf (stderr, "Xwpe: unable to open font \"%s\", exiting ...\n",
+		   font_name);
+	  exit (-1);
+	}
+    }
+  WpeXInfo.font_height = WpeXInfo.font->max_bounds.ascent +
+    WpeXInfo.font->max_bounds.descent;
+  WpeXInfo.font_width = WpeXInfo.font->max_bounds.width;
+  return;
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -136,83 +138,86 @@ void WpeXFontGet(XrmDatabase xresdb, XrmQuark *name_list,
       name_list    (In)  Name quark list (second element unset)
       class_list   (In)  Class quark list (second element unset)
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXColorGet(XrmDatabase xresdb, XrmQuark *name_list,
-                  XrmQuark *class_list)
+void
+WpeXColorGet (XrmDatabase xresdb, XrmQuark * name_list, XrmQuark * class_list)
 {
- XrmRepresentation return_value;
- XrmValue xval;
- Colormap cmap;
- XColor exact_def;
- Visual *visual;
- int loop, depth;
- char color_name[8];
- char color_class[8];
- Screen *xscreen;
+  XrmRepresentation return_value;
+  XrmValue xval;
+  Colormap cmap;
+  XColor exact_def;
+  Visual *visual;
+  int loop, depth;
+  char color_name[8];
+  char color_class[8];
+  Screen *xscreen;
 
- memset(color_name, 0, 8);
- memset(color_class, 0, 8);
- strcpy(color_name, "color");
- strcpy(color_class, "Color");
- for (loop = 0; loop < 16; loop++)
- {
-  /* color names start at 1 not 0 */
-  color_name[5] = color_class[5] = (loop < 9)? loop + '1': '1';
-  if (loop > 8)
-  {
-   color_name[6] = color_class[6] = loop - 9 + '0';
-  }
-  name_list[1] = XrmStringToQuark(color_name);
-  class_list[1] = XrmStringToQuark(color_name);
-  if (XrmQGetResource(xresdb, name_list, class_list, &return_value, &xval))
-  {
-   WpeXColorNames[loop] = (char *)xval.addr;
-  }
- }
+  memset (color_name, 0, 8);
+  memset (color_class, 0, 8);
+  strcpy (color_name, "color");
+  strcpy (color_class, "Color");
+  for (loop = 0; loop < 16; loop++)
+    {
+      /* color names start at 1 not 0 */
+      color_name[5] = color_class[5] = (loop < 9) ? loop + '1' : '1';
+      if (loop > 8)
+	{
+	  color_name[6] = color_class[6] = loop - 9 + '0';
+	}
+      name_list[1] = XrmStringToQuark (color_name);
+      class_list[1] = XrmStringToQuark (color_name);
+      if (XrmQGetResource
+	  (xresdb, name_list, class_list, &return_value, &xval))
+	{
+	  WpeXColorNames[loop] = (char *) xval.addr;
+	}
+    }
 
- cmap = DefaultColormap(WpeXInfo.display, WpeXInfo.screen);
- depth = DisplayPlanes(WpeXInfo.display, WpeXInfo.screen);
- visual = DefaultVisual(WpeXInfo.display, WpeXInfo.screen);
+  cmap = DefaultColormap (WpeXInfo.display, WpeXInfo.screen);
+  depth = DisplayPlanes (WpeXInfo.display, WpeXInfo.screen);
+  visual = DefaultVisual (WpeXInfo.display, WpeXInfo.screen);
 
- if (depth == 1)
- {
-  /* Old code */
-  /* Error message for depth of one removed */
-  e_X_sw_color();
-  WpeXInfo.colors[0] = BlackPixel(WpeXInfo.display, WpeXInfo.screen);
-  WpeXInfo.colors[1] = WhitePixel(WpeXInfo.display, WpeXInfo.screen);
-  return ;
- }
- /* Check for private colormap option */
- name_list[1] = XrmStringToQuark("pcmap");
- class_list[1] = XrmStringToQuark("Pcmap");
- if (XrmQGetResource(xresdb, name_list, class_list, &return_value, &xval))
- {
-  if (WpeStrccmp((char *)xval.addr, "on") == 0)
-  {
-   xscreen = DefaultScreenOfDisplay(WpeXInfo.display);
-   cmap = XCreateColormap(WpeXInfo.display,
-     RootWindowOfScreen(xscreen), visual, AllocNone);
-   XSetWindowColormap(WpeXInfo.display, WpeXInfo.window, cmap);
-  }
- }
- for(loop = 0; loop < 16; loop++)
- {
-  if (!XParseColor(WpeXInfo.display, cmap, WpeXColorNames[loop], &exact_def))
-  {
-   /* Should try a default color then bail if need be */
-   fprintf(stderr, "xwpe: unable to find color \"%s\", exiting ...\n",
-           WpeXColorNames[loop]);
-   exit(1);
-  }
-  if (!XAllocColor(WpeXInfo.display, cmap, &exact_def))
-  {
-   /* Should try to find closest color */
-   fprintf(stderr, "Xwpe: all colorcells allocated, exiting ...\n");
-   exit(1);
-  }
-  WpeXInfo.colors[loop] = exact_def.pixel;
- }
- return ;
+  if (depth == 1)
+    {
+      /* Old code */
+      /* Error message for depth of one removed */
+      e_X_sw_color ();
+      WpeXInfo.colors[0] = BlackPixel (WpeXInfo.display, WpeXInfo.screen);
+      WpeXInfo.colors[1] = WhitePixel (WpeXInfo.display, WpeXInfo.screen);
+      return;
+    }
+  /* Check for private colormap option */
+  name_list[1] = XrmStringToQuark ("pcmap");
+  class_list[1] = XrmStringToQuark ("Pcmap");
+  if (XrmQGetResource (xresdb, name_list, class_list, &return_value, &xval))
+    {
+      if (WpeStrccmp ((char *) xval.addr, "on") == 0)
+	{
+	  xscreen = DefaultScreenOfDisplay (WpeXInfo.display);
+	  cmap = XCreateColormap (WpeXInfo.display,
+				  RootWindowOfScreen (xscreen), visual,
+				  AllocNone);
+	  XSetWindowColormap (WpeXInfo.display, WpeXInfo.window, cmap);
+	}
+    }
+  for (loop = 0; loop < 16; loop++)
+    {
+      if (!XParseColor
+	  (WpeXInfo.display, cmap, WpeXColorNames[loop], &exact_def))
+	{
+	  /* Should try a default color then bail if need be */
+	  fprintf (stderr, "xwpe: unable to find color \"%s\", exiting ...\n",
+		   WpeXColorNames[loop]);
+	  exit (1);
+	}
+      if (!XAllocColor (WpeXInfo.display, cmap, &exact_def))
+	{
+	  /* Should try to find closest color */
+	  fprintf (stderr, "Xwpe: all colorcells allocated, exiting ...\n");
+	  exit (1);
+	}
+      WpeXInfo.colors[loop] = exact_def.pixel;
+    }
+  return;
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -224,44 +229,46 @@ void WpeXColorGet(XrmDatabase xresdb, XrmQuark *name_list,
       class_list   (In)  Class quark list (second element unset)
       size_hints   (Out) Initial geometry of window
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXGeometryGet(XrmDatabase xresdb, XrmQuark *name_list,
-                     XrmQuark *class_list, XSizeHints *size_hints)
+void
+WpeXGeometryGet (XrmDatabase xresdb, XrmQuark * name_list,
+		 XrmQuark * class_list, XSizeHints * size_hints)
 {
- XrmRepresentation return_value;
- XrmValue xval;
- char geom_str[20];
- int grav;
+  XrmRepresentation return_value;
+  XrmValue xval;
+  char geom_str[20];
+  int grav;
 
- size_hints->flags = PResizeInc | PMinSize | PBaseSize;
- size_hints->height_inc = WpeXInfo.font_height;
- size_hints->width_inc = WpeXInfo.font_width;
- size_hints->min_width = size_hints->width_inc * 80;
- size_hints->min_height = size_hints->height_inc * 24;
- size_hints->base_width = size_hints->base_height = 0;
- name_list[1] = XrmStringToQuark("geometry");
- class_list[1] = XrmStringToQuark("Geometry");
- if (!XrmQGetResource(xresdb, name_list, class_list, &return_value, &xval))
- {
-  xval.addr = NULL;
- }
- size_hints->x = size_hints->y = 0;
- /* Default to 80 columns and a number of lines to fill 3/4th of the screen */
- sprintf(geom_str, "80x%d", (3 *
-         DisplayHeight(WpeXInfo.display, WpeXInfo.screen) / 4) /
-         WpeXInfo.font_height);
- /* This doesn't correctly account for the title bar.  If someone could
-   point me in the right direction for correcting this I'd be grateful. */
- if (XWMGeometry(WpeXInfo.display, WpeXInfo.screen, (char *)xval.addr,
-                 geom_str, 4, size_hints, &size_hints->x, &size_hints->y,
-                 &size_hints->width, &size_hints->height, &grav) &
-     (XValue | YValue))
- {
-  size_hints->flags |= PPosition;
- }
- /* Old variables used since not converted yet */
- MAXSCOL = size_hints->width / WpeXInfo.font_width;
- MAXSLNS = size_hints->height / WpeXInfo.font_height;
- return ;
+  size_hints->flags = PResizeInc | PMinSize | PBaseSize;
+  size_hints->height_inc = WpeXInfo.font_height;
+  size_hints->width_inc = WpeXInfo.font_width;
+  size_hints->min_width = size_hints->width_inc * 80;
+  size_hints->min_height = size_hints->height_inc * 24;
+  size_hints->base_width = size_hints->base_height = 0;
+  name_list[1] = XrmStringToQuark ("geometry");
+  class_list[1] = XrmStringToQuark ("Geometry");
+  if (!XrmQGetResource (xresdb, name_list, class_list, &return_value, &xval))
+    {
+      xval.addr = NULL;
+    }
+  size_hints->x = size_hints->y = 0;
+  /* Default to 80 columns and a number of lines to fill 3/4th of the screen */
+  sprintf (geom_str, "80x%d", (3 *
+			       DisplayHeight (WpeXInfo.display,
+					      WpeXInfo.screen) / 4) /
+	   WpeXInfo.font_height);
+  /* This doesn't correctly account for the title bar.  If someone could
+     point me in the right direction for correcting this I'd be grateful. */
+  if (XWMGeometry (WpeXInfo.display, WpeXInfo.screen, (char *) xval.addr,
+		   geom_str, 4, size_hints, &size_hints->x, &size_hints->y,
+		   &size_hints->width, &size_hints->height, &grav) &
+      (XValue | YValue))
+    {
+      size_hints->flags |= PPosition;
+    }
+  /* Old variables used since not converted yet */
+  MAXSCOL = size_hints->width / WpeXInfo.font_width;
+  MAXSLNS = size_hints->height / WpeXInfo.font_height;
+  return;
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -273,51 +280,52 @@ void WpeXGeometryGet(XrmDatabase xresdb, XrmQuark *name_list,
       class_list   (In)  Class quark list (second element unset)
       iconic       (Out) Initial mode to start program in
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXOptionsGet(XrmDatabase xresdb, XrmQuark *name_list,
-                    XrmQuark *class_list, int *iconic)
+void
+WpeXOptionsGet (XrmDatabase xresdb, XrmQuark * name_list,
+		XrmQuark * class_list, int *iconic)
 {
- XrmRepresentation return_value;
- XrmValue xval;
+  XrmRepresentation return_value;
+  XrmValue xval;
 
- WpeXInfo.altmask = DEFAULT_ALTMASK;
- name_list[1] = XrmStringToQuark("altMask");
- class_list[1] = XrmStringToQuark("AltMask");
- if (XrmQGetResource(xresdb, name_list, class_list, &return_value, &xval))
- {
-  if (WpeStrnccmp((char *)xval.addr, "mod", 3) == 0)
-  {
-   switch (xval.addr[4] - '0')
-   {
-    case 1:
-     WpeXInfo.altmask = Mod1Mask;
-     break;
-    case 2:
-     WpeXInfo.altmask = Mod2Mask;
-     break;
-    case 3:
-     WpeXInfo.altmask = Mod3Mask;
-     break;
-    case 4:
-     WpeXInfo.altmask = Mod4Mask;
-     break;
-    case 5:
-     WpeXInfo.altmask = Mod5Mask;
-     break;
-    default:
-     break;
-   }
-  }
- }
- *iconic = NormalState;
- name_list[1] = XrmStringToQuark("iconic");
- class_list[1] = XrmStringToQuark("Iconic");
- if (XrmQGetResource(xresdb, name_list, class_list, &return_value, &xval))
- {
-  if (WpeStrccmp((char *)xval.addr, "on") == 0)
-  {
-   *iconic = IconicState;
-  }
- }
+  WpeXInfo.altmask = DEFAULT_ALTMASK;
+  name_list[1] = XrmStringToQuark ("altMask");
+  class_list[1] = XrmStringToQuark ("AltMask");
+  if (XrmQGetResource (xresdb, name_list, class_list, &return_value, &xval))
+    {
+      if (WpeStrnccmp ((char *) xval.addr, "mod", 3) == 0)
+	{
+	  switch (xval.addr[4] - '0')
+	    {
+	    case 1:
+	      WpeXInfo.altmask = Mod1Mask;
+	      break;
+	    case 2:
+	      WpeXInfo.altmask = Mod2Mask;
+	      break;
+	    case 3:
+	      WpeXInfo.altmask = Mod3Mask;
+	      break;
+	    case 4:
+	      WpeXInfo.altmask = Mod4Mask;
+	      break;
+	    case 5:
+	      WpeXInfo.altmask = Mod5Mask;
+	      break;
+	    default:
+	      break;
+	    }
+	}
+    }
+  *iconic = NormalState;
+  name_list[1] = XrmStringToQuark ("iconic");
+  class_list[1] = XrmStringToQuark ("Iconic");
+  if (XrmQGetResource (xresdb, name_list, class_list, &return_value, &xval))
+    {
+      if (WpeStrccmp ((char *) xval.addr, "on") == 0)
+	{
+	  *iconic = IconicState;
+	}
+    }
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -325,48 +333,50 @@ void WpeXOptionsGet(XrmDatabase xresdb, XrmQuark *name_list,
 
     Returns: X resource database
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-XrmDatabase WpeXDefaults()
+XrmDatabase
+WpeXDefaults ()
 {
- char *s, *home_env;
+  char *s, *home_env;
 
- s = XResourceManagerString(WpeXInfo.display);
- if (s)
- {
-  return XrmGetStringDatabase(s);
- }
- /* The password file should be checked if HOME isn't set but not done yet. */
- home_env = getenv("HOME");
- if (home_env)
- {
-  XrmDatabase tmpdb;
+  s = XResourceManagerString (WpeXInfo.display);
+  if (s)
+    {
+      return XrmGetStringDatabase (s);
+    }
+  /* The password file should be checked if HOME isn't set but not done yet. */
+  home_env = getenv ("HOME");
+  if (home_env)
+    {
+      XrmDatabase tmpdb;
 
-  s = malloc(strlen(home_env) + 12);
-  sprintf(s, "%s/.Xdefaults", home_env);
-  tmpdb = XrmGetFileDatabase(s);
-  free(s);
-  return (tmpdb);
- }
- return NULL;
+      s = malloc (strlen (home_env) + 12);
+      sprintf (s, "%s/.Xdefaults", home_env);
+      tmpdb = XrmGetFileDatabase (s);
+      free (s);
+      return (tmpdb);
+    }
+  return NULL;
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeXGCSetup - Sets up the graphic context with appropriate font, line, etc.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXGCSetup()
+void
+WpeXGCSetup ()
 {
- XGCValues values;
- static char dash_list[2] = {  12,  24  };
-   
- WpeXInfo.gc = XCreateGC(WpeXInfo.display, WpeXInfo.window, 0, &values);
- XSetFont(WpeXInfo.display, WpeXInfo.gc, WpeXInfo.font->fid);
- XSetForeground(WpeXInfo.display, WpeXInfo.gc,
-   BlackPixel(WpeXInfo.display, WpeXInfo.screen));
- XSetLineAttributes(WpeXInfo.display, WpeXInfo.gc, /*line width*/ 1,
-   /*line style*/ LineSolid, /*cap style*/ CapRound,
-   /*join style*/ JoinRound);
- XSetDashes(WpeXInfo.display, WpeXInfo.gc, /*dash offset*/ 0, dash_list,
-   /*dash list length*/ 2);
- return ;
+  XGCValues values;
+  static char dash_list[2] = { 12, 24 };
+
+  WpeXInfo.gc = XCreateGC (WpeXInfo.display, WpeXInfo.window, 0, &values);
+  XSetFont (WpeXInfo.display, WpeXInfo.gc, WpeXInfo.font->fid);
+  XSetForeground (WpeXInfo.display, WpeXInfo.gc,
+		  BlackPixel (WpeXInfo.display, WpeXInfo.screen));
+  XSetLineAttributes (WpeXInfo.display, WpeXInfo.gc, /*line width */ 1,
+		      /*line style */ LineSolid, /*cap style */ CapRound,
+		      /*join style */ JoinRound);
+  XSetDashes (WpeXInfo.display, WpeXInfo.gc, /*dash offset */ 0, dash_list,
+	      /*dash list length */ 2);
+  return;
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -376,124 +386,135 @@ void WpeXGCSetup()
       argc         (In & Out) Argument count
       argv         (In & Out) Argument values
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXInit(int *argc, char **argv)
+void
+WpeXInit (int *argc, char **argv)
 {
- XrmDatabase xres = 0;
- XrmQuark class_list[3];
- XrmQuark name_list[3];
- XrmRepresentation return_value;
- XrmValue xval;
- XWMHints wm_hints;
- XClassHint class_hint;
- XSizeHints size_hints;
- Atom *atom_list, *new_atom_list;
- int atom_num, cursor_num;
- char *window_name;
- char *display_name;
+  XrmDatabase xres = 0;
+  XrmQuark class_list[3];
+  XrmQuark name_list[3];
+  XrmRepresentation return_value;
+  XrmValue xval;
+  XWMHints wm_hints;
+  XClassHint class_hint;
+  XSizeHints size_hints;
+  Atom *atom_list, *new_atom_list;
+  int atom_num, cursor_num;
+  char *window_name;
+  char *display_name;
 
- XrmInitialize();
- if (WpeIsProg())
- {
-  window_name = "Window Programming Environment";
-  class_hint.res_name = "xwpe";
- }
- else
- {
-  window_name = "Window Editor";
-  class_hint.res_name = "xwe";
- }
- class_hint.res_class = "Xwpe";
- XrmParseCommand(&xres, WpeXOptionTable, OPTION_TABLE_SIZE,
-   class_hint.res_name, argc, argv);
- class_list[0] = XrmStringToQuark(class_hint.res_class);
- name_list[0] = XrmStringToQuark(class_hint.res_name);
- /* The second class quark is set to "display" since it doesn't matter */
- name_list[1] = class_list[1] = XrmStringToQuark("display");
- name_list[2] = class_list[2] = NULLQUARK;
- if (XrmQGetResource(xres, name_list, class_list, &return_value, &xval))
- {
-  display_name = (char *)xval.addr;
- }
- else
- {
-  display_name = NULL;
- }
- if ((WpeXInfo.display = XOpenDisplay(display_name)) == NULL)
- {
-  fprintf(stderr, "Xwpe: unable to open display \"%s\", exiting ...\n",
-    XDisplayName(display_name));
-  exit(-1);
- }
- WpeXInfo.screen = DefaultScreen(WpeXInfo.display);
- XrmCombineDatabase(WpeXDefaults(), &xres, False);
- WpeXFontGet(xres, name_list, class_list);
- WpeXGeometryGet(xres, name_list, class_list, &size_hints);
- WpeXOptionsGet(xres, name_list, class_list, &wm_hints.initial_state);
+  XrmInitialize ();
+  if (WpeIsProg ())
+    {
+      window_name = "Window Programming Environment";
+      class_hint.res_name = "xwpe";
+    }
+  else
+    {
+      window_name = "Window Editor";
+      class_hint.res_name = "xwe";
+    }
+  class_hint.res_class = "Xwpe";
+  XrmParseCommand (&xres, WpeXOptionTable, OPTION_TABLE_SIZE,
+		   class_hint.res_name, argc, argv);
+  class_list[0] = XrmStringToQuark (class_hint.res_class);
+  name_list[0] = XrmStringToQuark (class_hint.res_name);
+  /* The second class quark is set to "display" since it doesn't matter */
+  name_list[1] = class_list[1] = XrmStringToQuark ("display");
+  name_list[2] = class_list[2] = NULLQUARK;
+  if (XrmQGetResource (xres, name_list, class_list, &return_value, &xval))
+    {
+      display_name = (char *) xval.addr;
+    }
+  else
+    {
+      display_name = NULL;
+    }
+  if ((WpeXInfo.display = XOpenDisplay (display_name)) == NULL)
+    {
+      fprintf (stderr, "Xwpe: unable to open display \"%s\", exiting ...\n",
+	       XDisplayName (display_name));
+      exit (-1);
+    }
+  WpeXInfo.screen = DefaultScreen (WpeXInfo.display);
+  XrmCombineDatabase (WpeXDefaults (), &xres, False);
+  WpeXFontGet (xres, name_list, class_list);
+  WpeXGeometryGet (xres, name_list, class_list, &size_hints);
+  WpeXOptionsGet (xres, name_list, class_list, &wm_hints.initial_state);
 
- WpeXInfo.window = XCreateSimpleWindow(WpeXInfo.display,
-   RootWindow(WpeXInfo.display, WpeXInfo.screen), size_hints.x, size_hints.y,
-   size_hints.width, size_hints.height, 4,
-   BlackPixel(WpeXInfo.display, WpeXInfo.screen),
-   WhitePixel(WpeXInfo.display, WpeXInfo.screen));
+  WpeXInfo.window = XCreateSimpleWindow (WpeXInfo.display,
+					 RootWindow (WpeXInfo.display,
+						     WpeXInfo.screen),
+					 size_hints.x, size_hints.y,
+					 size_hints.width, size_hints.height,
+					 4, BlackPixel (WpeXInfo.display,
+							WpeXInfo.screen),
+					 WhitePixel (WpeXInfo.display,
+						     WpeXInfo.screen));
 
- WpeXColorGet(xres, name_list, class_list);
- XrmDestroyDatabase(xres);
+  WpeXColorGet (xres, name_list, class_list);
+  XrmDestroyDatabase (xres);
 
- wm_hints.flags = InputHint | StateHint | WindowGroupHint; /*  make it serve the window */
- wm_hints.input = True;                  /*  right from start */
- wm_hints.window_group = WpeXInfo.window;
- 
- XmbSetWMProperties(WpeXInfo.display, WpeXInfo.window, window_name,
-   class_hint.res_name, argv, *argc, &size_hints, &wm_hints, &class_hint);
- XSelectInput(WpeXInfo.display, WpeXInfo.window, ExposureMask |
-   KeyPressMask | ButtonPressMask | StructureNotifyMask);
+  wm_hints.flags = InputHint | StateHint | WindowGroupHint;	/*  make it serve the window */
+  wm_hints.input = True;	/*  right from start */
+  wm_hints.window_group = WpeXInfo.window;
 
- if(!XGetWMProtocols(WpeXInfo.display, WpeXInfo.window, &atom_list, &atom_num))
- {
-  atom_num = 0;
- }
- new_atom_list = malloc((atom_num + 1) * sizeof(Atom));
- if (atom_list != NULL)
- {
-  memcpy(new_atom_list, atom_list, atom_num * sizeof(Atom));
- }
- if (atom_num) XFree(atom_list);
- new_atom_list[atom_num] = WpeXInfo.delete_atom =
-   XInternAtom(WpeXInfo.display, "WM_DELETE_WINDOW", False);
- WpeXInfo.protocol_atom = XInternAtom(WpeXInfo.display, "WM_PROTOCOLS", False);
- XSetWMProtocols(WpeXInfo.display, WpeXInfo.window, new_atom_list,
-   atom_num + 1);
- free(new_atom_list);
+  XmbSetWMProperties (WpeXInfo.display, WpeXInfo.window, window_name,
+		      class_hint.res_name, argv, *argc, &size_hints,
+		      &wm_hints, &class_hint);
+  XSelectInput (WpeXInfo.display, WpeXInfo.window,
+		ExposureMask | KeyPressMask | ButtonPressMask |
+		StructureNotifyMask);
 
- WpeXInfo.selection_atom = XInternAtom(WpeXInfo.display, "PRIMARY", False);
- WpeXInfo.text_atom = XInternAtom(WpeXInfo.display, "STRING", False);
- WpeXInfo.property_atom = XInternAtom(WpeXInfo.display, "GTK_SELECTION", False);
- WpeXInfo.selection = NULL;
- WpeXGCSetup();
+  if (!XGetWMProtocols
+      (WpeXInfo.display, WpeXInfo.window, &atom_list, &atom_num))
+    {
+      atom_num = 0;
+    }
+  new_atom_list = malloc ((atom_num + 1) * sizeof (Atom));
+  if (atom_list != NULL)
+    {
+      memcpy (new_atom_list, atom_list, atom_num * sizeof (Atom));
+    }
+  if (atom_num)
+    XFree (atom_list);
+  new_atom_list[atom_num] = WpeXInfo.delete_atom =
+    XInternAtom (WpeXInfo.display, "WM_DELETE_WINDOW", False);
+  WpeXInfo.protocol_atom =
+    XInternAtom (WpeXInfo.display, "WM_PROTOCOLS", False);
+  XSetWMProtocols (WpeXInfo.display, WpeXInfo.window, new_atom_list,
+		   atom_num + 1);
+  free (new_atom_list);
 
- XMapWindow(WpeXInfo.display, WpeXInfo.window);
+  WpeXInfo.selection_atom = XInternAtom (WpeXInfo.display, "PRIMARY", False);
+  WpeXInfo.text_atom = XInternAtom (WpeXInfo.display, "STRING", False);
+  WpeXInfo.property_atom =
+    XInternAtom (WpeXInfo.display, "GTK_SELECTION", False);
+  WpeXInfo.selection = NULL;
+  WpeXGCSetup ();
 
- for (cursor_num = WpeEditingShape; cursor_num < WpeLastShape; cursor_num++)
- {
-  WpeXMouseCursor[cursor_num] =
-    XCreateFontCursor(WpeXInfo.display, WpeXMouseDefault[cursor_num]);
- }
- XDefineCursor(WpeXInfo.display, WpeXInfo.window,
-   WpeXMouseCursor[WpeEditingShape]);
- WpeXInfo.shape_list[0] = WpeXInfo.shape_list[1] = WpeEditingShape;
+  XMapWindow (WpeXInfo.display, WpeXInfo.window);
 
- /* Copied with little change since I haven't had the time to look into
-   what it does */
- if((*e_u_ini_size)())
- {
-  *argc = -1;
-  return ;
- }
+  for (cursor_num = WpeEditingShape; cursor_num < WpeLastShape; cursor_num++)
+    {
+      WpeXMouseCursor[cursor_num] =
+	XCreateFontCursor (WpeXInfo.display, WpeXMouseDefault[cursor_num]);
+    }
+  XDefineCursor (WpeXInfo.display, WpeXInfo.window,
+		 WpeXMouseCursor[WpeEditingShape]);
+  WpeXInfo.shape_list[0] = WpeXInfo.shape_list[1] = WpeEditingShape;
 
- e_abs_refr();
- /* end of untouched section */
+  /* Copied with little change since I haven't had the time to look into
+     what it does */
+  if ((*e_u_ini_size) ())
+    {
+      *argc = -1;
+      return;
+    }
 
- return;
+  e_abs_refr ();
+  /* end of untouched section */
+
+  return;
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -502,24 +523,26 @@ void WpeXInit(int *argc, char **argv)
     Parameters:
       new_shape    (In) new shape of the mouse pointer
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXMouseChangeShape(WpeMouseShape new_shape)
+void
+WpeXMouseChangeShape (WpeMouseShape new_shape)
 {
- WpeXInfo.shape_list[1] = WpeXInfo.shape_list[0];
- WpeXInfo.shape_list[0] = new_shape;
- XDefineCursor(WpeXInfo.display, WpeXInfo.window, WpeXMouseCursor[new_shape]);
- XFlush(WpeXInfo.display);
+  WpeXInfo.shape_list[1] = WpeXInfo.shape_list[0];
+  WpeXInfo.shape_list[0] = new_shape;
+  XDefineCursor (WpeXInfo.display, WpeXInfo.window,
+		 WpeXMouseCursor[new_shape]);
+  XFlush (WpeXInfo.display);
 }
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   WpeXMouseRestoreShape - Restores the mouse pointer to the previous shape.
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-void WpeXMouseRestoreShape()
+void
+WpeXMouseRestoreShape ()
 {
- WpeXInfo.shape_list[0] = WpeXInfo.shape_list[1];
- WpeXInfo.shape_list[1] = WpeEditingShape;
- XDefineCursor(WpeXInfo.display, WpeXInfo.window,
-   WpeXMouseCursor[WpeXInfo.shape_list[0]]);
+  WpeXInfo.shape_list[0] = WpeXInfo.shape_list[1];
+  WpeXInfo.shape_list[1] = WpeEditingShape;
+  XDefineCursor (WpeXInfo.display, WpeXInfo.window,
+		 WpeXMouseCursor[WpeXInfo.shape_list[0]]);
 }
 
 #endif
-

--- a/src/WeXterm.h
+++ b/src/WeXterm.h
@@ -8,7 +8,8 @@
 \*-------------------------------------------------------------------------*/
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
@@ -29,37 +30,37 @@ extern "C" {
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   New Types
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-typedef struct wpeXStruct {
- Display *display;
- int screen;
- Window window;
- GC gc;
- XFontStruct *font;
- Atom delete_atom, protocol_atom, selection_atom, text_atom, property_atom;
- int font_height, font_width;
- int altmask;
- int colors[16];
- WpeMouseShape shape_list[2];
+  typedef struct wpeXStruct
+  {
+    Display *display;
+    int screen;
+    Window window;
+    GC gc;
+    XFontStruct *font;
+    Atom delete_atom, protocol_atom, selection_atom, text_atom, property_atom;
+    int font_height, font_width;
+    int altmask;
+    int colors[16];
+    WpeMouseShape shape_list[2];
 #ifdef SELECTION
- unsigned char *selection;
+    unsigned char *selection;
 #else
- char *selection;
+    char *selection;
 #endif
-} WpeXStruct;
+  } WpeXStruct;
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - *\
   Global Variables
 \* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
-extern WpeXStruct WpeXInfo;
+  extern WpeXStruct WpeXInfo;
 
 
-void WpeXInit(int *argc, char **argv);
-void WpeXMouseChangeShape(WpeMouseShape new_shape);
-void WpeXMouseRestoreShape();
+  void WpeXInit (int *argc, char **argv);
+  void WpeXMouseChangeShape (WpeMouseShape new_shape);
+  void WpeXMouseRestoreShape ();
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/src/attrb.h
+++ b/src/attrb.h
@@ -21,7 +21,3 @@
 #define A_DIM           0x10
 #define A_BOLD          0x20
 #define A_ALTCHARSET    0x100
-
-
-
-

--- a/src/edit.h
+++ b/src/edit.h
@@ -21,7 +21,7 @@
 #include "unixkeys.h"
 
 extern int MAXSLNS, MAXSCOL, MENOPT;
-#define MAXEDT 35	// Maximum number of editting windows
+#define MAXEDT 35		// Maximum number of editting windows
 #endif // #ifdef UNIX
 
 #define MAXLINES 10
@@ -31,307 +31,336 @@ extern int MAXSLNS, MAXSCOL, MENOPT;
 #define WPE_BACKUP   0
 
 #if  MOUSE
-struct mouse {
- int x;
- int y;
- int k;
+struct mouse
+{
+  int x;
+  int y;
+  int k;
 };
 #endif
 
-#define DTMD_NORMAL        'n' /* Normal text file */
-#define DTMD_MSDOS         'm' /* MS-DOS text file */
-#define DTMD_HELP          'h' /* Help window */
-#define DTMD_DATA          'D' /* Data/project windows */
-#define DTMD_FILEMANAGER   'F' /* File manager */
+#define DTMD_NORMAL        'n'	/* Normal text file */
+#define DTMD_MSDOS         'm'	/* MS-DOS text file */
+#define DTMD_HELP          'h'	/* Help window */
+#define DTMD_DATA          'D'	/* Data/project windows */
+#define DTMD_FILEMANAGER   'F'	/* File manager */
 /* File/directory dropdown of previous files/directories on the file manager */
 #define DTMD_FILEDROPDOWN  'M'
 
 #define DTMD_ISTEXT(x)     (x > 'Z')
-#define DTMD_ISMARKABLE(x) (x > DTMD_HELP) /* Means end marks can be shown*/
+#define DTMD_ISMARKABLE(x) (x > DTMD_HELP)	/* Means end marks can be shown */
 
-struct dirfile {
- int anz;      /* number elements in the list */
- char **name;  /* the list elements */
+struct dirfile
+{
+  int anz;			/* number elements in the list */
+  char **name;			/* the list elements */
 };
 
-typedef struct PNT {
- int x;
- int y;
+typedef struct PNT
+{
+  int x;
+  int y;
 } POINT;
 
-typedef struct CLR {
- int f;
- int b;
- int fb;
+typedef struct CLR
+{
+  int f;
+  int b;
+  int fb;
 } COLOR;
 
-typedef struct view_struct {
- char *p;
- POINT a;
- POINT e;
+typedef struct view_struct
+{
+  char *p;
+  POINT a;
+  POINT e;
 } view;
 
-typedef struct FND {
- char search[80], replace[80];
- char file[80];   /* filename or pattern to search/open */
- char *dirct;
- int sn;
- int rn;
- unsigned int sw;
+typedef struct FND
+{
+  char search[80], replace[80];
+  char file[80];		/* filename or pattern to search/open */
+  char *dirct;
+  int sn;
+  int rn;
+  unsigned int sw;
 } FIND;
 
-typedef struct frb {
- COLOR er;   /* editor window border and text */
- COLOR es;   /* special signs (maximize/kill) on editor window border */
- COLOR et;   /* normal text in editor window */
- COLOR ez;   /* marked text in editor window */
- COLOR ek;   /* found/marked word in editor window */
- COLOR em;   /* scrollbar */
- COLOR hh;   /* Help header */
- COLOR hb;   /* button in Help */
- COLOR hm;   /* marked word in Help */
- COLOR db;   /* breakpoint set */
- COLOR dy;   /* stop at breakpoint */
- COLOR mr;   /* submenu border */
- COLOR ms;   /* menu shortkey text */
- COLOR mt;   /* menu text */
- COLOR mz;   /* active menu text */
- COLOR df;   /* desktop */
- COLOR nr;   /* message window border and text */
- COLOR ne;   /* special signs (maximize/kill) on message window border */
- COLOR nt;   /* normal text for widgets in message window */
- COLOR nsnt; /* widget selector shortkey in message window */
- COLOR fr;   /* passive entry */
- COLOR fa;   /* active entry */
- COLOR ft;   /* normal data text */
- COLOR fz;   /* active, marked data text */
- COLOR frft; /* passive, marked data text */
- COLOR fs;   /* passive switch */
- COLOR nsft; /* switch selector shortkey */
- COLOR fsm;  /* active switch */
- COLOR nz;   /* normal/passive button text */
- COLOR ns;   /* button shortkey text */
- COLOR nm;   /* active button text */
- COLOR of;
- COLOR ct;   /* normal program text */
- COLOR cr;   /* reserved keywords in program */
- COLOR ck;   /* constants in program */
- COLOR cp;   /* preprocessor command */
- COLOR cc;   /* comments in program */
- char dc;    /* desktop fill character */
- char ws; 
+typedef struct frb
+{
+  COLOR er;			/* editor window border and text */
+  COLOR es;			/* special signs (maximize/kill) on editor window border */
+  COLOR et;			/* normal text in editor window */
+  COLOR ez;			/* marked text in editor window */
+  COLOR ek;			/* found/marked word in editor window */
+  COLOR em;			/* scrollbar */
+  COLOR hh;			/* Help header */
+  COLOR hb;			/* button in Help */
+  COLOR hm;			/* marked word in Help */
+  COLOR db;			/* breakpoint set */
+  COLOR dy;			/* stop at breakpoint */
+  COLOR mr;			/* submenu border */
+  COLOR ms;			/* menu shortkey text */
+  COLOR mt;			/* menu text */
+  COLOR mz;			/* active menu text */
+  COLOR df;			/* desktop */
+  COLOR nr;			/* message window border and text */
+  COLOR ne;			/* special signs (maximize/kill) on message window border */
+  COLOR nt;			/* normal text for widgets in message window */
+  COLOR nsnt;			/* widget selector shortkey in message window */
+  COLOR fr;			/* passive entry */
+  COLOR fa;			/* active entry */
+  COLOR ft;			/* normal data text */
+  COLOR fz;			/* active, marked data text */
+  COLOR frft;			/* passive, marked data text */
+  COLOR fs;			/* passive switch */
+  COLOR nsft;			/* switch selector shortkey */
+  COLOR fsm;			/* active switch */
+  COLOR nz;			/* normal/passive button text */
+  COLOR ns;			/* button shortkey text */
+  COLOR nm;			/* active button text */
+  COLOR of;
+  COLOR ct;			/* normal program text */
+  COLOR cr;			/* reserved keywords in program */
+  COLOR ck;			/* constants in program */
+  COLOR cp;			/* preprocessor command */
+  COLOR cc;			/* comments in program */
+  char dc;			/* desktop fill character */
+  char ws;
 } FARBE;
 
-typedef struct undo {
- int type;
- POINT b, a, e;
- union {
-  char c;
-  void *pt;
- } u;
- struct undo *next;
-}  Undo;
+typedef struct undo
+{
+  int type;
+  POINT b, a, e;
+  union
+  {
+    char c;
+    void *pt;
+  } u;
+  struct undo *next;
+} Undo;
 
-typedef struct STR {
- unsigned char *s;
- int len; /* Length of string not counting '\n' at the end */
- size_t nrc;
- /*int size;*/ /* Memory allocated for the string */
+typedef struct STR
+{
+  unsigned char *s;
+  int len;			/* Length of string not counting '\n' at the end */
+  size_t nrc;
+  /*int size; *//* Memory allocated for the string */
 } STRING;
 
-typedef struct BFF {
- STRING *bf; /* bf[i] is the i-th line of the buffer */
- POINT b;    /* cursor coordinates in window (at least in some contexts) */
- POINT mx; /* maximum column and line */
- int mxlines; /* number of lines */
- int cl, clsv;
- Undo *ud, *rd;
- struct CNT *cn;
- struct FNST *f;
- FARBE *fb;
+typedef struct BFF
+{
+  STRING *bf;			/* bf[i] is the i-th line of the buffer */
+  POINT b;			/* cursor coordinates in window (at least in some contexts) */
+  POINT mx;			/* maximum column and line */
+  int mxlines;			/* number of lines */
+  int cl, clsv;
+  Undo *ud, *rd;
+  struct CNT *cn;
+  struct FNST *f;
+  FARBE *fb;
 } BUFFER;
 
-typedef struct SCHRM {
- POINT mark_begin;
- POINT mark_end;
- POINT ks;
- POINT pt[9];
- POINT fa;
- POINT fe;
- POINT a;
- POINT e;
- POINT c;
- FARBE *fb;
+typedef struct SCHRM
+{
+  POINT mark_begin;
+  POINT mark_end;
+  POINT ks;
+  POINT pt[9];
+  POINT fa;
+  POINT fe;
+  POINT a;
+  POINT e;
+  POINT c;
+  FARBE *fb;
 #ifdef DEBUGGER
- POINT da, de;
- int *brp;
+  POINT da, de;
+  int *brp;
 #endif
 } SCHIRM;
 
-typedef struct OPTION {
- char *t;
- int x;
- int s;
- int as;
+typedef struct OPTION
+{
+  char *t;
+  int x;
+  int s;
+  int as;
 } OPT;
 
-typedef struct WOPTION {
- char *t;
- int x, s, n, as;
+typedef struct WOPTION
+{
+  char *t;
+  int x, s, n, as;
 } WOPT;
 
-typedef struct OPTKAST {
- char *t;
- int x;
- char o;
- int (*fkt)(struct FNST *);
+typedef struct OPTKAST
+{
+  char *t;
+  int x;
+  char o;
+  int (*fkt) (struct FNST *);
 } OPTK;
 
-typedef struct {
- int position;
- int width;
- int no_of_items;
- OPTK *menuitems;
+typedef struct
+{
+  int position;
+  int width;
+  int no_of_items;
+  OPTK *menuitems;
 } MENU;
 
-typedef struct FNST {
- POINT a;         /* start corner of the box */
- POINT e;         /* other corner of the box */
- POINT sa;
- POINT se;
- char zoom;
- FARBE *fb;       /* color scheme */
- view *pic;        /* picture save below the box ??? */
- char *dirct;     /* working/actual directory */
- char *datnam;    /* window header text */
- int winnum;      /* ID number in parents structure ??? */
- char ins;
- char dtmd; /* (See DTMD_* defines) */
- int save;
- char *hlp_str;
- WOPT *blst;      /* status line text */
- int nblst;       /* no of options in the status line */
- int filemode, flg;
- int *c_sw;
- struct wpeSyntaxRule *c_st;
- struct CNT *ed;  /* parent control structure ??? */
- struct BFF *b;
- struct SCHRM *s;
- FIND fd;
+typedef struct FNST
+{
+  POINT a;			/* start corner of the box */
+  POINT e;			/* other corner of the box */
+  POINT sa;
+  POINT se;
+  char zoom;
+  FARBE *fb;			/* color scheme */
+  view *pic;			/* picture save below the box ??? */
+  char *dirct;			/* working/actual directory */
+  char *datnam;			/* window header text */
+  int winnum;			/* ID number in parents structure ??? */
+  char ins;
+  char dtmd;			/* (See DTMD_* defines) */
+  int save;
+  char *hlp_str;
+  WOPT *blst;			/* status line text */
+  int nblst;			/* no of options in the status line */
+  int filemode, flg;
+  int *c_sw;
+  struct wpeSyntaxRule *c_st;
+  struct CNT *ed;		/* parent control structure ??? */
+  struct BFF *b;
+  struct SCHRM *s;
+  FIND fd;
 } FENSTER;
 
-typedef struct CNT {
- int major, minor, patch; /* Version of option file. */
- int maxcol, tabn;
- int maxchg, numundo;
- int flopt, edopt;
- int mxedt;           /* max number of editing windows */
- int curedt;          /* currently active window */
- int edt[MAXEDT + 1]; /* 1 <= window IDs <= MAXEDT, arbitrary order */
- int autoindent;
- char *print_cmd;
- char *dirct;         /* current directory */
- char *optfile, *tabs; 
- struct dirfile *sdf, *rdf, *fdf, *ddf, *wdf, *hdf, *shdf;
- FIND fd;
- FARBE *fb;
- FENSTER *f[MAXEDT + 1];
- char dtmd, autosv; 
+typedef struct CNT
+{
+  int major, minor, patch;	/* Version of option file. */
+  int maxcol, tabn;
+  int maxchg, numundo;
+  int flopt, edopt;
+  int mxedt;			/* max number of editing windows */
+  int curedt;			/* currently active window */
+  int edt[MAXEDT + 1];		/* 1 <= window IDs <= MAXEDT, arbitrary order */
+  int autoindent;
+  char *print_cmd;
+  char *dirct;			/* current directory */
+  char *optfile, *tabs;
+  struct dirfile *sdf, *rdf, *fdf, *ddf, *wdf, *hdf, *shdf;
+  FIND fd;
+  FARBE *fb;
+  FENSTER *f[MAXEDT + 1];
+  char dtmd, autosv;
 } ECNT;
 
 
 /* structure for the windows in the file manager ??? */
-typedef struct fl_wnd {
- int xa, ya;         /* its own box corner ??? */
- int xe, ye;
- int ia, ja;
- int nf;             /* selected field in dirfile df struct */
- int nxfo, nyfo;
- int mxa, mya;       /* parent box corners ??? */
- int mxe, mye;
- int srcha;
- struct dirfile *df; /* directory tree or file list */
- FENSTER* f;         /* the window itself */
+typedef struct fl_wnd
+{
+  int xa, ya;			/* its own box corner ??? */
+  int xe, ye;
+  int ia, ja;
+  int nf;			/* selected field in dirfile df struct */
+  int nxfo, nyfo;
+  int mxa, mya;			/* parent box corners ??? */
+  int mxe, mye;
+  int srcha;
+  struct dirfile *df;		/* directory tree or file list */
+  FENSTER *f;			/* the window itself */
 } FLWND;
 
-typedef struct FLBFF {
- struct dirfile *cd; /* current directory */
- struct dirfile *dd; /* list of directories in the current dir. */
- struct dirfile *df; /* list of files in the current dir. */
- struct fl_wnd *fw;  /* window for file list */
- struct fl_wnd *dw;  /* window for dir tree */
- char *rdfile;       /* file pattern entered for searching */
- char sw;
- int xfa, xfd, xda, xdd;
+typedef struct FLBFF
+{
+  struct dirfile *cd;		/* current directory */
+  struct dirfile *dd;		/* list of directories in the current dir. */
+  struct dirfile *df;		/* list of files in the current dir. */
+  struct fl_wnd *fw;		/* window for file list */
+  struct fl_wnd *dw;		/* window for dir tree */
+  char *rdfile;			/* file pattern entered for searching */
+  char sw;
+  int xfa, xfd, xda, xdd;
 } FLBFFR;
 
-typedef struct {
- int x, y;
- char *txt;
+typedef struct
+{
+  int x, y;
+  char *txt;
 } W_O_TXTSTR;
 
-typedef struct {
- int xt, yt, xw, yw, nw, wmx, nc, sw; 
- char *header;
- char *txt;
- struct dirfile **df;
+typedef struct
+{
+  int xt, yt, xw, yw, nw, wmx, nc, sw;
+  char *header;
+  char *txt;
+  struct dirfile **df;
 } W_O_WRSTR;
 
-typedef struct {
- int xt, yt, xw, yw, nw, wmx, nc, num, sw; 
- char *header;
+typedef struct
+{
+  int xt, yt, xw, yw, nw, wmx, nc, num, sw;
+  char *header;
 } W_O_NUMSTR;
 
-typedef struct {
- int x, y, nc, sw, num;
- char *header;
+typedef struct
+{
+  int x, y, nc, sw, num;
+  char *header;
 } W_O_SSWSTR;
 
-typedef struct {
- int x, y, nc, sw;
- char *header;
+typedef struct
+{
+  int x, y, nc, sw;
+  char *header;
 } W_O_SPSWSTR;
 
-typedef struct {
- int num, np;
- W_O_SPSWSTR **ps;
+typedef struct
+{
+  int num, np;
+  W_O_SPSWSTR **ps;
 } W_O_PSWSTR;
 
-typedef struct {
- int x, y, nc, sw;
- char *header; 
- int (*fkt)(FENSTER *f);
+typedef struct
+{
+  int x, y, nc, sw;
+  char *header;
+  int (*fkt) (FENSTER * f);
 } W_O_BTTSTR;
 
-typedef struct {
- int xa, ya, xe, ye, bgsw, crsw;
- int frt, frs, ftt, fts, fst, fss, fsa, fbt;
- int fbs, fbz, fwt, fws;
- int tn, sn, pn, bn, wn, nn;
- char *name;
- view *pic;
- W_O_TXTSTR **tstr;
- W_O_SSWSTR **sstr;
- W_O_PSWSTR **pstr;
- W_O_BTTSTR **bstr;
- W_O_WRSTR  **wstr;
- W_O_NUMSTR **nstr;
- FENSTER *f;
+typedef struct
+{
+  int xa, ya, xe, ye, bgsw, crsw;
+  int frt, frs, ftt, fts, fst, fss, fsa, fbt;
+  int fbs, fbz, fwt, fws;
+  int tn, sn, pn, bn, wn, nn;
+  char *name;
+  view *pic;
+  W_O_TXTSTR **tstr;
+  W_O_SSWSTR **sstr;
+  W_O_PSWSTR **pstr;
+  W_O_BTTSTR **bstr;
+  W_O_WRSTR **wstr;
+  W_O_NUMSTR **nstr;
+  FENSTER *f;
 } W_OPTSTR;
 
-typedef struct wpeOptionSection {
- char *section;
- int (*function)(ECNT *cn, char *section, char *option, char *value);
+typedef struct wpeOptionSection
+{
+  char *section;
+  int (*function) (ECNT * cn, char *section, char *option, char *value);
 } WpeOptionSection;
 
 #ifdef UNIX
 
-int e_put_pic_xrect(view *pic);
-int e_get_pic_xrect(int xa, int ya, int xe, int ye, view *pic);
+int e_put_pic_xrect (view * pic);
+int e_get_pic_xrect (int xa, int ya, int xe, int ye, view * pic);
 
 #if defined(NEWSTYLE) && !defined(NO_XWINDOWS)
-int e_make_xrect(int xa, int ya, int xe, int ye, int sw);
-int e_make_xrect_abs(int xa, int ya, int xe, int ye, int sw);
+int e_make_xrect (int xa, int ya, int xe, int ye, int sw);
+int e_make_xrect_abs (int xa, int ya, int xe, int ye, int sw);
 #else
 #define e_make_xrect(a,b,c,d,e)
 #define e_make_xrect_abs(a,b,c,d,e)
@@ -340,4 +369,3 @@ int e_make_xrect_abs(int xa, int ya, int xe, int ye, int sw);
 #endif // #ifdef UNIX
 
 #endif // #ifndef __EDIT_H
-

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,7 +1,7 @@
 #ifndef WE_GLOBALS_H
 #define WE_GLOBALS_H
 
-extern struct CNT * WpeEditor;
+extern struct CNT *WpeEditor;
 
 
 /* Checks if programming editor is running (old variable currently used) */

--- a/src/keys.h
+++ b/src/keys.h
@@ -85,7 +85,7 @@
 #define ENTF 338
 #define POS1 326
 #define ENDE 334
-#define BUP 328               
+#define BUP 328
 #define BDO 336
 #define CBUP 387
 #define CBDO 373
@@ -144,13 +144,13 @@
 #define CF10 951
 
 
-#define HBG CtrlA	/*  Button start  */
-#define HFB CtrlG	/*  Button-Man-Page start  */
-#define HNF CtrlC	/*  Button with link to file   */
-#define HED CtrlE	/*  End Mark   */
-#define HHD CtrlB	/*  start headline   */
-#define HFE CtrlF	/*  end of page   */
-#define HBS CtrlH	/*  Backspace (Man-Pages)  */
-#define HBB CtrlO	/*  start highlight  */
+#define HBG CtrlA		/*  Button start  */
+#define HFB CtrlG		/*  Button-Man-Page start  */
+#define HNF CtrlC		/*  Button with link to file   */
+#define HED CtrlE		/*  End Mark   */
+#define HHD CtrlB		/*  start headline   */
+#define HFE CtrlF		/*  end of page   */
+#define HBS CtrlH		/*  Backspace (Man-Pages)  */
+#define HBB CtrlO		/*  start highlight  */
 
 #define MBKEY -100

--- a/src/messages.h
+++ b/src/messages.h
@@ -85,4 +85,3 @@
 #define ERR_NOPROCESS   27
 
 #endif
-

--- a/src/model.h
+++ b/src/model.h
@@ -21,13 +21,13 @@
 /*  XWindow Definitions  */
 
 #if !defined(NO_XWINDOWS)  || defined (HAVE_LIBGPM)
-#define MOUSE   1        /*  activate mouse  */
+#define MOUSE   1		/*  activate mouse  */
 #else
-#define MOUSE   0        /*  deactivate mouse  */
+#define MOUSE   0		/*  deactivate mouse  */
 #endif
 
 /*  Newstyle only for XWindow   */
-#if !defined(NO_XWINDOWS) 
+#if !defined(NO_XWINDOWS)
 #define NEWSTYLE
 #endif
 

--- a/src/options.h
+++ b/src/options.h
@@ -8,7 +8,7 @@
 \*-------------------------------------------------------------------------*/
 
 /* FENSTER f -> CNT ed -> flopt */
- 
+
 #define FM_SHOW_HIDDEN_FILES  0x0001
 #define FM_SHOW_HIDDEN_DIRS   0x0002
 #define FM_DELETE_AT_EXIT     0x0004
@@ -58,4 +58,3 @@
   (ED_ERRORS_STOP_AT | ED_MESSAGES_STOP_AT | ED_SYNTAX_HIGHLIGHT)
 
 #endif
-

--- a/src/progr.h
+++ b/src/progr.h
@@ -10,4 +10,3 @@
 #include "WeProg.h"
 
 #endif
-

--- a/src/unixkeys.h
+++ b/src/unixkeys.h
@@ -22,7 +22,7 @@
 #define HELP_FILE   "help.xwpe"
 #define OPTION_FILE "xwperc"
 
-#define BUFFER_NAME "Buffer"   /*  Clipboard in Buffer changed  */
+#define BUFFER_NAME "Buffer"	/*  Clipboard in Buffer changed  */
 #define SUDIR "*"
 #define MAXREC 15
 #ifndef DEF_SHELL
@@ -64,10 +64,10 @@ extern char RE1, RE2, RE3, RE4, RE5, RE6, WBT;
 #define CUT   430
 #define HELP  431
 
-#define DWR 20       /*  ctrl t  */
-#define DWL 18       /*  ctrl r  */
-#define DNDL 17      /*  ctrl q  */
-#define DGZ 25       /*  ctrl y  */
+#define DWR 20			/*  ctrl t  */
+#define DWL 18			/*  ctrl r  */
+#define DNDL 17			/*  ctrl q  */
+#define DGZ 25			/*  ctrl y  */
 
 #define WPE_CR 13
 //extern const unsigned char WPE_WR;
@@ -75,7 +75,7 @@ extern char RE1, RE2, RE3, RE4, RE5, RE6, WBT;
 #define WPE_ESC 27
 #define WPE_DC 8
 #define WPE_TAB 9
-#define WPE_BTAB 28 /*First value which looks suitable for me*/
+#define WPE_BTAB 28		/*First value which looks suitable for me */
 
 #define SCLE CLE+512
 #define SCRI CRI+512

--- a/src/unixmakr.h
+++ b/src/unixmakr.h
@@ -7,8 +7,8 @@
 #include "config.h"
 
 #ifdef NOSTRSTR
-char *strstr(char *s1, char *s2);
-char *getcwd(char *dir, int n);
+char *strstr (char *s1, char *s2);
+char *getcwd (char *dir, int n);
 #endif
 
 
@@ -117,4 +117,3 @@ extern char *extbyte, *altextbyte;
 #define sc_txt_3(y, b, sw) {  if(b->f->c_sw) e_sc_nw_txt(y, b, sw);  }
 #define sc_txt_4(y, b, sw)						\
 {  if(b->f->c_sw && !e_undo_sw) e_sc_nw_txt(y, b, sw);  }
-

--- a/src/we_block.c
+++ b/src/we_block.c
@@ -18,721 +18,763 @@
 extern int e_undo_sw;
 
 /*	delete block */
-int e_blck_del(FENSTER *f)
+int
+e_blck_del (FENSTER * f)
 {
- BUFFER *b;
- SCHIRM *s;
- int i,y,len;
+  BUFFER *b;
+  SCHIRM *s;
+  int i, y, len;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;  s = f->s;
- if ((s->mark_end.y < s->mark_begin.y) ||
-   ((s->mark_begin.y == s->mark_end.y) && (s->mark_end.x <= s->mark_begin.x)))
- {
-  return(0);
- }
- if (f->ins == (char) 8)
-  return(WPE_ESC);
- if (s->mark_begin.y == s->mark_end.y)
- {
-  e_del_nchar(b, s, s->mark_begin.x, s->mark_begin.y,
-    s->mark_end.x - s->mark_begin.x);
-  b->b.x = s->mark_end.x = s->mark_begin.x;
- }
- else
- {
-/***********************/ 
-  y=s->mark_begin.y;
-  if(s->mark_begin.x>0) y++;
-  len=y-s->mark_end.y+1;
-/***********************/ 
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  if ((s->mark_end.y < s->mark_begin.y) ||
+      ((s->mark_begin.y == s->mark_end.y)
+       && (s->mark_end.x <= s->mark_begin.x)))
+    {
+      return (0);
+    }
+  if (f->ins == (char) 8)
+    return (WPE_ESC);
+  if (s->mark_begin.y == s->mark_end.y)
+    {
+      e_del_nchar (b, s, s->mark_begin.x, s->mark_begin.y,
+		   s->mark_end.x - s->mark_begin.x);
+      b->b.x = s->mark_end.x = s->mark_begin.x;
+    }
+  else
+    {
+/***********************/
+      y = s->mark_begin.y;
+      if (s->mark_begin.x > 0)
+	y++;
+      len = y - s->mark_end.y + 1;
+/***********************/
 
-  e_add_undo('d', b, s->mark_begin.x, s->mark_begin.y, 0);
-  f->save = b->cn->maxchg + 1;
-  
-/***********************/ 
-  e_brk_recalc(f,y,len);
-/***********************/ 
- }
- if (f->c_sw) {
-   f->c_sw = e_sc_txt(f->c_sw, f->b);
- }
- e_cursor(f, 1);
- e_schirm(f, 1);
- return(0);
+      e_add_undo ('d', b, s->mark_begin.x, s->mark_begin.y, 0);
+      f->save = b->cn->maxchg + 1;
+
+/***********************/
+      e_brk_recalc (f, y, len);
+/***********************/
+    }
+  if (f->c_sw)
+    {
+      f->c_sw = e_sc_txt (f->c_sw, f->b);
+    }
+  e_cursor (f, 1);
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*      dup selected block BD*/
-int e_blck_dup(char *dup, FENSTER *f)
+int
+e_blck_dup (char *dup, FENSTER * f)
 {
- BUFFER *b;
- SCHIRM *s;
- int i;
+  BUFFER *b;
+  SCHIRM *s;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- if (f->ins == 8)
-  return(0);
- b = f->b;  s = f->s;
- i=s->mark_end.x - s->mark_begin.x;
- /* Brian thinks that 80 characters is enough.  For the time being return
-    nothing if longer than that. */
- if ((s->mark_end.y != s->mark_begin.y) || (i <= 0) || (i >= 80))
- {
-  return(0);
- }
- strncpy(dup, (const char *)&b->bf[s->mark_begin.y].s[s->mark_begin.x], i);
- dup[i]=0;
- return(i);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  if (f->ins == 8)
+    return (0);
+  b = f->b;
+  s = f->s;
+  i = s->mark_end.x - s->mark_begin.x;
+  /* Brian thinks that 80 characters is enough.  For the time being return
+     nothing if longer than that. */
+  if ((s->mark_end.y != s->mark_begin.y) || (i <= 0) || (i >= 80))
+    {
+      return (0);
+    }
+  strncpy (dup, (const char *) &b->bf[s->mark_begin.y].s[s->mark_begin.x], i);
+  dup[i] = 0;
+  return (i);
 }
 
-int e_blck_clear(BUFFER *b, SCHIRM *s)
+int
+e_blck_clear (BUFFER * b, SCHIRM * s)
 {
- int i;
- int len = (s->mark_end.y-s->mark_begin.y-1);
+  int i;
+  int len = (s->mark_end.y - s->mark_begin.y - 1);
 
- if (s->mark_end.y == s->mark_begin.y)
- {
-  e_del_nchar(b, s, s->mark_begin.x, s->mark_end.y,
-    s->mark_end.x - s->mark_begin.x);
+  if (s->mark_end.y == s->mark_begin.y)
+    {
+      e_del_nchar (b, s, s->mark_begin.x, s->mark_end.y,
+		   s->mark_end.x - s->mark_begin.x);
+      b->b.x = s->mark_end.x = s->mark_begin.x;
+      b->b.y = s->mark_end.y = s->mark_begin.y;
+      return (0);
+    }
+  for (i = s->mark_begin.y + 1; i < s->mark_end.y; i++)
+    free (b->bf[i].s);
+  for (i = s->mark_begin.y + 1; i <= b->mxlines - len; i++)
+    b->bf[i] = b->bf[i + len];
+  (b->mxlines) -= len;
+  (s->mark_end.y) -= len;
+  e_del_nchar (b, s, 0, s->mark_end.y, s->mark_end.x);
+  if (*(b->bf[s->mark_begin.y].s + (len = b->bf[s->mark_begin.y].len)) !=
+      '\0')
+    len++;
+  e_del_nchar (b, s, s->mark_begin.x, s->mark_begin.y, len - s->mark_begin.x);
   b->b.x = s->mark_end.x = s->mark_begin.x;
   b->b.y = s->mark_end.y = s->mark_begin.y;
- return(0);
- }
- for (i = s->mark_begin.y + 1; i < s->mark_end.y; i++)
-  free(b->bf[i].s);
- for (i = s->mark_begin.y + 1; i <= b->mxlines-len; i++)
-  b->bf[i] = b->bf[i+len];
- (b->mxlines) -= len;
- (s->mark_end.y) -= len;
- e_del_nchar(b, s, 0, s->mark_end.y, s->mark_end.x);
- if (*(b->bf[s->mark_begin.y].s+(len = b->bf[s->mark_begin.y].len)) != '\0')
-  len++;
- e_del_nchar(b, s, s->mark_begin.x, s->mark_begin.y, len - s->mark_begin.x);
- b->b.x = s->mark_end.x = s->mark_begin.x;
- b->b.y = s->mark_end.y = s->mark_begin.y;
- return(0);
+  return (0);
 }
 
 /*   write buffer to screen */
-int e_show_clipboard(FENSTER *f)
+int
+e_show_clipboard (FENSTER * f)
 {
- ECNT *cn = f->ed;
- FENSTER *fo;
- int i, j;
+  ECNT *cn = f->ed;
+  FENSTER *fo;
+  int i, j;
 
- for (j = 1; j <= cn->mxedt; j++)
-  if (cn->f[j] == cn->f[0])
-  {
-   e_switch_window(cn->edt[j], f);
-   return(0);
-  }
+  for (j = 1; j <= cn->mxedt; j++)
+    if (cn->f[j] == cn->f[0])
+      {
+	e_switch_window (cn->edt[j], f);
+	return (0);
+      }
 
- if (cn->mxedt > MAXEDT)
- {
-  e_error(e_msg[ERR_MAXWINS], 0, cn->fb);
-  return(0);
- }
- for (j = 1; j <= MAXEDT; j++)
- {
-  for (i = 1; i <= cn->mxedt && cn->edt[i] != j; i++)
-   ;
-  if ( i > cn->mxedt) break;
- }
- cn->curedt=j;
- (cn->mxedt)++;
- cn->edt[cn->mxedt]=j;
+  if (cn->mxedt > MAXEDT)
+    {
+      e_error (e_msg[ERR_MAXWINS], 0, cn->fb);
+      return (0);
+    }
+  for (j = 1; j <= MAXEDT; j++)
+    {
+      for (i = 1; i <= cn->mxedt && cn->edt[i] != j; i++);
+      if (i > cn->mxedt)
+	break;
+    }
+  cn->curedt = j;
+  (cn->mxedt)++;
+  cn->edt[cn->mxedt] = j;
 
- f = cn->f[cn->mxedt] = cn->f[0];
+  f = cn->f[cn->mxedt] = cn->f[0];
 #ifdef PROG
- if (WpeIsProg())
- {
-  for (i = cn->mxedt-1; i > 0; i--)
-   ;
-  if (i < 1)
-  {
-   f->a = e_set_pnt(0, 1);
-   f->e = e_set_pnt(MAXSCOL-1, 2*MAXSLNS/3);
-  }
+  if (WpeIsProg ())
+    {
+      for (i = cn->mxedt - 1; i > 0; i--);
+      if (i < 1)
+	{
+	  f->a = e_set_pnt (0, 1);
+	  f->e = e_set_pnt (MAXSCOL - 1, 2 * MAXSLNS / 3);
+	}
+      else
+	{
+	  f->a = e_set_pnt (cn->f[i]->a.x + 1, cn->f[i]->a.y + 1);
+	  f->e = e_set_pnt (cn->f[i]->e.x, cn->f[i]->e.y);
+	}
+    }
   else
-  {
-   f->a = e_set_pnt(cn->f[i]->a.x+1, cn->f[i]->a.y+1);
-   f->e = e_set_pnt(cn->f[i]->e.x, cn->f[i]->e.y);
-  }
- }
- else
 #endif
- {
-  if (cn->mxedt < 2)
-  {
-   f->a = e_set_pnt(0, 1);
-   f->e = e_set_pnt(MAXSCOL-1, MAXSLNS-2);
-  }
-  else
-  {
-   f->a = e_set_pnt(cn->f[cn->mxedt-1]->a.x+1, cn->f[cn->mxedt-1]->a.y+1);
-   f->e = e_set_pnt(cn->f[cn->mxedt-1]->e.x, cn->f[cn->mxedt-1]->e.y);
-  }
- }
- f->winnum = cn->curedt;
+    {
+      if (cn->mxedt < 2)
+	{
+	  f->a = e_set_pnt (0, 1);
+	  f->e = e_set_pnt (MAXSCOL - 1, MAXSLNS - 2);
+	}
+      else
+	{
+	  f->a =
+	    e_set_pnt (cn->f[cn->mxedt - 1]->a.x + 1,
+		       cn->f[cn->mxedt - 1]->a.y + 1);
+	  f->e =
+	    e_set_pnt (cn->f[cn->mxedt - 1]->e.x, cn->f[cn->mxedt - 1]->e.y);
+	}
+    }
+  f->winnum = cn->curedt;
 
- if (cn->mxedt > 1)
- {
-  fo = cn->f[cn->mxedt-1];
-  e_ed_rahmen(fo, 0);
- }
- e_firstl(f, 1);
- e_zlsplt(f);
- e_schirm(f, 1);
- e_cursor(f, 1);
- return(0);
+  if (cn->mxedt > 1)
+    {
+      fo = cn->f[cn->mxedt - 1];
+      e_ed_rahmen (fo, 0);
+    }
+  e_firstl (f, 1);
+  e_zlsplt (f);
+  e_schirm (f, 1);
+  e_cursor (f, 1);
+  return (0);
 }
 
 /*   move block to buffer */
-int e_edt_del(FENSTER *f)
+int
+e_edt_del (FENSTER * f)
 {
- e_edt_copy(f);
- e_blck_del(f);
- return(0);
+  e_edt_copy (f);
+  e_blck_del (f);
+  return (0);
 }
 
 /* copy block to buffer */
-int e_edt_copy(FENSTER *f)
+int
+e_edt_copy (FENSTER * f)
 {
- BUFFER *b;
- BUFFER *b0 = f->ed->f[0]->b;
- int i, save;
+  BUFFER *b;
+  BUFFER *b0 = f->ed->f[0]->b;
+  int i, save;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;  save = f->save;
- if ((f->s->mark_end.y < f->s->mark_begin.y) ||
-   ((f->s->mark_begin.y == f->s->mark_end.y) &&
-     (f->s->mark_end.x <= f->s->mark_begin.x)))
- {
-  return(0);
- }
- for (i = 1; i < b0->mxlines; i++)
-  free(b0->bf[i].s);
- b0->mxlines = 1;
- *(b0->bf[0].s) = WPE_WR;
- *(b0->bf[0].s+1) = '\0';
- b0->bf[0].len = 0;
- e_copy_block(0, 0, b, b0, f);
- f->save = save;
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  save = f->save;
+  if ((f->s->mark_end.y < f->s->mark_begin.y) ||
+      ((f->s->mark_begin.y == f->s->mark_end.y) &&
+       (f->s->mark_end.x <= f->s->mark_begin.x)))
+    {
+      return (0);
+    }
+  for (i = 1; i < b0->mxlines; i++)
+    free (b0->bf[i].s);
+  b0->mxlines = 1;
+  *(b0->bf[0].s) = WPE_WR;
+  *(b0->bf[0].s + 1) = '\0';
+  b0->bf[0].len = 0;
+  e_copy_block (0, 0, b, b0, f);
+  f->save = save;
+  return (0);
 }
 
 /*            Copy block buffer into window  */
-int e_edt_einf(FENSTER *f)
+int
+e_edt_einf (FENSTER * f)
 {
- BUFFER *b;
- BUFFER *b0 = f->ed->f[0]->b;
- int i,y,len;
+  BUFFER *b;
+  BUFFER *b0 = f->ed->f[0]->b;
+  int i, y, len;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- if (f->ins == 8)
-  return(0);
- e_undo_sw = 1;
- 
-/**********************/ 
- y=b->b.y;
- if(b->b.x>0) y++;
-/**********************/ 
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  if (f->ins == 8)
+    return (0);
+  e_undo_sw = 1;
 
- e_copy_block(b->b.x, b->b.y, b0, b, f);
- 
-/**********************/ 
- len=b0->f->s->mark_end.y-b0->f->s->mark_begin.y;
- e_brk_recalc(f,y,len);
-/**********************/ 
+/**********************/
+  y = b->b.y;
+  if (b->b.x > 0)
+    y++;
+/**********************/
 
- e_undo_sw = 0;
- e_add_undo('c', b, b->b.x, b->b.y, 0);
- sc_txt_2(f);
- f->save = b->cn->maxchg + 1;
- return(0);
+  e_copy_block (b->b.x, b->b.y, b0, b, f);
+
+/**********************/
+  len = b0->f->s->mark_end.y - b0->f->s->mark_begin.y;
+  e_brk_recalc (f, y, len);
+/**********************/
+
+  e_undo_sw = 0;
+  e_add_undo ('c', b, b->b.x, b->b.y, 0);
+  sc_txt_2 (f);
+  f->save = b->cn->maxchg + 1;
+  return (0);
 }
 
 /*   move block within window */
-int e_blck_move(FENSTER *f)
+int
+e_blck_move (FENSTER * f)
 {
- BUFFER *b;
- int i;
- POINT ka;
+  BUFFER *b;
+  int i;
+  POINT ka;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- ka.x = f->ed->f[f->ed->mxedt]->s->mark_begin.x;
- if (b->b.y > f->ed->f[f->ed->mxedt]->s->mark_begin.y)
-  ka.y = f->ed->f[f->ed->mxedt]->s->mark_begin.y;
- else
- {
-  ka.y = f->ed->f[f->ed->mxedt]->s->mark_end.y;
-  if (b->b.y == f->ed->f[f->ed->mxedt]->s->mark_begin.y &&
-    b->b.x < f->ed->f[f->ed->mxedt]->s->mark_begin.x)
-   ka.x = f->ed->f[f->ed->mxedt]->s->mark_end.x +
-     f->ed->f[f->ed->mxedt]->s->mark_begin.x - b->b.x;
- }
- e_undo_sw = 1;
- e_move_block(b->b.x, b->b.y, b, b, f);
- e_undo_sw = 0;
- e_add_undo('v', b, ka.x, ka.y, 0);
- f->save = b->cn->maxchg + 1;
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  ka.x = f->ed->f[f->ed->mxedt]->s->mark_begin.x;
+  if (b->b.y > f->ed->f[f->ed->mxedt]->s->mark_begin.y)
+    ka.y = f->ed->f[f->ed->mxedt]->s->mark_begin.y;
+  else
+    {
+      ka.y = f->ed->f[f->ed->mxedt]->s->mark_end.y;
+      if (b->b.y == f->ed->f[f->ed->mxedt]->s->mark_begin.y &&
+	  b->b.x < f->ed->f[f->ed->mxedt]->s->mark_begin.x)
+	ka.x = f->ed->f[f->ed->mxedt]->s->mark_end.x +
+	  f->ed->f[f->ed->mxedt]->s->mark_begin.x - b->b.x;
+    }
+  e_undo_sw = 1;
+  e_move_block (b->b.x, b->b.y, b, b, f);
+  e_undo_sw = 0;
+  e_add_undo ('v', b, ka.x, ka.y, 0);
+  f->save = b->cn->maxchg + 1;
+  return (0);
 }
 
 /*    move Block    */
-void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f)
+void
+e_move_block (int x, int y, BUFFER * bv, BUFFER * bz, FENSTER * f)
 {
- SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
- SCHIRM *sv = bv->f->s;
- SCHIRM *sz = bz->f->s;
- int sw = (y < s->mark_begin.y) ? 0 : 1, i, n = s->mark_end.y - s->mark_begin.y - 1;
- int kax = s->mark_begin.x, kay = s->mark_begin.y, kex = s->mark_end.x, key = s->mark_end.y;
- STRING *str, *tmp;
- unsigned char *cstr;
+  SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
+  SCHIRM *sv = bv->f->s;
+  SCHIRM *sz = bz->f->s;
+  int sw = (y < s->mark_begin.y) ? 0 : 1, i, n =
+    s->mark_end.y - s->mark_begin.y - 1;
+  int kax = s->mark_begin.x, kay = s->mark_begin.y, kex =
+    s->mark_end.x, key = s->mark_end.y;
+  STRING *str, *tmp;
+  unsigned char *cstr;
 
- if (key < kay || (kay == key && kex <= kax)) return;
- if (f->ins == 8)
- {
-  return;
- }
- if (bv == bz && y >= kay && y <= key && x >= kax && x <= kex)
- {
-  return;
- }
- if (kay == key)
- {
-  n = kex - kax;
-  bz->b.x = x; bz->b.y = y;
-  if ((cstr = malloc(f->ed->maxcol * sizeof(char))) == NULL)
-  {
-   e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
-   return;
-  }
-  for (i = 0; i < n; i++)
-   cstr[i] = bv->bf[key].s[kax+i];
-  e_ins_nchar(bz, sz, cstr, x, y, n);
-  bv->b.x = kax;  bv->b.y = kay+bz->b.y-y;
-  e_del_nchar(bv, sv, sv->mark_begin.x, sv->mark_begin.y, n);
-  if (bv == bz && kay == y && x > kex)
-   x -= n;
-  sz->mark_begin.x = x;   sz->mark_end.x = bz->b.x = x + n;
-  sz->mark_begin.y = sz->mark_end.y = bz->b.y = y;
-  e_cursor(f, 1);
-  e_schirm(f, 1);
-  free(cstr);
-  return;
- }
+  if (key < kay || (kay == key && kex <= kax))
+    return;
+  if (f->ins == 8)
+    {
+      return;
+    }
+  if (bv == bz && y >= kay && y <= key && x >= kax && x <= kex)
+    {
+      return;
+    }
+  if (kay == key)
+    {
+      n = kex - kax;
+      bz->b.x = x;
+      bz->b.y = y;
+      if ((cstr = malloc (f->ed->maxcol * sizeof (char))) == NULL)
+	{
+	  e_error (e_msg[ERR_LOWMEM], 0, bz->fb);
+	  return;
+	}
+      for (i = 0; i < n; i++)
+	cstr[i] = bv->bf[key].s[kax + i];
+      e_ins_nchar (bz, sz, cstr, x, y, n);
+      bv->b.x = kax;
+      bv->b.y = kay + bz->b.y - y;
+      e_del_nchar (bv, sv, sv->mark_begin.x, sv->mark_begin.y, n);
+      if (bv == bz && kay == y && x > kex)
+	x -= n;
+      sz->mark_begin.x = x;
+      sz->mark_end.x = bz->b.x = x + n;
+      sz->mark_begin.y = sz->mark_end.y = bz->b.y = y;
+      e_cursor (f, 1);
+      e_schirm (f, 1);
+      free (cstr);
+      return;
+    }
 
- if (bv == bz && y == kay && x < kax )
- {
-  n = kax - x;
-  bv->b.x = x; bv->b.y = y;
-  if ((cstr = malloc(f->ed->maxcol * sizeof(char))) == NULL)
-  {
-   e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
-   return;
-  }
-  for (i = 0; i < n; i++)
-   cstr[i] = bv->bf[y].s[x+i];
-  e_del_nchar(bv, sv, x, y, n);
-  bz->b.x = kex; bz->b.y = key;
-  e_ins_nchar(bz, sz, cstr, kex, key, n);
-  bv->b.x = sv->mark_begin.x = x;  bv->b.y = sv->mark_begin.y = y;
-  sv->mark_end.x = kex;  sv->mark_end.y = key;
-  e_cursor(f, 1);
-  e_schirm(f, 1);
-  free(cstr);
-  return;
- }
+  if (bv == bz && y == kay && x < kax)
+    {
+      n = kax - x;
+      bv->b.x = x;
+      bv->b.y = y;
+      if ((cstr = malloc (f->ed->maxcol * sizeof (char))) == NULL)
+	{
+	  e_error (e_msg[ERR_LOWMEM], 0, bz->fb);
+	  return;
+	}
+      for (i = 0; i < n; i++)
+	cstr[i] = bv->bf[y].s[x + i];
+      e_del_nchar (bv, sv, x, y, n);
+      bz->b.x = kex;
+      bz->b.y = key;
+      e_ins_nchar (bz, sz, cstr, kex, key, n);
+      bv->b.x = sv->mark_begin.x = x;
+      bv->b.y = sv->mark_begin.y = y;
+      sv->mark_end.x = kex;
+      sv->mark_end.y = key;
+      e_cursor (f, 1);
+      e_schirm (f, 1);
+      free (cstr);
+      return;
+    }
 
- if (bv == bz && y == key && x > kex )
- {
-  n = x - kex;
-  bv->b.x = kex; bv->b.y = y;
-  if ((cstr = malloc(f->ed->maxcol * sizeof(char))) == NULL)
-  {
-   e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
-   return;
-  }
-  for (i = 0; i < n; i++)
-   cstr[i] = bv->bf[y].s[kex+i];
-  e_del_nchar(bv, sv, kex, y, n);
-  bz->b.x = kex; bz->b.y = key;
-  e_ins_nchar(bz, sz, cstr, kax, kay, n);
+  if (bv == bz && y == key && x > kex)
+    {
+      n = x - kex;
+      bv->b.x = kex;
+      bv->b.y = y;
+      if ((cstr = malloc (f->ed->maxcol * sizeof (char))) == NULL)
+	{
+	  e_error (e_msg[ERR_LOWMEM], 0, bz->fb);
+	  return;
+	}
+      for (i = 0; i < n; i++)
+	cstr[i] = bv->bf[y].s[kex + i];
+      e_del_nchar (bv, sv, kex, y, n);
+      bz->b.x = kex;
+      bz->b.y = key;
+      e_ins_nchar (bz, sz, cstr, kax, kay, n);
 
-  bv->b.x = sv->mark_end.x;  bv->b.y = sv->mark_end.y;
-  e_cursor(f, 1);
-  e_schirm(f, 1);
-  free(cstr);
-  return;
- }
+      bv->b.x = sv->mark_end.x;
+      bv->b.y = sv->mark_end.y;
+      e_cursor (f, 1);
+      e_schirm (f, 1);
+      free (cstr);
+      return;
+    }
 
- while (bz->mxlines+n > bz->mx.y-2)
- {
-  bz->mx.y += MAXLINES;
-  if ((tmp = realloc(bz->bf, bz->mx.y * sizeof(STRING))) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, bz->fb);
-  else
-   bz->bf = tmp;
+  while (bz->mxlines + n > bz->mx.y - 2)
+    {
+      bz->mx.y += MAXLINES;
+      if ((tmp = realloc (bz->bf, bz->mx.y * sizeof (STRING))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, bz->fb);
+      else
+	bz->bf = tmp;
+      if (bz->f->c_sw)
+	bz->f->c_sw = realloc (bz->f->c_sw, bz->mx.y * sizeof (int));
+    }
+  if ((str = malloc ((n + 2) * sizeof (STRING))) == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, bz->fb);
+      return;
+    }
+  for (i = kay; i <= key; i++)
+    str[i - kay] = bv->bf[i];
+  e_new_line (y + 1, bz);
+  if (*(bz->bf[y].s + bz->bf[y].len) != '\0')
+    (bz->bf[y].len)++;
+  for (i = x; i <= bz->bf[y].len; i++)
+    *(bz->bf[y + 1].s + i - x) = *(bz->bf[y].s + i);
+  *(bz->bf[y].s + x) = '\0';
+  bz->bf[y].len = bz->bf[y].nrc = x;
+  bz->bf[y + 1].len = e_str_len (bz->bf[y + 1].s);
+  bz->bf[y + 1].nrc = strlen ((const char *) bz->bf[y + 1].s);
+  for (i = bz->mxlines; i > y; i--)
+    bz->bf[i + n] = bz->bf[i];
+  (bz->mxlines) += n;
+  for (i = 1; i <= n; i++)
+    bz->bf[y + i] = str[i];
+
+  if (bz == bv)
+    {
+      if (y < kay)
+	{
+	  kay += (n + 1);
+	  key += (n + 1);
+	}
+      else if (y > kay)
+	y -= n;
+    }
+
+  for (i = kay + 1; i <= bv->mxlines - n; i++)
+    bv->bf[i] = bv->bf[i + n];
+  (bv->mxlines) -= n;
+
+  if (*(str[0].s + (n = str[0].len)) != '\0')
+    n++;
+  e_ins_nchar (bz, sz, (str[key - kay].s), 0, y + key - kay, kex);
+  e_ins_nchar (bz, sz, (str[0].s + kax), x, y, n - kax);
+  e_del_nchar (bv, sv, 0, kay + 1, kex);
+  e_del_nchar (bv, sv, kax, kay, n - kax);
+
+  if (bz == bv && sw != 0)
+    y--;
+
+  sv->mark_begin.x = sv->mark_end.x = bv->b.x = kax;
+  sv->mark_begin.y = sv->mark_end.y = bv->b.y = kay;
+
+  sz->mark_begin.x = x;
+  sz->mark_begin.y = y;
+  bz->b.x = sz->mark_end.x = kex;
+  bz->b.y = sz->mark_end.y = key - kay + y;
+
+  f->save = f->ed->maxchg + 1;
+  if (bv->f->c_sw)
+    {
+      bv->f->c_sw = e_sc_txt (bv->f->c_sw, bv->f->b);
+    }
   if (bz->f->c_sw)
-   bz->f->c_sw = realloc(bz->f->c_sw, bz->mx.y * sizeof(int));
- }
- if ((str = malloc((n+2) * sizeof(STRING))) == NULL)
- {
-  e_error(e_msg[ERR_LOWMEM], 0, bz->fb);
-  return;
- }
- for (i = kay; i <= key; i++)
-  str[i-kay] = bv->bf[i];
- e_new_line(y+1, bz);
- if (*(bz->bf[y].s+bz->bf[y].len) != '\0')
-  (bz->bf[y].len)++;
- for (i = x;  i <= bz->bf[y].len; i++)
-  *(bz->bf[y+1].s+i-x) = *(bz->bf[y].s+i);
- *(bz->bf[y].s+x) = '\0';
- bz->bf[y].len = bz->bf[y].nrc = x;
- bz->bf[y+1].len = e_str_len(bz->bf[y+1].s);
- bz->bf[y+1].nrc = strlen((const char *)bz->bf[y+1].s);
- for (i = bz->mxlines; i > y; i--)
-  bz->bf[i+n] = bz->bf[i];
- (bz->mxlines) += n;
- for (i = 1; i <= n; i++)
-  bz->bf[y+i] = str[i];
-
- if (bz == bv)
- {
-  if (y < kay)
-  {  kay += (n+1);  key +=(n+1);  }
-  else if (y > kay)
-   y -= n;
- }
-
- for (i = kay + 1; i <= bv->mxlines-n; i++)
-  bv->bf[i] = bv->bf[i+n];
- (bv->mxlines) -= n;
-
- if (*(str[0].s+(n = str[0].len)) != '\0')
-  n++;
- e_ins_nchar(bz, sz, (str[key-kay].s), 0, y+key-kay, kex);
- e_ins_nchar(bz, sz, (str[0].s+kax), x, y, n-kax);
- e_del_nchar(bv, sv, 0, kay+1, kex);
- e_del_nchar(bv, sv, kax, kay, n - kax);
-
- if (bz == bv && sw != 0)
-  y--;
-
- sv->mark_begin.x = sv->mark_end.x = bv->b.x = kax;
- sv->mark_begin.y = sv->mark_end.y = bv->b.y = kay;
-
- sz->mark_begin.x = x;
- sz->mark_begin.y = y;
- bz->b.x = sz->mark_end.x = kex;
- bz->b.y = sz->mark_end.y = key-kay+y;
-
- f->save = f->ed->maxchg + 1;
- if (bv->f->c_sw) {
-   bv->f->c_sw = e_sc_txt(bv->f->c_sw, bv->f->b);
- }
- if (bz->f->c_sw) {
-   bz->f->c_sw = e_sc_txt(bz->f->c_sw, bz->f->b);
- }
- e_cursor(f, 1);
- e_schirm(f, 1);
- free(str);
+    {
+      bz->f->c_sw = e_sc_txt (bz->f->c_sw, bz->f->b);
+    }
+  e_cursor (f, 1);
+  e_schirm (f, 1);
+  free (str);
 }
 
 /*   copy block within window   */
-int e_blck_copy(FENSTER *f)
+int
+e_blck_copy (FENSTER * f)
 {
- BUFFER *b;
- int i;
+  BUFFER *b;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- if (f->ins == 8) return(0);
- f->save = 1;
- e_undo_sw = 1;
- e_copy_block(b->b.x, b->b.y, b, b, f);
- e_undo_sw = 0;
- e_add_undo('c', b, b->b.x, b->b.y, 0);
- sc_txt_2(f);
- f->save = b->cn->maxchg + 1;
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  if (f->ins == 8)
+    return (0);
+  f->save = 1;
+  e_undo_sw = 1;
+  e_copy_block (b->b.x, b->b.y, b, b, f);
+  e_undo_sw = 0;
+  e_add_undo ('c', b, b->b.x, b->b.y, 0);
+  sc_txt_2 (f);
+  f->save = b->cn->maxchg + 1;
+  return (0);
 }
 
 /*   copy block  */
-void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
-  FENSTER *f)
+void
+e_copy_block (int x, int y, BUFFER * buffer_src, BUFFER * buffer_dst,
+	      FENSTER * f)
 {
- BUFFER *b = f->ed->f[f->ed->mxedt]->b;
- SCHIRM *s_src = buffer_src->f->s;
- SCHIRM *s_dst = buffer_dst->f->s;
- int i, j, n = s_src->mark_end.y - s_src->mark_begin.y - 1;
- int kax = s_src->mark_begin.x, kay = s_src->mark_begin.y, kex = s_src->mark_end.x, key = s_src->mark_end.y;
- int kse = key, ksa = kay;
- STRING **str, *tmp;
- unsigned char *cstr;
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  SCHIRM *s_src = buffer_src->f->s;
+  SCHIRM *s_dst = buffer_dst->f->s;
+  int i, j, n = s_src->mark_end.y - s_src->mark_begin.y - 1;
+  int kax = s_src->mark_begin.x, kay = s_src->mark_begin.y, kex =
+    s_src->mark_end.x, key = s_src->mark_end.y;
+  int kse = key, ksa = kay;
+  STRING **str, *tmp;
+  unsigned char *cstr;
 
- if (key < kay || (kay == key && kex <= kax)) return;
- if ((cstr = malloc(buffer_src->mx.x + 1)) == NULL)
- {
-  e_error(e_msg[ERR_LOWMEM], 0, buffer_dst->fb);
-  return;
- }
- if (kay == key)
- {
-  if (buffer_src == buffer_dst && y == kay && x >= kax && x < kex)
-  {
-   free(cstr);
-   return;
-  }
-  n = kex - kax;
-  buffer_dst->b.x = x; buffer_dst->b.y = y;
-  for (i = 0; i < n; i++)
-   cstr[i] = buffer_src->bf[key].s[kax+i];
-  e_ins_nchar(buffer_dst, s_dst, cstr, x, y, n);
+  if (key < kay || (kay == key && kex <= kax))
+    return;
+  if ((cstr = malloc (buffer_src->mx.x + 1)) == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, buffer_dst->fb);
+      return;
+    }
+  if (kay == key)
+    {
+      if (buffer_src == buffer_dst && y == kay && x >= kax && x < kex)
+	{
+	  free (cstr);
+	  return;
+	}
+      n = kex - kax;
+      buffer_dst->b.x = x;
+      buffer_dst->b.y = y;
+      for (i = 0; i < n; i++)
+	cstr[i] = buffer_src->bf[key].s[kax + i];
+      e_ins_nchar (buffer_dst, s_dst, cstr, x, y, n);
+      s_dst->mark_begin.x = x;
+      s_dst->mark_end.x = buffer_dst->b.x = x + n;
+      s_dst->mark_begin.y = s_dst->mark_end.y = buffer_dst->b.y = y;
+      free (cstr);
+      e_cursor (f, 1);
+      e_schirm (f, 1);
+      return;
+    }
+
+  if (buffer_src == buffer_dst && ((y > kay && y < key) ||
+				   (y == kay && x >= kax) || (y == key
+							      && x < kex)))
+    {
+      free (cstr);
+      return;
+    }
+  while (buffer_dst->mxlines + n > buffer_dst->mx.y - 2)
+    {
+      buffer_dst->mx.y += MAXLINES;
+      if ((tmp =
+	   realloc (buffer_dst->bf,
+		    buffer_dst->mx.y * sizeof (STRING))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, buffer_dst->fb);
+      else
+	buffer_dst->bf = tmp;
+      if (buffer_dst->f->c_sw)
+	buffer_dst->f->c_sw =
+	  realloc (buffer_dst->f->c_sw, buffer_dst->mx.y * sizeof (int));
+    }
+  if ((str = malloc ((n + 2) * sizeof (STRING *))) == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, buffer_dst->fb);
+      free (cstr);
+      return;
+    }
+  e_new_line (y + 1, buffer_dst);
+  if (buffer_dst == buffer_src && y < ksa)
+    {
+      kse += (n + 1);
+      ksa += (n + 1);
+    }
+  if (*(buffer_dst->bf[y].s + buffer_dst->bf[y].len) != '\0')
+    (buffer_dst->bf[y].len)++;
+  for (i = x; i <= buffer_dst->bf[y].len; i++)
+    *(buffer_dst->bf[y + 1].s + i - x) = *(buffer_dst->bf[y].s + i);
+  *(buffer_dst->bf[y].s + x) = '\0';
+  buffer_dst->bf[y].len = buffer_dst->bf[y].nrc = x;
+  buffer_dst->bf[y + 1].len = e_str_len (buffer_dst->bf[y + 1].s);
+  buffer_dst->bf[y + 1].nrc = strlen ((const char *) buffer_dst->bf[y + 1].s);
+  for (i = buffer_dst->mxlines; i > y; i--)
+    buffer_dst->bf[i + n] = buffer_dst->bf[i];
+  (buffer_dst->mxlines) += n;
+  for (i = ksa; i <= kse; i++)
+    str[i - ksa] = &(buffer_src->bf[i]);
+  for (i = 1; i <= n; i++)
+    buffer_dst->bf[i + y].s = NULL;
+  for (i = 1; i <= n; i++)
+    {
+      if ((buffer_dst->bf[i + y].s = malloc (buffer_dst->mx.x + 1)) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, b->fb);
+      for (j = 0; j <= str[i]->len; j++)
+	*(buffer_dst->bf[i + y].s + j) = *(str[i]->s + j);
+      if (*(str[i]->s + str[i]->len) != '\0')
+	*(buffer_dst->bf[i + y].s + j) = '\0';
+      buffer_dst->bf[i + y].len = str[i]->len;
+      buffer_dst->bf[i + y].nrc = str[i]->nrc;
+    }
+
+  for (i = 0; i < kex; i++)
+    cstr[i] = str[key - kay]->s[i];
+  e_ins_nchar (buffer_dst, s_dst, cstr, 0, y + key - kay, kex);
+  if (*(str[0]->s + (n = str[0]->len)) != '\0')
+    n++;
+  for (i = 0; i < n - kax; i++)
+    cstr[i] = str[0]->s[i + kax];
+  cstr[n - kax] = '\0';
+  e_ins_nchar (buffer_dst, s_dst, cstr, x, y, n - kax);
   s_dst->mark_begin.x = x;
-  s_dst->mark_end.x = buffer_dst->b.x = x + n;
-  s_dst->mark_begin.y = s_dst->mark_end.y = buffer_dst->b.y = y;
-  free(cstr);
-  e_cursor(f, 1);
-  e_schirm(f, 1);
-  return;
- }
-   
- if (buffer_src == buffer_dst && ( (y > kay && y < key) ||
-   ( y == kay && x >= kax ) || ( y == key && x < kex) ))
- {
-  free(cstr);
-  return;
- }
- while (buffer_dst->mxlines+n > buffer_dst->mx.y-2)
- {
-  buffer_dst->mx.y += MAXLINES;
-  if ((tmp = realloc(buffer_dst->bf, buffer_dst->mx.y * sizeof(STRING))) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, buffer_dst->fb);
-  else
-   buffer_dst->bf = tmp;
-  if (buffer_dst->f->c_sw)
-   buffer_dst->f->c_sw = realloc(buffer_dst->f->c_sw , buffer_dst->mx.y * sizeof(int));
- }
- if ((str = malloc((n+2) * sizeof(STRING *))) == NULL)
- {
-  e_error(e_msg[ERR_LOWMEM], 0, buffer_dst->fb);
-  free(cstr);
-  return;
- }
- e_new_line(y+1, buffer_dst);
- if (buffer_dst == buffer_src && y < ksa)
- {
-  kse += (n+1);
-  ksa += (n+1);
- }
- if (*(buffer_dst->bf[y].s+buffer_dst->bf[y].len) != '\0')
-  (buffer_dst->bf[y].len)++;
- for (i = x;  i <= buffer_dst->bf[y].len; i++)
-  *(buffer_dst->bf[y+1].s+i-x) = *(buffer_dst->bf[y].s+i);
- *(buffer_dst->bf[y].s+x) = '\0';
- buffer_dst->bf[y].len = buffer_dst->bf[y].nrc = x;
- buffer_dst->bf[y+1].len = e_str_len(buffer_dst->bf[y+1].s);
- buffer_dst->bf[y+1].nrc = strlen((const char *)buffer_dst->bf[y+1].s);
- for (i = buffer_dst->mxlines; i > y; i--)
-  buffer_dst->bf[i+n] = buffer_dst->bf[i];
- (buffer_dst->mxlines) += n;
- for (i = ksa; i <= kse; i++)
-  str[i-ksa] = &(buffer_src->bf[i]);
- for (i = 1; i <= n; i++)
-  buffer_dst->bf[i+y].s = NULL;
- for (i = 1; i <= n; i++)
- {
-  if ((buffer_dst->bf[i+y].s = malloc(buffer_dst->mx.x+1)) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, b->fb);
-  for (j = 0; j <= str[i]->len; j++)
-   *(buffer_dst->bf[i+y].s+j) = *(str[i]->s+j);
-  if (*(str[i]->s+str[i]->len) != '\0')
-   *(buffer_dst->bf[i+y].s+j) = '\0';
-  buffer_dst->bf[i+y].len = str[i]->len;
-  buffer_dst->bf[i+y].nrc = str[i]->nrc;
- }
+  s_dst->mark_begin.y = y;
+  buffer_dst->b.x = s_dst->mark_end.x = kex;
+  buffer_dst->b.y = s_dst->mark_end.y = key - kay + y;
 
- for (i = 0; i < kex; i++)
-  cstr[i] = str[key-kay]->s[i];
- e_ins_nchar(buffer_dst, s_dst, cstr, 0, y+key-kay, kex);
- if (*(str[0]->s+(n = str[0]->len)) != '\0')
-  n++;
- for (i = 0; i < n - kax; i++)
-  cstr[i] = str[0]->s[i+kax];
- cstr[n-kax] = '\0';
- e_ins_nchar(buffer_dst, s_dst, cstr, x, y, n-kax);
- s_dst->mark_begin.x = x;
- s_dst->mark_begin.y = y;
- buffer_dst->b.x = s_dst->mark_end.x = kex;
- buffer_dst->b.y = s_dst->mark_end.y = key-kay+y;
-
- e_cursor(f, 1);
- e_schirm(f, 1);
- free(cstr);
- free(str);
+  e_cursor (f, 1);
+  e_schirm (f, 1);
+  free (cstr);
+  free (str);
 }
 
 /*   delete block marks   */
-int e_blck_hide(FENSTER *f)
+int
+e_blck_hide (FENSTER * f)
 {
- SCHIRM *s;
- int i;
+  SCHIRM *s;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- s = f->s;
- s->mark_begin = e_set_pnt(0, 0);
- s->mark_end = e_set_pnt(0, 0);
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  s = f->s;
+  s->mark_begin = e_set_pnt (0, 0);
+  s->mark_end = e_set_pnt (0, 0);
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*   mark begin of block   */
-int e_blck_begin(FENSTER *f)
+int
+e_blck_begin (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0) return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- f->s->mark_begin = f->b->b;
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  f->s->mark_begin = f->b->b;
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*           Set end of block   */
-int e_blck_end(FENSTER *f)
+int
+e_blck_end (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- f->s->mark_end = f->b->b;
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  f->s->mark_end = f->b->b;
+  e_schirm (f, 1);
+  return (0);
 }
 
 /* goto begin of block   */
-int e_blck_gt_beg(FENSTER *f)
+int
+e_blck_gt_beg (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- f->b->b = f->s->mark_begin;
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  f->b->b = f->s->mark_begin;
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*   goto end of block   */
-int e_blck_gt_end(FENSTER *f)
+int
+e_blck_gt_end (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- f->b->b = f->s->mark_end;
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  f->b->b = f->s->mark_end;
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*   mark text line in block   */
-int e_blck_mrk_all(FENSTER *f)
+int
+e_blck_mrk_all (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- f->s->mark_begin.x = 0;
- f->s->mark_begin.y = 0;
- f->s->mark_end.y = f->b->mxlines-1;
- f->s->mark_end.x = f->b->bf[f->b->mxlines-1].len;
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  f->s->mark_begin.x = 0;
+  f->s->mark_begin.y = 0;
+  f->s->mark_end.y = f->b->mxlines - 1;
+  f->s->mark_end.x = f->b->bf[f->b->mxlines - 1].len;
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*   mark text line in block   */
-int e_blck_mrk_line(FENSTER *f)
+int
+e_blck_mrk_line (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- f->s->mark_begin.x = 0;
- f->s->mark_begin.y = f->b->b.y;
- if(f->b->b.y < f->b->mxlines-1)
- {
-  f->s->mark_end.x = 0;
-  f->s->mark_end.y = f->b->b.y+1;
- }
- else
- {
-  f->s->mark_end.x = f->b->bf[f->b->b.y].len;
-  f->s->mark_end.y = f->b->b.y;
- }
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  f->s->mark_begin.x = 0;
+  f->s->mark_begin.y = f->b->b.y;
+  if (f->b->b.y < f->b->mxlines - 1)
+    {
+      f->s->mark_end.x = 0;
+      f->s->mark_end.y = f->b->b.y + 1;
+    }
+  else
+    {
+      f->s->mark_end.x = f->b->bf[f->b->b.y].len;
+      f->s->mark_end.y = f->b->b.y;
+    }
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*	block: up- or downcase
@@ -740,354 +782,388 @@ mode=0 every character downcase
 mode=1 every character upcase
 mode=2 first character in each word upcase
 mode=3 first character in each line upcase   */
-int e_blck_changecase(FENSTER *f, int mode)
+int
+e_blck_changecase (FENSTER * f, int mode)
 {
- BUFFER *b;
- SCHIRM *screen;
- int i,x,y,x_begin,x_end;
+  BUFFER *b;
+  SCHIRM *screen;
+  int i, x, y, x_begin, x_end;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0) return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- screen = f->s;
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  screen = f->s;
 
- for (y = screen->mark_begin.y; y <= screen->mark_end.y; y++)
- {
-  if (y == screen->mark_begin.y)
-   x_begin = screen->mark_begin.x;
-  else x_begin = 0;
-  if (y == screen->mark_end.y)
-   x_end = screen->mark_end.x;
-  else x_end = b->bf[y].len;
-  for (x = x_begin; x < x_end; x++)
-   if (mode == 0)
-    b->bf[y].s[x]=tolower(b->bf[y].s[x]);
-   else if (mode == 1)
-    b->bf[y].s[x]=toupper(b->bf[y].s[x]);
-   else if ((mode == 2) && ((x == 0) || (b->bf[y].s[x-1] == ' ') || (b->bf[y].s[x-1] == '\t')))
-    b->bf[y].s[x]=toupper(b->bf[y].s[x]);
-   else if ((mode == 3) && (x == 0))
-    b->bf[y].s[x]=toupper(b->bf[y].s[x]);
- }
- f->save++;
- e_schirm(f, 1);
- return 0;
+  for (y = screen->mark_begin.y; y <= screen->mark_end.y; y++)
+    {
+      if (y == screen->mark_begin.y)
+	x_begin = screen->mark_begin.x;
+      else
+	x_begin = 0;
+      if (y == screen->mark_end.y)
+	x_end = screen->mark_end.x;
+      else
+	x_end = b->bf[y].len;
+      for (x = x_begin; x < x_end; x++)
+	if (mode == 0)
+	  b->bf[y].s[x] = tolower (b->bf[y].s[x]);
+	else if (mode == 1)
+	  b->bf[y].s[x] = toupper (b->bf[y].s[x]);
+	else if ((mode == 2)
+		 && ((x == 0) || (b->bf[y].s[x - 1] == ' ')
+		     || (b->bf[y].s[x - 1] == '\t')))
+	  b->bf[y].s[x] = toupper (b->bf[y].s[x]);
+	else if ((mode == 3) && (x == 0))
+	  b->bf[y].s[x] = toupper (b->bf[y].s[x]);
+    }
+  f->save++;
+  e_schirm (f, 1);
+  return 0;
 }
 
-int e_changecase_dialog(FENSTER *f)
+int
+e_changecase_dialog (FENSTER * f)
 {
- static int b_sw = 0;
- int ret;
- W_OPTSTR *o = e_init_opt_kst(f);
- if (!o) return(-1);
- o->xa = 21;
- o->xe = 52;
- o->ya = 4;
- o->ye = 15;
+  static int b_sw = 0;
+  int ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
+  if (!o)
+    return (-1);
+  o->xa = 21;
+  o->xe = 52;
+  o->ya = 4;
+  o->ye = 15;
 
- o->bgsw = AltO;
- o->name = "Change Case";
- o->crsw = AltO;
- e_add_txtstr(4, 2, "Which mode:", o);
+  o->bgsw = AltO;
+  o->name = "Change Case";
+  o->crsw = AltO;
+  e_add_txtstr (4, 2, "Which mode:", o);
 
- e_add_pswstr(1, 5, 3, 0, AltD, 0, "Downcase          ", o);
- e_add_pswstr(0, 5, 4, 0, AltU, b_sw & 1, "Upcase            ", o);
- e_add_pswstr(0, 5, 5, 0, AltH, b_sw & 2, "Headline          ", o);
- e_add_pswstr(0, 5, 6, 0, AltE, b_sw & 3, "First character   ", o);
+  e_add_pswstr (1, 5, 3, 0, AltD, 0, "Downcase          ", o);
+  e_add_pswstr (0, 5, 4, 0, AltU, b_sw & 1, "Upcase            ", o);
+  e_add_pswstr (0, 5, 5, 0, AltH, b_sw & 2, "Headline          ", o);
+  e_add_pswstr (0, 5, 6, 0, AltE, b_sw & 3, "First character   ", o);
 
- e_add_bttstr(7, 9, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(18, 9, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
+  e_add_bttstr (7, 9, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (18, 9, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
 
- if (ret != WPE_ESC)
-  e_blck_changecase(f,o->pstr[0]->num);
- freeostr(o);
- return 0;
+  if (ret != WPE_ESC)
+    e_blck_changecase (f, o->pstr[0]->num);
+  freeostr (o);
+  return 0;
 }
 
 /*   unindent block   */
-int e_blck_to_left(FENSTER *f)
+int
+e_blck_to_left (FENSTER * f)
 {
- BUFFER *b;
- SCHIRM *s;
- int n = f->ed->tabn/2, i, j, k, l, m, nn;
- unsigned char *tstr = malloc((n+2)*sizeof(char));
+  BUFFER *b;
+  SCHIRM *s;
+  int n = f->ed->tabn / 2, i, j, k, l, m, nn;
+  unsigned char *tstr = malloc ((n + 2) * sizeof (char));
 
- for(i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--);
- if(i <= 0) return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- s = f->s;
- for(i = 0; i <= n; i++) tstr[i] = ' ';
- tstr[n] = '\0';
- for (i = (!s->mark_begin.x) ? s->mark_begin.y : s->mark_begin.y + 1;
-   i < s->mark_end.y || (i == s->mark_end.y && s->mark_end.x > 0); i++)
- {
-  for(j = 0; j < b->bf[i].len && isspace(b->bf[i].s[j]); j++);
-  for(l = j - 1, k = 0; l >= 0 && k < n; l--)
-  {
-   if(b->bf[i].s[l] == ' ') k++;
-   else if(b->bf[i].s[l] == '\t')
-   {
-    for(nn = m = 0; m < l; m++)
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  for (i = 0; i <= n; i++)
+    tstr[i] = ' ';
+  tstr[n] = '\0';
+  for (i = (!s->mark_begin.x) ? s->mark_begin.y : s->mark_begin.y + 1;
+       i < s->mark_end.y || (i == s->mark_end.y && s->mark_end.x > 0); i++)
     {
-     if(b->bf[i].s[m] == ' ') nn++;
-     else if(b->bf[i].s[m] == '\t')
-     nn += f->ed->tabn - (nn % f->ed->tabn);
+      for (j = 0; j < b->bf[i].len && isspace (b->bf[i].s[j]); j++);
+      for (l = j - 1, k = 0; l >= 0 && k < n; l--)
+	{
+	  if (b->bf[i].s[l] == ' ')
+	    k++;
+	  else if (b->bf[i].s[l] == '\t')
+	    {
+	      for (nn = m = 0; m < l; m++)
+		{
+		  if (b->bf[i].s[m] == ' ')
+		    nn++;
+		  else if (b->bf[i].s[m] == '\t')
+		    nn += f->ed->tabn - (nn % f->ed->tabn);
+		}
+	      k += f->ed->tabn - (nn % f->ed->tabn);
+	    }
+	}
+      l = j - l - 1;
+      if (l > 0)
+	{
+	  nn = s->mark_begin.x;
+	  e_del_nchar (b, s, j - l, i, l);
+	  if (k > n)
+	    e_ins_nchar (b, s, tstr, j - l, i, k - n);
+	  s->mark_begin.x = nn;
+	}
     }
-    k += f->ed->tabn - (nn % f->ed->tabn);
-   }
-  }
-  l = j - l - 1;
-  if(l > 0)
-  {
-   nn = s->mark_begin.x;
-   e_del_nchar(b, s, j - l, i, l);
-   if (k > n) e_ins_nchar(b, s, tstr, j-l, i, k-n);
-   s->mark_begin.x = nn;
-  }
- }
- free(tstr);
- e_schirm(f, 1);
- return(0);
+  free (tstr);
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*   indent block   */
-int e_blck_to_right(FENSTER *f)
+int
+e_blck_to_right (FENSTER * f)
 {
- BUFFER *b;
- SCHIRM *s;
- int n = f->ed->tabn/2, i, j;
- unsigned char *tstr = malloc((n+1)*sizeof(char));
+  BUFFER *b;
+  SCHIRM *s;
+  int n = f->ed->tabn / 2, i, j;
+  unsigned char *tstr = malloc ((n + 1) * sizeof (char));
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- s = f->s;
- for (i = 0; i < n; i++)
-  tstr[i] = ' ';
- tstr[n] = '\0';
- for (i = (!s->mark_begin.x) ? s->mark_begin.y : s->mark_begin.y + 1;
-   i < s->mark_end.y || (i == s->mark_end.y && s->mark_end.x > 0); i++)
- {
-  for (j = 0; b->bf[i].len && isspace(b->bf[i].s[j]); j++)
-   ;
-  e_ins_nchar(b, s, tstr, j, i, n);
-  if (i == s->mark_begin.y)
-   s->mark_begin.x = 0;
- }
- free(tstr);
- e_schirm(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  for (i = 0; i < n; i++)
+    tstr[i] = ' ';
+  tstr[n] = '\0';
+  for (i = (!s->mark_begin.x) ? s->mark_begin.y : s->mark_begin.y + 1;
+       i < s->mark_end.y || (i == s->mark_end.y && s->mark_end.x > 0); i++)
+    {
+      for (j = 0; b->bf[i].len && isspace (b->bf[i].s[j]); j++);
+      e_ins_nchar (b, s, tstr, j, i, n);
+      if (i == s->mark_begin.y)
+	s->mark_begin.x = 0;
+    }
+  free (tstr);
+  e_schirm (f, 1);
+  return (0);
 }
 
 /*            Read block from file   */
-int e_blck_read(FENSTER *f)
+int
+e_blck_read (FENSTER * f)
 {
- if (f->ins == 8)
-  return(WPE_ESC);
- WpeCreateFileManager(1, f->ed, "");
- f->save = f->ed->maxchg + 1;
- return(0);
+  if (f->ins == 8)
+    return (WPE_ESC);
+  WpeCreateFileManager (1, f->ed, "");
+  f->save = f->ed->maxchg + 1;
+  return (0);
 }
 
 /*   write block to file   */
-int e_blck_write(FENSTER *f)
+int
+e_blck_write (FENSTER * f)
 {
- WpeCreateFileManager(2, f->ed, "");
- return(0);
+  WpeCreateFileManager (2, f->ed, "");
+  return (0);
 }
 
 /*   find again   */
-int e_rep_search(FENSTER *f)
+int
+e_rep_search (FENSTER * f)
 {
- SCHIRM *s;
- BUFFER *b;
- FIND *fd = &(f->ed->fd);
- int i, ret, j, iend, jend, end;
+  SCHIRM *s;
+  BUFFER *b;
+  FIND *fd = &(f->ed->fd);
+  int i, ret, j, iend, jend, end;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;  s = f->s;
- ret = b->b.x;
- j = b->b.y;
- if ((fd->sw & 8) == 0)
- {
-  jend = (fd->sw & 4) ? 0 : b->mxlines-1;
-  iend = (fd->sw & 4) ? 0 : b->bf[b->mxlines-1].len;
- }
- else
- {
-  jend = (fd->sw & 4) ? s->mark_begin.y : s->mark_end.y;
-  iend = (fd->sw & 4) ? s->mark_begin.x : s->mark_end.x;
- }
-
- for (; ; ret = -1)
- {
-  if ((fd->sw & 4) == 0 && j > jend)
-   break;
-  else if ((fd->sw & 4) != 0 && j < jend)
-   break;
-  do
-  {
-   if (j == jend)
-    end = iend;
-   else if (!(fd->sw & 4))
-    end = b->bf[j].len;
-   else
-    end = 0;
-   if (fd->sw & 4 && ret == -1)
-    ret = b->bf[j].len;
-   if ((fd->sw & 32) == 0)
-   {
-    if ((fd->sw & 128) != 0)
-     ret = e_strstr(ret, end, b->bf[j].s, (unsigned char *)fd->search);
-    else
-     ret = e_ustrstr(ret, end, b->bf[j].s, (unsigned char *)fd->search);
-   }
-   else
-   {
-    if ((fd->sw & 128) != 0)
-     ret = e_rstrstr(ret, end, b->bf[j].s, (unsigned char *)fd->search, &(fd->sn));
-    else
-     ret = e_urstrstr(ret, end, b->bf[j].s, (unsigned char *)fd->search, &(fd->sn));
-   }
-   if ((fd->sw & 4) == 0 && j == jend && ret > iend)
-    break;
-   else if ((fd->sw & 4) != 0 && j == jend && ret < iend)
-    break;
-   if (ret >= 0 && ((fd->sw & 64) == 0 ||
-     (isalnum(*(b->bf[j].s+ret+fd->sn)) == 0 &&
-     (ret == 0 || isalnum(*(b->bf[j].s+ret-1)) == 0))))
-   {
-    s->fa.x = ret;
-    b->b.y = s->fa.y = s->fe.y = j;
-    s->fe.x = ret + fd->sn;
-    b->b.x = ret = !(fd->sw & 4) ? s->fe.x : ret;
-    if (!(fd->sw & 1))
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  ret = b->b.x;
+  j = b->b.y;
+  if ((fd->sw & 8) == 0)
     {
-     e_cursor(f, 1);
-     s->fa.y = j;
-     e_schirm(f, 1);
+      jend = (fd->sw & 4) ? 0 : b->mxlines - 1;
+      iend = (fd->sw & 4) ? 0 : b->bf[b->mxlines - 1].len;
     }
-    return(1);
-   }
-   else if (ret >= 0 && (fd->sw & 64) != 0)
-    ret++;
-  } while(ret >= 0);
-  if ((fd->sw & 4) == 0 && j > jend)
-   break;
-  else if ((fd->sw & 4) != 0 && j < jend)
-   break;
-  j = ((fd->sw & 4) == 0) ? j+1 : j-1;
- }
- if (!(fd->sw & 1))
-  e_message(0, e_msg[ERR_GETSTRING], f);
- return(0);
+  else
+    {
+      jend = (fd->sw & 4) ? s->mark_begin.y : s->mark_end.y;
+      iend = (fd->sw & 4) ? s->mark_begin.x : s->mark_end.x;
+    }
+
+  for (;; ret = -1)
+    {
+      if ((fd->sw & 4) == 0 && j > jend)
+	break;
+      else if ((fd->sw & 4) != 0 && j < jend)
+	break;
+      do
+	{
+	  if (j == jend)
+	    end = iend;
+	  else if (!(fd->sw & 4))
+	    end = b->bf[j].len;
+	  else
+	    end = 0;
+	  if (fd->sw & 4 && ret == -1)
+	    ret = b->bf[j].len;
+	  if ((fd->sw & 32) == 0)
+	    {
+	      if ((fd->sw & 128) != 0)
+		ret =
+		  e_strstr (ret, end, b->bf[j].s,
+			    (unsigned char *) fd->search);
+	      else
+		ret =
+		  e_ustrstr (ret, end, b->bf[j].s,
+			     (unsigned char *) fd->search);
+	    }
+	  else
+	    {
+	      if ((fd->sw & 128) != 0)
+		ret =
+		  e_rstrstr (ret, end, b->bf[j].s,
+			     (unsigned char *) fd->search, &(fd->sn));
+	      else
+		ret =
+		  e_urstrstr (ret, end, b->bf[j].s,
+			      (unsigned char *) fd->search, &(fd->sn));
+	    }
+	  if ((fd->sw & 4) == 0 && j == jend && ret > iend)
+	    break;
+	  else if ((fd->sw & 4) != 0 && j == jend && ret < iend)
+	    break;
+	  if (ret >= 0 && ((fd->sw & 64) == 0 ||
+			   (isalnum (*(b->bf[j].s + ret + fd->sn)) == 0 &&
+			    (ret == 0
+			     || isalnum (*(b->bf[j].s + ret - 1)) == 0))))
+	    {
+	      s->fa.x = ret;
+	      b->b.y = s->fa.y = s->fe.y = j;
+	      s->fe.x = ret + fd->sn;
+	      b->b.x = ret = !(fd->sw & 4) ? s->fe.x : ret;
+	      if (!(fd->sw & 1))
+		{
+		  e_cursor (f, 1);
+		  s->fa.y = j;
+		  e_schirm (f, 1);
+		}
+	      return (1);
+	    }
+	  else if (ret >= 0 && (fd->sw & 64) != 0)
+	    ret++;
+	}
+      while (ret >= 0);
+      if ((fd->sw & 4) == 0 && j > jend)
+	break;
+      else if ((fd->sw & 4) != 0 && j < jend)
+	break;
+      j = ((fd->sw & 4) == 0) ? j + 1 : j - 1;
+    }
+  if (!(fd->sw & 1))
+    e_message (0, e_msg[ERR_GETSTRING], f);
+  return (0);
 }
 
 /*   goto line  */
-int e_goto_line(FENSTER *f)
+int
+e_goto_line (FENSTER * f)
 {
- int i, num;
- BUFFER *b;
+  int i, num;
+  BUFFER *b;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- if ((num = e_num_kst("Goto Line Number", b->b.y+1, b->mxlines, f, 0, AltG)) > 0)
-  b->b.y = num - 1;
- else if (num == 0)
-  b->b.y = num;
- e_cursor(f, 1);
- return(0);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  if ((num =
+       e_num_kst ("Goto Line Number", b->b.y + 1, b->mxlines, f, 0,
+		  AltG)) > 0)
+    b->b.y = num - 1;
+  else if (num == 0)
+    b->b.y = num;
+  e_cursor (f, 1);
+  return (0);
 }
 
-int e_find(FENSTER *f)
+int
+e_find (FENSTER * f)
 {
- SCHIRM *s;
- BUFFER *b;
- FIND *fd = &(f->ed->fd);
- int i, ret;
- char strTemp[80];
- W_OPTSTR *o = e_init_opt_kst(f);
+  SCHIRM *s;
+  BUFFER *b;
+  FIND *fd = &(f->ed->fd);
+  int i, ret;
+  char strTemp[80];
+  W_OPTSTR *o = e_init_opt_kst (f);
 
- if (!o)
-  return(-1);
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;  s = f->s;
- if (e_blck_dup(strTemp, f))
- {
-  strcpy(fd->search, strTemp);
-  fd->sn = strlen(fd->search);
- }
- o->xa = 7;  o->ya = 3;  o->xe = 63;  o->ye = 18;
- o->bgsw = 0;
- o->crsw = AltO;
- o->name = "Find";
- e_add_txtstr(32, 4, "Direction:", o);
- e_add_txtstr(4, 4, "Options:", o);
- e_add_txtstr(4, 9, "Scope:", o);
- e_add_txtstr(32, 9, "Begin:", o);
- e_add_wrstr(4, 2, 18, 2, 35, 128, 0, AltT, "Text to Find:", fd->search, &f->ed->sdf, o);
- e_add_sswstr(5, 5, 0, AltC, fd->sw & 128 ? 1 : 0, "Case sensitive    ", o);
- e_add_sswstr(5, 6, 0, AltW, fd->sw & 64 ? 1 : 0, "Whole words only  ", o);
- e_add_sswstr(5, 7, 0, AltR, fd->sw & 32 ? 1 : 0, "Regular expression", o);
- e_add_pswstr(0, 33, 5, 6, AltD, 0, "ForwarD        ", o);
- e_add_pswstr(0, 33, 6, 0, AltB, fd->sw & 4 ? 1 : 0, "Backward       ", o);
- e_add_pswstr(1, 5, 10, 0, AltG, 0, "Global            ", o);
- e_add_pswstr(1, 5, 11, 0, AltS, fd->sw & 8 ? 1 : 0, "Selected Text     ", o);
- e_add_pswstr(2, 33, 10, 0, AltF, 0, "From Cursor    ", o);
- e_add_pswstr(2, 33, 11, 0, AltE, fd->sw & 2 ? 1 : 0, "Entire Scope   ", o);
- e_add_bttstr(16, 13, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(34, 13, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
-  fd->sw = (o->pstr[0]->num << 2) + (o->pstr[1]->num << 3) +
-    (o->pstr[2]->num << 1) + (o->sstr[0]->num << 7) + (o->sstr[1]->num << 6) +
-    (o->sstr[2]->num << 5);
-  strcpy(fd->search, o->wstr[0]->txt);
-  fd->sn = strlen(fd->search);
-  if ((fd->sw & 2) != 0)
-  {
-   if ((fd->sw & 4) == 0)
-   {
-    b->b.x = (fd->sw & 8) == 0 ? 0 : s->mark_begin.x;
-    b->b.y = (fd->sw & 8) == 0 ? 0 : s->mark_begin.y;
-   }
-   else
-   {
-    b->b.x = (fd->sw & 8) == 0 ? b->bf[b->mxlines-1].len : s->mark_end.x;
-    b->b.y = (fd->sw & 8) == 0 ? b->mxlines-1 : s->mark_end.y;
-   }
-  }
- }
- freeostr(o);
- if (ret != WPE_ESC)
-  e_rep_search(f);
- return(0);
+  if (!o)
+    return (-1);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  if (e_blck_dup (strTemp, f))
+    {
+      strcpy (fd->search, strTemp);
+      fd->sn = strlen (fd->search);
+    }
+  o->xa = 7;
+  o->ya = 3;
+  o->xe = 63;
+  o->ye = 18;
+  o->bgsw = 0;
+  o->crsw = AltO;
+  o->name = "Find";
+  e_add_txtstr (32, 4, "Direction:", o);
+  e_add_txtstr (4, 4, "Options:", o);
+  e_add_txtstr (4, 9, "Scope:", o);
+  e_add_txtstr (32, 9, "Begin:", o);
+  e_add_wrstr (4, 2, 18, 2, 35, 128, 0, AltT, "Text to Find:", fd->search,
+	       &f->ed->sdf, o);
+  e_add_sswstr (5, 5, 0, AltC, fd->sw & 128 ? 1 : 0, "Case sensitive    ", o);
+  e_add_sswstr (5, 6, 0, AltW, fd->sw & 64 ? 1 : 0, "Whole words only  ", o);
+  e_add_sswstr (5, 7, 0, AltR, fd->sw & 32 ? 1 : 0, "Regular expression", o);
+  e_add_pswstr (0, 33, 5, 6, AltD, 0, "ForwarD        ", o);
+  e_add_pswstr (0, 33, 6, 0, AltB, fd->sw & 4 ? 1 : 0, "Backward       ", o);
+  e_add_pswstr (1, 5, 10, 0, AltG, 0, "Global            ", o);
+  e_add_pswstr (1, 5, 11, 0, AltS, fd->sw & 8 ? 1 : 0,
+		"Selected Text     ", o);
+  e_add_pswstr (2, 33, 10, 0, AltF, 0, "From Cursor    ", o);
+  e_add_pswstr (2, 33, 11, 0, AltE, fd->sw & 2 ? 1 : 0, "Entire Scope   ", o);
+  e_add_bttstr (16, 13, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (34, 13, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      fd->sw = (o->pstr[0]->num << 2) + (o->pstr[1]->num << 3) +
+	(o->pstr[2]->num << 1) + (o->sstr[0]->num << 7) +
+	(o->sstr[1]->num << 6) + (o->sstr[2]->num << 5);
+      strcpy (fd->search, o->wstr[0]->txt);
+      fd->sn = strlen (fd->search);
+      if ((fd->sw & 2) != 0)
+	{
+	  if ((fd->sw & 4) == 0)
+	    {
+	      b->b.x = (fd->sw & 8) == 0 ? 0 : s->mark_begin.x;
+	      b->b.y = (fd->sw & 8) == 0 ? 0 : s->mark_begin.y;
+	    }
+	  else
+	    {
+	      b->b.x =
+		(fd->sw & 8) == 0 ? b->bf[b->mxlines - 1].len : s->mark_end.x;
+	      b->b.y = (fd->sw & 8) == 0 ? b->mxlines - 1 : s->mark_end.y;
+	    }
+	}
+    }
+  freeostr (o);
+  if (ret != WPE_ESC)
+    e_rep_search (f);
+  return (0);
 }
 
 /* The menu and menuhandling have been rewritten to support only 4 choices
@@ -1100,114 +1176,123 @@ int e_find(FENSTER *f)
   The result window is either 'String NOT Found' or the number of
   occurrences found and the number actually replaced.
 */
-int e_replace(FENSTER *f)
+int
+e_replace (FENSTER * f)
 {
- SCHIRM *s;
- BUFFER *b;
- FIND *fd = &(f->ed->fd);
- int i, ret, c, rep=0, found=0;
- char strTemp[80];
- W_OPTSTR *o = e_init_opt_kst(f);
+  SCHIRM *s;
+  BUFFER *b;
+  FIND *fd = &(f->ed->fd);
+  int i, ret, c, rep = 0, found = 0;
+  char strTemp[80];
+  W_OPTSTR *o = e_init_opt_kst (f);
 
- if (!o)
-  return(-1);
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
-  return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;  s = f->s;
- if (e_blck_dup(strTemp, f))
- {
-  strcpy(fd->search, strTemp);
-  fd->sn = strlen(fd->search);
- }
- o->xa = 7;  o->ya = 3;  o->xe = 67;  o->ye = 17;
- o->bgsw = 0;
- o->name = "Replace";
- o->crsw = AltO;
- e_add_txtstr(4, 6, "Options:", o);
- e_add_txtstr(32, 6, "Scope:", o);
- e_add_wrstr(4, 2, 18, 2, 35, 128, 0, AltT, "Text to Find:", fd->search, &f->ed->sdf, o);
- e_add_wrstr(4, 4, 18, 4, 35, 128, 0, AltN, "New Text:", fd->replace, &f->ed->rdf, o);
- e_add_sswstr(5, 7, 0, AltC, fd->sw & 128 ? 1 : 0, "Case sensitive    ", o);
- e_add_sswstr(5, 8, 0, AltW, fd->sw & 64 ? 1 : 0, "Whole words only  ", o);
- e_add_sswstr(5, 9, 0, AltR, fd->sw & 32 ? 1 : 0, "Regular expression", o);
- e_add_sswstr(5, 10, 0, AltP, 1, "Prompt on Replace ", o);
- e_add_pswstr(0, 33, 7, 0, AltF, 0, "Forward from Cursor", o);
- e_add_pswstr(0, 33, 8, 0, AltB, fd->sw & 4 ? 1 : 0, "Back from Cursor   ", o);
- e_add_pswstr(0, 33, 9, 0, AltG, fd->sw & 2 ? 1 : 0, "Global Replace     ", o);
- if (s->mark_end.y)
-  e_add_pswstr(0, 33, 10, 0, AltS, fd->sw & 10 ? 1 : 0, "Selected Text      ", o);
- e_add_bttstr(10, 12, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(41, 12, -1, WPE_ESC, "Cancel", NULL, o);
- e_add_bttstr(22, 12, 7, AltA, "Change All", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
-  strcpy(fd->search, o->wstr[0]->txt);
-  fd->sn = strlen(fd->search);
-  strcpy(fd->replace, o->wstr[1]->txt);
-  fd->rn = strlen(fd->replace);
-  fd->sw = 1 + (o->sstr[0]->num << 7)+ (o->sstr[1]->num << 6)
-    + (o->sstr[2]->num << 5) + (o->sstr[3]->num << 4);
-  switch (o->pstr[0]->num)
-  {
-   case 2:
-    fd->sw |= 2;
-    b->b.x = b->b.y = 0;
-    break;
-   case 1:
-    fd->sw |= 4;
-    b->b.x = b->bf[b->mxlines-1].len;
-    b->b.y = b->mxlines-1;
-    break;
-   case 3:
-    fd->sw |= 10;
-    b->b.x = s->mark_begin.x;
-    b->b.y = s->mark_begin.y;
-   default:
-    break;
-  }
- }
- freeostr(o);
- if (ret != WPE_ESC)
- {
-  while (e_rep_search(f) && ((ret == AltA) || (!found)))
-  {
-   found++;
-   if (f->a.y < 11)
-   {
-    s->c.y = b->b.y - 1; 
-   }
-   e_schirm(f, 1);
-   c = 'Y';
-   if (fd->sw & 16)
-    c = e_message(1, "String found:\nReplace this occurrence ?",f);
-   if (c == WPE_ESC)
-    break;
-   if (c == 'Y')
-   {
-    rep++;
-    e_add_undo('s', b, s->fa.x, b->b.y, fd->sn);
-    e_undo_sw = 1;
-    e_del_nchar(b, s, s->fa.x, b->b.y, fd->sn);
-    e_ins_nchar(b, s, (unsigned char *)fd->replace, s->fa.x, b->b.y, fd->rn);
-    e_undo_sw = 0;
-    s->fe.x = s->fa.x + fd->rn;
-    b->b.x = !(fd->sw & 4) ? s->fe.x : s->fa.x;
-    e_schirm(f, 1);
-   }
-  }
-  if (found)
-  {
-   sprintf(strTemp, "Found %d\nReplaced %d", found, rep);
-   e_message(0, strTemp, f);
-  }
-  else
-   e_message(0, e_msg[ERR_GETSTRING], f);
- }
- return(0);
+  if (!o)
+    return (-1);
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  if (e_blck_dup (strTemp, f))
+    {
+      strcpy (fd->search, strTemp);
+      fd->sn = strlen (fd->search);
+    }
+  o->xa = 7;
+  o->ya = 3;
+  o->xe = 67;
+  o->ye = 17;
+  o->bgsw = 0;
+  o->name = "Replace";
+  o->crsw = AltO;
+  e_add_txtstr (4, 6, "Options:", o);
+  e_add_txtstr (32, 6, "Scope:", o);
+  e_add_wrstr (4, 2, 18, 2, 35, 128, 0, AltT, "Text to Find:", fd->search,
+	       &f->ed->sdf, o);
+  e_add_wrstr (4, 4, 18, 4, 35, 128, 0, AltN, "New Text:", fd->replace,
+	       &f->ed->rdf, o);
+  e_add_sswstr (5, 7, 0, AltC, fd->sw & 128 ? 1 : 0, "Case sensitive    ", o);
+  e_add_sswstr (5, 8, 0, AltW, fd->sw & 64 ? 1 : 0, "Whole words only  ", o);
+  e_add_sswstr (5, 9, 0, AltR, fd->sw & 32 ? 1 : 0, "Regular expression", o);
+  e_add_sswstr (5, 10, 0, AltP, 1, "Prompt on Replace ", o);
+  e_add_pswstr (0, 33, 7, 0, AltF, 0, "Forward from Cursor", o);
+  e_add_pswstr (0, 33, 8, 0, AltB, fd->sw & 4 ? 1 : 0,
+		"Back from Cursor   ", o);
+  e_add_pswstr (0, 33, 9, 0, AltG, fd->sw & 2 ? 1 : 0,
+		"Global Replace     ", o);
+  if (s->mark_end.y)
+    e_add_pswstr (0, 33, 10, 0, AltS, fd->sw & 10 ? 1 : 0,
+		  "Selected Text      ", o);
+  e_add_bttstr (10, 12, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (41, 12, -1, WPE_ESC, "Cancel", NULL, o);
+  e_add_bttstr (22, 12, 7, AltA, "Change All", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      strcpy (fd->search, o->wstr[0]->txt);
+      fd->sn = strlen (fd->search);
+      strcpy (fd->replace, o->wstr[1]->txt);
+      fd->rn = strlen (fd->replace);
+      fd->sw = 1 + (o->sstr[0]->num << 7) + (o->sstr[1]->num << 6)
+	+ (o->sstr[2]->num << 5) + (o->sstr[3]->num << 4);
+      switch (o->pstr[0]->num)
+	{
+	case 2:
+	  fd->sw |= 2;
+	  b->b.x = b->b.y = 0;
+	  break;
+	case 1:
+	  fd->sw |= 4;
+	  b->b.x = b->bf[b->mxlines - 1].len;
+	  b->b.y = b->mxlines - 1;
+	  break;
+	case 3:
+	  fd->sw |= 10;
+	  b->b.x = s->mark_begin.x;
+	  b->b.y = s->mark_begin.y;
+	default:
+	  break;
+	}
+    }
+  freeostr (o);
+  if (ret != WPE_ESC)
+    {
+      while (e_rep_search (f) && ((ret == AltA) || (!found)))
+	{
+	  found++;
+	  if (f->a.y < 11)
+	    {
+	      s->c.y = b->b.y - 1;
+	    }
+	  e_schirm (f, 1);
+	  c = 'Y';
+	  if (fd->sw & 16)
+	    c = e_message (1, "String found:\nReplace this occurrence ?", f);
+	  if (c == WPE_ESC)
+	    break;
+	  if (c == 'Y')
+	    {
+	      rep++;
+	      e_add_undo ('s', b, s->fa.x, b->b.y, fd->sn);
+	      e_undo_sw = 1;
+	      e_del_nchar (b, s, s->fa.x, b->b.y, fd->sn);
+	      e_ins_nchar (b, s, (unsigned char *) fd->replace, s->fa.x,
+			   b->b.y, fd->rn);
+	      e_undo_sw = 0;
+	      s->fe.x = s->fa.x + fd->rn;
+	      b->b.x = !(fd->sw & 4) ? s->fe.x : s->fa.x;
+	      e_schirm (f, 1);
+	    }
+	}
+      if (found)
+	{
+	  sprintf (strTemp, "Found %d\nReplaced %d", found, rep);
+	  e_message (0, strTemp, f);
+	}
+      else
+	e_message (0, e_msg[ERR_GETSTRING], f);
+    }
+  return (0);
 }
-

--- a/src/we_block.h
+++ b/src/we_block.h
@@ -5,28 +5,28 @@
 #include "we_opt.h"
 #include "we_debug.h"
 
-int e_blck_del(FENSTER *f);
-int e_blck_dup(char *dup, FENSTER *f);
-int e_show_clipboard(FENSTER *f);
-int e_edt_del(FENSTER *f);
-int e_edt_copy(FENSTER *f);
-int e_edt_einf(FENSTER *f);
-int e_blck_move(FENSTER *f);
-void e_move_block(int x, int y, BUFFER *bv, BUFFER *bz, FENSTER *f);
-int e_blck_copy(FENSTER *f);
-void e_copy_block(int x, int y, BUFFER *buffer_src, BUFFER *buffer_dst,
-  FENSTER *f);
-int e_blck_begin(FENSTER *f);
-int e_blck_end(FENSTER *f);
-int e_blck_hide(FENSTER *f);
-int e_find(FENSTER *f);
-int e_replace(FENSTER *f);
-int e_goto_line(FENSTER *f);
-int e_changecase_dialog(FENSTER *f);
-int e_blck_to_left(FENSTER *f);
-int e_blck_to_right(FENSTER *f);
-int e_blck_read(FENSTER *f);
-int e_blck_write(FENSTER *f);
-int e_rep_search(FENSTER *f);
+int e_blck_del (FENSTER * f);
+int e_blck_dup (char *dup, FENSTER * f);
+int e_show_clipboard (FENSTER * f);
+int e_edt_del (FENSTER * f);
+int e_edt_copy (FENSTER * f);
+int e_edt_einf (FENSTER * f);
+int e_blck_move (FENSTER * f);
+void e_move_block (int x, int y, BUFFER * bv, BUFFER * bz, FENSTER * f);
+int e_blck_copy (FENSTER * f);
+void e_copy_block (int x, int y, BUFFER * buffer_src, BUFFER * buffer_dst,
+		   FENSTER * f);
+int e_blck_begin (FENSTER * f);
+int e_blck_end (FENSTER * f);
+int e_blck_hide (FENSTER * f);
+int e_find (FENSTER * f);
+int e_replace (FENSTER * f);
+int e_goto_line (FENSTER * f);
+int e_changecase_dialog (FENSTER * f);
+int e_blck_to_left (FENSTER * f);
+int e_blck_to_right (FENSTER * f);
+int e_blck_read (FENSTER * f);
+int e_blck_write (FENSTER * f);
+int e_rep_search (FENSTER * f);
 
 #endif

--- a/src/we_debug.c
+++ b/src/we_debug.c
@@ -7,7 +7,7 @@
 #include <ctype.h>
 #include <string.h>
 #if defined HAVE_LIBNCURSES || HAVE_LIBCURSES
-#  include <curses.h>
+#include <curses.h>
 #endif
 #include "config.h"
 #include "keys.h"
@@ -43,8 +43,8 @@
 #define CTRLC CtrlC
 #define SVLINES 12
 
-int e_d_delbreak(FENSTER *f);
-int e_d_error(char *s);
+int e_d_delbreak (FENSTER * f);
+int e_d_error (char *s);
 
 #define MAXOUT  2 * MAXSCOL * MAXSLNS
 
@@ -59,7 +59,7 @@ int e_d_nwtchs = 0;
    the i-th watch in the Watches window */
 int *e_d_nrwtchs;
 
-char **e_d_swtchs; /* e_d_swtchs[i] is the i-th watch expression (a char*) */
+char **e_d_swtchs;		/* e_d_swtchs[i] is the i-th watch expression (a char*) */
 
 int e_d_nstack;
 char e_d_file[128], **e_d_sbrpts;
@@ -77,8 +77,8 @@ extern char *att_no;
 extern char *e_tmp_dir;
 
 #ifndef HAVE_TPARM
-char *tparm();
-char *tgoto();
+char *tparm ();
+char *tgoto ();
 #endif
 
 // Disabled DEFTPUTS because it is part if stdio.h
@@ -86,179 +86,182 @@ char *tgoto();
 //int tputs();
 //#endif
 
-char *npipe[5] = {  NULL, NULL, NULL, NULL, NULL  };
+char *npipe[5] = { NULL, NULL, NULL, NULL, NULL };
 
-char *e_d_msg[] = {  "Ctrl C pressed\nQuit Debugger ?",
-			"Quit Debugger ?",
-			"End of Debugging",
-			"Program is not running",
-			"No symbol in current context\n",
-			"No Source-Code",       /*  Number 5  */
-			"Start Debugger",
-			"Can\'t start Debugger",
-			"Starting program:",
-			"Can\'t start Program",
-			"Program exited",       /*   Number 10   */
-			"Program terminated",
-			"Program received signal",
-			"Unknown Break\nQuit Debugger ?",
-			"Can\'t find file %s",
-			"Can\'t create named pipe",  /*   Number 15   */
-			"Breakpoint",
-			"(sig ",
-			"program exited",
-			"signal",
-			"interrupt",      /* Number 20  */
-			"stopped in",
-			"BREAKPOINT",
-			"Child process terminated normally",
-			"software termination",
-			"Continuing.\n",  /* Number 25  */
-			"No stack.",
-			"no process"
-		  };
+char *e_d_msg[] = { "Ctrl C pressed\nQuit Debugger ?",
+  "Quit Debugger ?",
+  "End of Debugging",
+  "Program is not running",
+  "No symbol in current context\n",
+  "No Source-Code",		/*  Number 5  */
+  "Start Debugger",
+  "Can\'t start Debugger",
+  "Starting program:",
+  "Can\'t start Program",
+  "Program exited",		/*   Number 10   */
+  "Program terminated",
+  "Program received signal",
+  "Unknown Break\nQuit Debugger ?",
+  "Can\'t find file %s",
+  "Can\'t create named pipe",	/*   Number 15   */
+  "Breakpoint",
+  "(sig ",
+  "program exited",
+  "signal",
+  "interrupt",			/* Number 20  */
+  "stopped in",
+  "BREAKPOINT",
+  "Child process terminated normally",
+  "software termination",
+  "Continuing.\n",		/* Number 25  */
+  "No stack.",
+  "no process"
+};
 
 extern char *e_p_msg[];
 
-int e_deb_inp(FENSTER *f)
+int
+e_deb_inp (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int c = 0;
+  ECNT *cn = f->ed;
+  int c = 0;
 
- f = cn->f[cn->mxedt];
- c = e_getch();
- switch(c)
- {
-  case 'p':
-  case ('p' - 'a' + 1):
-   e_deb_out(f);
-   break;
-  case 'o':
-  case ('o' - 'a' + 1):
-   e_deb_options(f);
-   break;
-  case 'b':
-  case ('b' - 'a' + 1):
-   e_breakpoint(f);
-   break;
-  case 'm':
-  case ('m' - 'a' + 1):
-   e_remove_breakpoints(f);
-   break;
-  case 'a':
-  case 1:
-   e_remove_all_watches(f);
-   break;
-  case 'd':
-  case ('d' - 'a' + 1):
-   e_delete_watches(f);
-   break;
-  case 'w':
-  case ('w' - 'a' + 1):
-   e_make_watches(f);
-   break;
-  case 'e':
-  case ('e' - 'a' + 1):
-   e_edit_watches(f);
-   break;
-  case 'k':
-  case ('k' - 'a' + 1):
-   e_deb_stack(f);
-   break;
-  case 't':
-  case ('t' - 'a' + 1):
-   e_deb_trace(f);
-   break;
-  case 's':
-  case ('s' - 'a' + 1):
-   e_deb_next(f);
-   break;
-  case 'r':
-  case 'c':
-  case ('r' - 'a' + 1):
-  case ('c' - 'a' + 1):
-   e_deb_run(f);
-   break;
-  case 'q':
-  case ('q' - 'a' + 1):
-   e_d_quit(f);
-   break;
-  case 'u':
-  case ('u'-'a'+1):
-   e_d_goto_cursor(f);
-   break;
-  case 'f':
-  case ('f'-'a'+1):
-   e_d_finish_func(f);
-   break;
-  default:
-   return(c);
- }
- return(0);
+  f = cn->f[cn->mxedt];
+  c = e_getch ();
+  switch (c)
+    {
+    case 'p':
+    case ('p' - 'a' + 1):
+      e_deb_out (f);
+      break;
+    case 'o':
+    case ('o' - 'a' + 1):
+      e_deb_options (f);
+      break;
+    case 'b':
+    case ('b' - 'a' + 1):
+      e_breakpoint (f);
+      break;
+    case 'm':
+    case ('m' - 'a' + 1):
+      e_remove_breakpoints (f);
+      break;
+    case 'a':
+    case 1:
+      e_remove_all_watches (f);
+      break;
+    case 'd':
+    case ('d' - 'a' + 1):
+      e_delete_watches (f);
+      break;
+    case 'w':
+    case ('w' - 'a' + 1):
+      e_make_watches (f);
+      break;
+    case 'e':
+    case ('e' - 'a' + 1):
+      e_edit_watches (f);
+      break;
+    case 'k':
+    case ('k' - 'a' + 1):
+      e_deb_stack (f);
+      break;
+    case 't':
+    case ('t' - 'a' + 1):
+      e_deb_trace (f);
+      break;
+    case 's':
+    case ('s' - 'a' + 1):
+      e_deb_next (f);
+      break;
+    case 'r':
+    case 'c':
+    case ('r' - 'a' + 1):
+    case ('c' - 'a' + 1):
+      e_deb_run (f);
+      break;
+    case 'q':
+    case ('q' - 'a' + 1):
+      e_d_quit (f);
+      break;
+    case 'u':
+    case ('u' - 'a' + 1):
+      e_d_goto_cursor (f);
+      break;
+    case 'f':
+    case ('f' - 'a' + 1):
+      e_d_finish_func (f);
+      break;
+    default:
+      return (c);
+    }
+  return (0);
 }
 
-int e_d_q_quit(FENSTER *f)
+int
+e_d_q_quit (FENSTER * f)
 {
- int ret = e_message(1, e_d_msg[ERR_QUITDEBUG], f);
+  int ret = e_message (1, e_d_msg[ERR_QUITDEBUG], f);
 
- if (ret == 'Y')
-  e_d_quit(f);
- return(0);
+  if (ret == 'Y')
+    e_d_quit (f);
+  return (0);
 }
 
-int e_debug_switch(FENSTER *f, int c)
+int
+e_debug_switch (FENSTER * f, int c)
 {
- switch (c)
- {
-  case F7:
-   e_deb_trace(f);
-   break;
-  case F8:
-   e_deb_next(f);
-   break;
-  case CF10:
-   e_deb_run(f);
-   break;
-  case CF2:
-   e_d_q_quit(f);
-   break;
-  default:
-   if (f->ed->edopt & ED_CUA_STYLE)
-   {
-    switch (c)
+  switch (c)
     {
-     case F5:
-      e_breakpoint(f);
+    case F7:
+      e_deb_trace (f);
       break;
-     case CF5:
-      e_make_watches(f);
+    case F8:
+      e_deb_next (f);
       break;
-     case CF3:
-      e_deb_stack(f);
+    case CF10:
+      e_deb_run (f);
       break;
-     default:
-      return(c);
+    case CF2:
+      e_d_q_quit (f);
+      break;
+    default:
+      if (f->ed->edopt & ED_CUA_STYLE)
+	{
+	  switch (c)
+	    {
+	    case F5:
+	      e_breakpoint (f);
+	      break;
+	    case CF5:
+	      e_make_watches (f);
+	      break;
+	    case CF3:
+	      e_deb_stack (f);
+	      break;
+	    default:
+	      return (c);
+	    }
+	}
+      else
+	{
+	  switch (c)
+	    {
+	    case CF8:
+	      e_breakpoint (f);
+	      break;
+	    case CF7:
+	      e_make_watches (f);
+	      break;
+	    case CF6:
+	      e_deb_stack (f);
+	      break;
+	    default:
+	      return (c);
+	    }
+	}
     }
-   }
-   else
-   {
-    switch (c)
-    {
-     case CF8:
-      e_breakpoint(f);
-      break;
-     case CF7:
-      e_make_watches(f);
-      break;
-     case CF6:
-      e_deb_stack(f);
-      break;
-     default:
-      return(c);
-    }
-   }
- }
- return(0);
+  return (0);
 }
 
 /*  Input Routines   */
@@ -280,30 +283,31 @@ int e_debug_switch(FENSTER *f, int c)
  *
  *  FIXME: find out what the returns mean exactly
  */
-int e_e_line_read(int n, char *s, int max)
+int
+e_e_line_read (int n, char *s, int max)
 {
- int i, ret = 0;
+  int i, ret = 0;
 
- for (i = 0; i < max - 1; i++)
- {
-  ret = read(n, s + i, 1);
-  if (ret != 1 || s[i] == EOF || s[i] == '\n'|| s[i] == '\0')
-   break;
- }
- if (ret != 1 && i == 0)
-  return(-1);
- s[i+1] = '\0';
- if (e_deb_type == 1 && s[i] == '*')
-  return(1);
- if (e_deb_type == 3 && s[i] == '>')
-  return(1);
- else if (e_deb_type == 2 && i > 4 && s[i] == ' ' 
-		&& !strncmp((const char *)s+i-5, "(dbx)", 5))
-  return(1);
- else if (e_deb_type == 0 && i > 4 && s[i] == ' ' 
-		&& !strncmp((const char *)s+i-5, "(gdb)", 5))
-  return(1);
- return(2);
+  for (i = 0; i < max - 1; i++)
+    {
+      ret = read (n, s + i, 1);
+      if (ret != 1 || s[i] == EOF || s[i] == '\n' || s[i] == '\0')
+	break;
+    }
+  if (ret != 1 && i == 0)
+    return (-1);
+  s[i + 1] = '\0';
+  if (e_deb_type == 1 && s[i] == '*')
+    return (1);
+  if (e_deb_type == 3 && s[i] == '>')
+    return (1);
+  else if (e_deb_type == 2 && i > 4 && s[i] == ' '
+	   && !strncmp ((const char *) s + i - 5, "(dbx)", 5))
+    return (1);
+  else if (e_deb_type == 0 && i > 4 && s[i] == ' '
+	   && !strncmp ((const char *) s + i - 5, "(gdb)", 5))
+    return (1);
+  return (2);
 }
 
 /**
@@ -313,2454 +317,2846 @@ int e_e_line_read(int n, char *s, int max)
  * TODO: Must the string s really be signed char *? Replaced with char *. check & test.
  *
 */
-int e_d_line_read(int n, char *s, int max, int sw, int esw)
+int
+e_d_line_read (int n, char *s, int max, int sw, int esw)
 {
- static char wt = 0, esc_sv = 0, str[12];
- int i, j, ret = 0, kbdflgs;
+  static char wt = 0, esc_sv = 0, str[12];
+  int i, j, ret = 0, kbdflgs;
 
- if (esw)
- {  if((ret = e_e_line_read(efildes[0], s, max)) >= 0) return(ret);  }
- else
- {  while(e_e_line_read(efildes[0], s, max) >= 0);  }
- for(i = 0; i < max - 1; i++)
- {
-  if (esc_sv)  {  s[i] = WPE_ESC;  esc_sv = 0;  continue;  }
-  kbdflgs = fcntl(n, F_GETFL, 0 );
-  fcntl( n, F_SETFL, kbdflgs | O_NONBLOCK);
-  while ((ret = read(n, s + i, 1)) <= 0 && i == 0 && wt >= sw)
-   if(e_d_getchar() == D_CBREAK) return(-1);
+  if (esw)
+    {
+      if ((ret = e_e_line_read (efildes[0], s, max)) >= 0)
+	return (ret);
+    }
+  else
+    {
+      while (e_e_line_read (efildes[0], s, max) >= 0);
+    }
+  for (i = 0; i < max - 1; i++)
+    {
+      if (esc_sv)
+	{
+	  s[i] = WPE_ESC;
+	  esc_sv = 0;
+	  continue;
+	}
+      kbdflgs = fcntl (n, F_GETFL, 0);
+      fcntl (n, F_SETFL, kbdflgs | O_NONBLOCK);
+      while ((ret = read (n, s + i, 1)) <= 0 && i == 0 && wt >= sw)
+	if (e_d_getchar () == D_CBREAK)
+	  return (-1);
 /*	Read until no chars are left anymore
    	Return if buffer not empty
         return(-1) if CBREAK
 */
-  fcntl( n, F_SETFL, kbdflgs & ~O_NONBLOCK);
-  if (ret == -1) break;
-  else if (ret != 1 ||  s[i] == EOF || s[i] == '\0') break;
-  else if(s[i] == '\n' || s[i] == WPE_CR)  break;
-  else if(s[i] == WPE_ESC)
-  {  s[i] = '\0';  esc_sv = 1;  break;  }
- }
- if (ret != 1)
- {
-  s[i] = '\0';
-  if(e_deb_type == 1 && i > 0 && s[i-1] == '*')
-  {  str[0] = 0;  wt = 0;   return(1);  }
-  else if(e_deb_type == 3 && i > 0 && s[i-1] == '>')
-  {  str[0] = 0;  wt = 0;   return(1);  }
-  else if(e_deb_type == 0)
-  {
-   if(i > 5 && !strncmp((const char *)s+i-6, "(gdb) ", 6))
-   {  str[0] = 0;  wt = 0;   return(1);  }
-   else if(i < 6)
-   {
-    for (j = 0; j <= i; j++) str[6+j] = s[j];
-    if (!strncmp(str+i-6, "(gdb) ", 6))
-    {  str[0] = '\0';  wt = 0;  return(1);  }
-   }
-  }
-  else if (e_deb_type == 2)
-  {
-   if(i > 5 && !strncmp((const char *)s+i-6, "(dbx) ", 6))
-   {  str[0] = 0;  wt = 0;   return(1);  }
-   else if(i < 6)
-   {
-    for(j = 0; j <= i; j++) str[6+j] = s[j];
-    if(!strncmp(str+i-6, "(dbx) ", 6))
-    {  str[0] = '\0';  wt = 0;  return(1);  }
-   }
-  }
- }
- else {  s[i+1] = '\0';  }
- if (i != 0) wt = 0;
- else wt++;
- if(i > 4) for(j = 0; j < 6; j++) str[j] = s[j+i-5];
- return(0);
+      fcntl (n, F_SETFL, kbdflgs & ~O_NONBLOCK);
+      if (ret == -1)
+	break;
+      else if (ret != 1 || s[i] == EOF || s[i] == '\0')
+	break;
+      else if (s[i] == '\n' || s[i] == WPE_CR)
+	break;
+      else if (s[i] == WPE_ESC)
+	{
+	  s[i] = '\0';
+	  esc_sv = 1;
+	  break;
+	}
+    }
+  if (ret != 1)
+    {
+      s[i] = '\0';
+      if (e_deb_type == 1 && i > 0 && s[i - 1] == '*')
+	{
+	  str[0] = 0;
+	  wt = 0;
+	  return (1);
+	}
+      else if (e_deb_type == 3 && i > 0 && s[i - 1] == '>')
+	{
+	  str[0] = 0;
+	  wt = 0;
+	  return (1);
+	}
+      else if (e_deb_type == 0)
+	{
+	  if (i > 5 && !strncmp ((const char *) s + i - 6, "(gdb) ", 6))
+	    {
+	      str[0] = 0;
+	      wt = 0;
+	      return (1);
+	    }
+	  else if (i < 6)
+	    {
+	      for (j = 0; j <= i; j++)
+		str[6 + j] = s[j];
+	      if (!strncmp (str + i - 6, "(gdb) ", 6))
+		{
+		  str[0] = '\0';
+		  wt = 0;
+		  return (1);
+		}
+	    }
+	}
+      else if (e_deb_type == 2)
+	{
+	  if (i > 5 && !strncmp ((const char *) s + i - 6, "(dbx) ", 6))
+	    {
+	      str[0] = 0;
+	      wt = 0;
+	      return (1);
+	    }
+	  else if (i < 6)
+	    {
+	      for (j = 0; j <= i; j++)
+		str[6 + j] = s[j];
+	      if (!strncmp (str + i - 6, "(dbx) ", 6))
+		{
+		  str[0] = '\0';
+		  wt = 0;
+		  return (1);
+		}
+	    }
+	}
+    }
+  else
+    {
+      s[i + 1] = '\0';
+    }
+  if (i != 0)
+    wt = 0;
+  else
+    wt++;
+  if (i > 4)
+    for (j = 0; j < 6; j++)
+      str[j] = s[j + i - 5];
+  return (0);
 }
 
-int e_d_dum_read()
+int
+e_d_dum_read ()
 {
- char str[256];
- int ret;
+  char str[256];
+  int ret;
 
- while ((ret = e_d_line_read(wfildes[0], str, 128, 0, 0)) == 0 || ret == 2)
-  if (ret == 2)
-   e_d_error(str);
- return(ret);
+  while ((ret = e_d_line_read (wfildes[0], str, 128, 0, 0)) == 0 || ret == 2)
+    if (ret == 2)
+      e_d_error (str);
+  return (ret);
 }
 
 /* Output Routines */
-int e_d_p_exec(FENSTER *f)
+int
+e_d_p_exec (FENSTER * f)
 {
- ECNT *cn = f->ed;
- BUFFER *b;
- int ret, i, is, j;
- char str[512];
+  ECNT *cn = f->ed;
+  BUFFER *b;
+  int ret, i, is, j;
+  char str[512];
 
- for (i = cn->mxedt; i > 0 && strcmp(cn->f[i]->datnam, "Messages"); i--)
-  ;
- if (i <= 0)
- {  e_edit(cn, "Messages");  i = cn->mxedt;  }
- f = cn->f[i];
- b = cn->f[i]->b;
- if (b->bf[b->mxlines-1].len != 0)
-  e_new_line(b->mxlines, b);
- for (j = 0, i = is = b->mxlines-1;
-   (ret = e_d_line_read(wfildes[0], str, 512, 0, 0)) == 0; )
- {
-  if (ret == -1)
-   return(ret);
-  print_to_end_of_buffer(b, str, b->mx.x);
- }
- if (ret == 1)
- {
-  e_new_line(i, b);
-  for (j = 0; j < NUM_COLS_ON_SCREEN_SAFE - 2 && str[j] != '\n' &&
-    str[j] != '\0'; j++)
-   *(b->bf[i].s+j) = str[j];
-  b->b.y = i;
-  b->b.x = b->bf[i].len = j;
-  b->bf[i].nrc = j;
- }
- b->b.y = b->mxlines-1;
- b->b.x = 0;
+  for (i = cn->mxedt; i > 0 && strcmp (cn->f[i]->datnam, "Messages"); i--)
+    ;
+  if (i <= 0)
+    {
+      e_edit (cn, "Messages");
+      i = cn->mxedt;
+    }
+  f = cn->f[i];
+  b = cn->f[i]->b;
+  if (b->bf[b->mxlines - 1].len != 0)
+    e_new_line (b->mxlines, b);
+  for (j = 0, i = is = b->mxlines - 1;
+       (ret = e_d_line_read (wfildes[0], str, 512, 0, 0)) == 0;)
+    {
+      if (ret == -1)
+	return (ret);
+      print_to_end_of_buffer (b, str, b->mx.x);
+    }
+  if (ret == 1)
+    {
+      e_new_line (i, b);
+      for (j = 0; j < NUM_COLS_ON_SCREEN_SAFE - 2 && str[j] != '\n' &&
+	   str[j] != '\0'; j++)
+	*(b->bf[i].s + j) = str[j];
+      b->b.y = i;
+      b->b.x = b->bf[i].len = j;
+      b->bf[i].nrc = j;
+    }
+  b->b.y = b->mxlines - 1;
+  b->b.x = 0;
 
- e_rep_win_tree(cn);
- return(ret);
+  e_rep_win_tree (cn);
+  return (ret);
 }
 
 /*    Help Routines   */
-int e_d_getchar()
+int
+e_d_getchar ()
 {
- int i = 1, fd;
- char c = 0, kbdflgs = 0;
+  int i = 1, fd;
+  char c = 0, kbdflgs = 0;
 
- if (WpeIsXwin()) fd = rfildes[0];
- else fd = 0;
+  if (WpeIsXwin ())
+    fd = rfildes[0];
+  else
+    fd = 0;
 
 /*   if(WpeIsXwin() || e_deb_mode)    */
- {
-  kbdflgs = fcntl(fd, F_GETFL, 0 );
-  fcntl( fd, F_SETFL, kbdflgs | O_NONBLOCK);
- }
-#ifndef NO_XWINDOWS
- if (WpeIsXwin())
-  c = (*e_u_change)(NULL);
-#endif
- if (c || (i = read(fd, &c, 1)) == 1)
- {
-  if (c == CTRLC)
   {
-/*	 if (WpeIsXwin() || e_deb_mode)    */
-   fcntl(fd, F_SETFL, kbdflgs & ~O_NONBLOCK);
-   e_d_switch_out(0);
-   i = e_message(1, e_d_msg[ERR_CTRLCPRESS], WpeEditor->f[WpeEditor->mxedt]);
-   if (i == 'Y')
-   {
-    e_d_quit(WpeEditor->f[WpeEditor->mxedt]);
-    return(D_CBREAK);
-   }
-   else
-    return(c);
+    kbdflgs = fcntl (fd, F_GETFL, 0);
+    fcntl (fd, F_SETFL, kbdflgs | O_NONBLOCK);
   }
-  else
-   if (write(rfildes[1], &c, 1) < 1) {
-	printf("[e_d_getchar] writing 1 character failed.\n");
-   }
- }
+#ifndef NO_XWINDOWS
+  if (WpeIsXwin ())
+    c = (*e_u_change) (NULL);
+#endif
+  if (c || (i = read (fd, &c, 1)) == 1)
+    {
+      if (c == CTRLC)
+	{
+/*	 if (WpeIsXwin() || e_deb_mode)    */
+	  fcntl (fd, F_SETFL, kbdflgs & ~O_NONBLOCK);
+	  e_d_switch_out (0);
+	  i =
+	    e_message (1, e_d_msg[ERR_CTRLCPRESS],
+		       WpeEditor->f[WpeEditor->mxedt]);
+	  if (i == 'Y')
+	    {
+	      e_d_quit (WpeEditor->f[WpeEditor->mxedt]);
+	      return (D_CBREAK);
+	    }
+	  else
+	    return (c);
+	}
+      else if (write (rfildes[1], &c, 1) < 1)
+	{
+	  printf ("[e_d_getchar] writing 1 character failed.\n");
+	}
+    }
 /*   if (WpeIsXwin() || e_deb_mode)   */
- fcntl(fd, F_SETFL, kbdflgs & ~O_NONBLOCK);
- return(i == 1 ? c : 0);
+  fcntl (fd, F_SETFL, kbdflgs & ~O_NONBLOCK);
+  return (i == 1 ? c : 0);
 }
 
-int e_d_is_watch(int c, FENSTER *f)
+int
+e_d_is_watch (int c, FENSTER * f)
 {
- if (strcmp(f->datnam, "Watches"))
-  return(0);
- if(c == EINFG)
-  return(e_make_watches(f));
- else if (c == ENTF)
-  return(e_delete_watches(f));
- else
-  return(0);
+  if (strcmp (f->datnam, "Watches"))
+    return (0);
+  if (c == EINFG)
+    return (e_make_watches (f));
+  else if (c == ENTF)
+    return (e_delete_watches (f));
+  else
+    return (0);
 }
 
 /** 
  * Remark: return changed to void: no return was given and no one tested return. 
  *
  * */
-void e_d_quit_basic(FENSTER *f)
+void
+e_d_quit_basic (FENSTER * f)
 {
- UNUSED(f);
- int kbdflgs;
+  UNUSED (f);
+  int kbdflgs;
 
- if (!e_d_swtch)
-  return;
- if (rfildes[1] >= 0)
- {
-  char *cstr = 0;
-  if (e_deb_type == 0 || e_deb_type == 3)
-   cstr = "q\ny\n";
-  else if (e_deb_type == 1)
-   cstr = "q\n";
-  else if (e_deb_type == 2)
-   cstr = "quit\n";
-  if (cstr) {
-    int n = strlen(cstr);
-    if (n != write(rfildes[1], cstr, n)) {
-  	printf("[e_d_is_watch] failed to write %i characters: %s.\n", n, cstr);
+  if (!e_d_swtch)
+    return;
+  if (rfildes[1] >= 0)
+    {
+      char *cstr = 0;
+      if (e_deb_type == 0 || e_deb_type == 3)
+	cstr = "q\ny\n";
+      else if (e_deb_type == 1)
+	cstr = "q\n";
+      else if (e_deb_type == 2)
+	cstr = "quit\n";
+      if (cstr)
+	{
+	  int n = strlen (cstr);
+	  if (n != write (rfildes[1], cstr, n))
+	    {
+	      printf ("[e_d_is_watch] failed to write %i characters: %s.\n",
+		      n, cstr);
+	    }
+	}
     }
-  }
- }
- kbdflgs = fcntl(0, F_GETFL, 0 );
- fcntl(0, F_SETFL, kbdflgs & ~O_NONBLOCK);
- e_d_swtch = 0;
- if (e_d_pid)
- {
-  kill(e_d_pid, 9);
-  e_d_pid = 0;
- }
- if (!WpeIsXwin())
- {
-  if (e_d_out)
-   free(e_d_out);
-  e_d_out = NULL;
- }
- if (rfildes[1] >= 0)
-  close(rfildes[1]);
- if (wfildes[0] >= 0)
-  close(wfildes[0]);
- if (efildes[0] >= 0)
-  close(efildes[0]);
- if (rfildes[0] >= 0)
-  close(rfildes[0]);
- if (wfildes[1] >= 0)
-  close(wfildes[1]);
- if (WpeIsXwin())
- {
-  remove(npipe[0]);
-  remove(npipe[1]);
-  remove(npipe[2]);
-  remove(npipe[3]);
-  remove(npipe[4]);
- }
- else
- {
-  if (efildes[1] >= 0)
-   close(efildes[1]);
-  if (!e_deb_mode)
-   e_g_sys_end();
+  kbdflgs = fcntl (0, F_GETFL, 0);
+  fcntl (0, F_SETFL, kbdflgs & ~O_NONBLOCK);
+  e_d_swtch = 0;
+  if (e_d_pid)
+    {
+      kill (e_d_pid, 9);
+      e_d_pid = 0;
+    }
+  if (!WpeIsXwin ())
+    {
+      if (e_d_out)
+	free (e_d_out);
+      e_d_out = NULL;
+    }
+  if (rfildes[1] >= 0)
+    close (rfildes[1]);
+  if (wfildes[0] >= 0)
+    close (wfildes[0]);
+  if (efildes[0] >= 0)
+    close (efildes[0]);
+  if (rfildes[0] >= 0)
+    close (rfildes[0]);
+  if (wfildes[1] >= 0)
+    close (wfildes[1]);
+  if (WpeIsXwin ())
+    {
+      remove (npipe[0]);
+      remove (npipe[1]);
+      remove (npipe[2]);
+      remove (npipe[3]);
+      remove (npipe[4]);
+    }
   else
-  {
-   e_d_switch_out(1);
-   fk_locate(MAXSCOL, MAXSLNS);
+    {
+      if (efildes[1] >= 0)
+	close (efildes[1]);
+      if (!e_deb_mode)
+	e_g_sys_end ();
+      else
+	{
+	  e_d_switch_out (1);
+	  fk_locate (MAXSCOL, MAXSLNS);
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
-   e_putp("\r\n");
-   e_putp(att_no);
+	  e_putp ("\r\n");
+	  e_putp (att_no);
 #endif
-   e_d_switch_out(0);
-  }
- }
+	  e_d_switch_out (0);
+	}
+    }
 }
 
-int e_d_quit(FENSTER *f)
+int
+e_d_quit (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int i;
- e_d_quit_basic(f);
- e_d_p_message(e_d_msg[ERR_ENDDEBUG], f, 1);
- WpeMouseChangeShape(WpeEditingShape);
- e_d_delbreak(f);
- for (i = cn->mxedt; i > 0; i--)
-  if (!strcmp(cn->f[i]->datnam, "Messages"))
-  {
-   e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-   break;
-  }
- if (i <= 0)
-  e_edit(cn, "Messages");
- return(0);
+  ECNT *cn = f->ed;
+  int i;
+  e_d_quit_basic (f);
+  e_d_p_message (e_d_msg[ERR_ENDDEBUG], f, 1);
+  WpeMouseChangeShape (WpeEditingShape);
+  e_d_delbreak (f);
+  for (i = cn->mxedt; i > 0; i--)
+    if (!strcmp (cn->f[i]->datnam, "Messages"))
+      {
+	e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	break;
+      }
+  if (i <= 0)
+    e_edit (cn, "Messages");
+  return (0);
 }
 
 /*    Watches   */
-int e_d_add_watch(char *str, FENSTER *f)
+int
+e_d_add_watch (char *str, FENSTER * f)
 {
- int ret;
+  int ret;
 
- ret = e_add_arguments(str, "Add Watch", f, 0, AltA, &f->ed->wdf);
- if (ret != WPE_ESC)
- {
-  f->ed->wdf = e_add_df(str, f->ed->wdf);
- }
- fk_cursor(1);
- return(ret);
+  ret = e_add_arguments (str, "Add Watch", f, 0, AltA, &f->ed->wdf);
+  if (ret != WPE_ESC)
+    {
+      f->ed->wdf = e_add_df (str, f->ed->wdf);
+    }
+  fk_cursor (1);
+  return (ret);
 }
 
-int e_remove_all_watches(FENSTER *f)
+int
+e_remove_all_watches (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int i, n;
+  ECNT *cn = f->ed;
+  int i, n;
 
- if (e_d_nwtchs < 1) return(0);
- for (n = 0; n < e_d_nwtchs;n++) free(e_d_swtchs[n]);
- free(e_d_swtchs);
- free(e_d_nrwtchs);
- e_d_nwtchs = 0;
- for (i = cn->mxedt; i > 0; i--)
- {
-  if (!strcmp(cn->f[i]->datnam, "Watches"))
-  {
-   e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-   e_close_window(cn->f[cn->mxedt]);
-   break;
-  }
- }
- e_close_buffer(e_p_w_buffer);
- e_p_w_buffer = NULL;
- return(0);
+  if (e_d_nwtchs < 1)
+    return (0);
+  for (n = 0; n < e_d_nwtchs; n++)
+    free (e_d_swtchs[n]);
+  free (e_d_swtchs);
+  free (e_d_nrwtchs);
+  e_d_nwtchs = 0;
+  for (i = cn->mxedt; i > 0; i--)
+    {
+      if (!strcmp (cn->f[i]->datnam, "Watches"))
+	{
+	  e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	  e_close_window (cn->f[cn->mxedt]);
+	  break;
+	}
+    }
+  e_close_buffer (e_p_w_buffer);
+  e_p_w_buffer = NULL;
+  return (0);
 }
 
-int e_delete_watches(FENSTER *f)
+int
+e_delete_watches (FENSTER * f)
 {
- ECNT *cn = f->ed;
- BUFFER *b = cn->f[cn->mxedt]->b;
- int n;
+  ECNT *cn = f->ed;
+  BUFFER *b = cn->f[cn->mxedt]->b;
+  int n;
 
- f = cn->f[cn->mxedt];
- if (e_d_nwtchs < 1 || strcmp(f->datnam, "Watches"))
-  return(0);
- for (n = 0; n < e_d_nwtchs && e_d_nrwtchs[n] <= b->b.y; n++)
-  ;
- free(e_d_swtchs[n - 1]);
- for (; n < e_d_nwtchs; n++)
-  e_d_swtchs[n - 1] = e_d_swtchs[n];
- e_d_nwtchs--;
- e_d_swtchs = realloc(e_d_swtchs, e_d_nwtchs * sizeof(char *));
- e_d_nrwtchs = realloc(e_d_nrwtchs, e_d_nwtchs * sizeof(int));
- e_d_p_watches(f, 0);
- return(0);
+  f = cn->f[cn->mxedt];
+  if (e_d_nwtchs < 1 || strcmp (f->datnam, "Watches"))
+    return (0);
+  for (n = 0; n < e_d_nwtchs && e_d_nrwtchs[n] <= b->b.y; n++)
+    ;
+  free (e_d_swtchs[n - 1]);
+  for (; n < e_d_nwtchs; n++)
+    e_d_swtchs[n - 1] = e_d_swtchs[n];
+  e_d_nwtchs--;
+  e_d_swtchs = realloc (e_d_swtchs, e_d_nwtchs * sizeof (char *));
+  e_d_nrwtchs = realloc (e_d_nrwtchs, e_d_nwtchs * sizeof (int));
+  e_d_p_watches (f, 0);
+  return (0);
 }
 
-int e_make_watches(FENSTER *f)
+int
+e_make_watches (FENSTER * f)
 {
- char str[128];
- int i, y;
+  char str[128];
+  int i, y;
 
- if ((f->ed->mxedt > 0) && (strcmp(f->datnam, "Watches") == 0))
- { /* sets y=number of watch we're inserting */
-  for(y = 0; y < e_d_nwtchs && e_d_nrwtchs[y] < f->b->b.y; y++)
-   ;
- }
- else
-  y = e_d_nwtchs;
- if (f->ed->wdf && f->ed->wdf->anz > 0)
-  strcpy(str, f->ed->wdf->name[0]);
- else
-  str[0] = '\0';
- if (e_d_add_watch(str, f))
- {
-  e_d_nwtchs++;
-  if (e_d_nwtchs == 1)
-  {
-   e_d_swtchs = malloc(sizeof(char *));
-   e_d_nrwtchs = malloc(sizeof(int));
-  }
+  if ((f->ed->mxedt > 0) && (strcmp (f->datnam, "Watches") == 0))
+    {				/* sets y=number of watch we're inserting */
+      for (y = 0; y < e_d_nwtchs && e_d_nrwtchs[y] < f->b->b.y; y++)
+	;
+    }
   else
-  {
-   e_d_swtchs = realloc(e_d_swtchs, e_d_nwtchs * sizeof(char *));
-   e_d_nrwtchs = realloc(e_d_nrwtchs, e_d_nwtchs * sizeof(int));
-  }
+    y = e_d_nwtchs;
+  if (f->ed->wdf && f->ed->wdf->anz > 0)
+    strcpy (str, f->ed->wdf->name[0]);
+  else
+    str[0] = '\0';
+  if (e_d_add_watch (str, f))
+    {
+      e_d_nwtchs++;
+      if (e_d_nwtchs == 1)
+	{
+	  e_d_swtchs = malloc (sizeof (char *));
+	  e_d_nrwtchs = malloc (sizeof (int));
+	}
+      else
+	{
+	  e_d_swtchs = realloc (e_d_swtchs, e_d_nwtchs * sizeof (char *));
+	  e_d_nrwtchs = realloc (e_d_nrwtchs, e_d_nwtchs * sizeof (int));
+	}
 
-  /*
-    move watch number y and following up one position so that we can insert
-    at position y
-  */
-  for (i = e_d_nwtchs - 1; i > y; i--)
-  {
-   e_d_swtchs[i] = e_d_swtchs[i-1];
+      /*
+         move watch number y and following up one position so that we can insert
+         at position y
+       */
+      for (i = e_d_nwtchs - 1; i > y; i--)
+	{
+	  e_d_swtchs[i] = e_d_swtchs[i - 1];
 
-   /* The following instruction is pointless as e_d_nrwtchs[i] is invalidated
-      by inserting the new watch and has to be recomputed by e_d_p_watches()
-   */
-   e_d_nrwtchs[i] = e_d_nrwtchs[i-1];
-  }
-  e_d_swtchs[y] = malloc(strlen(str) + 1); /* insert...                    */
-  strcpy(e_d_swtchs[y], str);              /*       ... new watch at pos y */
-  e_d_p_watches(f, 1);
-  return(0);
- }
- return(-1);
+	  /* The following instruction is pointless as e_d_nrwtchs[i] is invalidated
+	     by inserting the new watch and has to be recomputed by e_d_p_watches()
+	   */
+	  e_d_nrwtchs[i] = e_d_nrwtchs[i - 1];
+	}
+      e_d_swtchs[y] = malloc (strlen (str) + 1);	/* insert...                    */
+      strcpy (e_d_swtchs[y], str);	/*       ... new watch at pos y */
+      e_d_p_watches (f, 1);
+      return (0);
+    }
+  return (-1);
 }
 
-int e_edit_watches(FENSTER *f)
+int
+e_edit_watches (FENSTER * f)
 {
- BUFFER *b = f->ed->f[f->ed->mxedt]->b;
- char str[128];
- int l;
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  char str[128];
+  int l;
 
- if (strcmp(f->datnam, "Watches"))
-  return(0);
- for (l = 0; l < e_d_nwtchs && e_d_nrwtchs[l] <= b->b.y; l++)
-  ;
- if (l == e_d_nwtchs && b->bf[b->b.y].len == 0)
-  return(e_make_watches(f));
- strcpy(str, e_d_swtchs[l - 1]);
- if (e_d_add_watch(str, f))
- {
-  e_d_swtchs[l - 1] = realloc(e_d_swtchs[l - 1], strlen(str) + 1);
-  strcpy(e_d_swtchs[l - 1], str);
-  e_d_p_watches(f, 0);
-  return(0);
- }
- return(-1);
+  if (strcmp (f->datnam, "Watches"))
+    return (0);
+  for (l = 0; l < e_d_nwtchs && e_d_nrwtchs[l] <= b->b.y; l++)
+    ;
+  if (l == e_d_nwtchs && b->bf[b->b.y].len == 0)
+    return (e_make_watches (f));
+  strcpy (str, e_d_swtchs[l - 1]);
+  if (e_d_add_watch (str, f))
+    {
+      e_d_swtchs[l - 1] = realloc (e_d_swtchs[l - 1], strlen (str) + 1);
+      strcpy (e_d_swtchs[l - 1], str);
+      e_d_p_watches (f, 0);
+      return (0);
+    }
+  return (-1);
 }
 
 /* Among other things, e_d_p_watches() must recompute e_d_nrwtchs when
    called from e_edit_watches(),
    but has code paths that don't do this ==> possible BUG
 */
-int e_d_p_watches(FENSTER *f, int sw)
+int
+e_d_p_watches (FENSTER * f, int sw)
 {
- ECNT *cn = f->ed;
- BUFFER *b;
- int iw, k = 0, l, ret;
- char str1[256], *str; /* is 256 always large enough? */
- char *str2;
+  ECNT *cn = f->ed;
+  BUFFER *b;
+  int iw, k = 0, l, ret;
+  char str1[256], *str;		/* is 256 always large enough? */
+  char *str2;
 
- e_d_switch_out(0);
- if ((e_d_swtch > 2) && (e_d_p_stack(f, 0) == -1))
-  return(-1);
- /* Find the watch window */
- for (iw = cn->mxedt; iw > 0 && strcmp(cn->f[iw]->datnam, "Watches"); iw--);
- if (iw == 0 && !e_d_nwtchs)
- { /* if no watches and the mysterious iw!=0 then just repaint window tree */
-  e_rep_win_tree(cn);
-  return(0);
- }
- else if (iw == 0)
- {
-  if(e_edit(cn, "Watches"))
-  {
-   return(-1);
-  }
+  e_d_switch_out (0);
+  if ((e_d_swtch > 2) && (e_d_p_stack (f, 0) == -1))
+    return (-1);
+  /* Find the watch window */
+  for (iw = cn->mxedt; iw > 0 && strcmp (cn->f[iw]->datnam, "Watches"); iw--);
+  if (iw == 0 && !e_d_nwtchs)
+    {				/* if no watches and the mysterious iw!=0 then just repaint window tree */
+      e_rep_win_tree (cn);
+      return (0);
+    }
+  else if (iw == 0)
+    {
+      if (e_edit (cn, "Watches"))
+	{
+	  return (-1);
+	}
+      else
+	{
+	  iw = cn->mxedt;
+	}
+    }
+  f = cn->f[iw];
+  b = cn->f[iw]->b;
+
+  /* free all lines of BUFFER b */
+  e_p_red_buffer (b);
+  free (b->bf[0].s);
+  b->mxlines = 0;
+
+  for (l = 0; l < e_d_nwtchs; l++)
+    {
+      str = str1;
+
+      /* Create appropriate command for the debugger */
+      if (e_deb_type == 0 || e_deb_type == 3)
+	{
+	  sprintf (str1, "p %s\n", e_d_swtchs[l]);
+	}
+      else if (e_deb_type == 1)
+	{
+	  sprintf (str1, "%s/\n", e_d_swtchs[l]);
+	}
+      else if (e_deb_type == 2)
+	{
+	  sprintf (str1, "print %s\n", e_d_swtchs[l]);
+	}
+
+      /* Send command to debugger */
+      if (e_d_swtch)
+	{
+	  int n = strlen (str1);
+	  if (n != write (rfildes[1], str1, n))
+	    {
+	      printf ("[e_d_p_watches]: write to debugger failed for '%s'.\n",
+		      str1);
+	    }
+	}
+
+      /* If no debugger or no response, give message of no symbol in context */
+      if (!e_d_swtch
+	  || (ret = e_d_line_read (wfildes[0], str1, 256, 0, 0)) == 1)
+	{
+	  strcpy (str1, e_d_msg[ERR_NOSYMBOL]);
+	  k = 0;
+	}
+      else			/* Debugger successfully returned a value */
+	{
+	  if (ret == -1)
+	    {
+	      return (ret);	/* BUG? e_d_nrwtchs not initialized if this return is taken */
+	    }
+	  str = malloc (strlen (str1) + 1);
+	  strcpy (str, str1);
+	  while ((ret = e_d_line_read (wfildes[0], str1, 256, 0, 0)) == 0
+		 || ret == 2)
+	    {
+	      if (ret == -1)
+		return (ret);	/* BUG? e_d_nrwtchs not initialized if this return is taken */
+	      if (ret == 2)
+		e_d_error (str1);
+	      str = realloc (str, (k = strlen (str)) + strlen (str1) + 1);
+	      if (str[k - 1] == '\n')
+		str[k - 1] = ' ';
+	      strcat (str, str1);
+	    }
+
+	  /* Find the beginning of the information (depends on debugger output
+	     format) */
+	  if (e_deb_type == 0 || e_deb_type == 2 || e_deb_type == 3)
+	    {
+	      if (e_deb_type == 3 && str[0] == '0')
+		{
+		  for (k = 1; str[k] != '\0' && !isspace (str[k]); k++);
+		}
+	      else
+		for (k = 0; str[k] != '\0' && str[k] != '='; k++);
+	      if (str[k] == '\0')
+		{
+		  if (str != str1)
+		    free (str);
+		  str = str1;
+		  strcpy (str, e_d_msg[ERR_NOSYMBOL]);
+		  k = 0;
+		}
+	      for (k++; str[k] != '\0' && isspace (str[k]); k++);
+	    }
+	  else if (e_deb_type == 1)
+	    {
+	      for (k = 0; str[k] != '\0' && str[k] != ':'; k++);
+	      if (str[k] == '\0')
+		k = 0;
+	      else
+		k++;
+	    }
+	}
+
+      /* Print variable name */
+      for (; str[k] != '\0' && isspace (str[k]); k++);
+      str2 = malloc (strlen (e_d_swtchs[l]) + strlen (str + k) + 4);
+      sprintf (str2, "%s: %s", e_d_swtchs[l], str + k);
+
+      e_d_nrwtchs[l] = b->mxlines;
+      print_to_end_of_buffer (b, str2, b->mx.x);
+
+      /* Free any allocated string */
+      free (str2);
+      if (str != str1)
+	{
+	  free (str);
+	}
+    }
+
+  e_new_line (b->mxlines, b);
+  fk_cursor (1);
+  if (sw && iw != cn->mxedt)
+    e_switch_window (cn->edt[iw], cn->f[cn->mxedt]);
   else
-  {
-   iw = cn->mxedt;
-  }
- }
- f = cn->f[iw];
- b = cn->f[iw]->b;
-
- /* free all lines of BUFFER b */
- e_p_red_buffer(b);
- free(b->bf[0].s);
- b->mxlines=0;
-
- for (l = 0; l < e_d_nwtchs; l++)
- {
-  str = str1;
-
-  /* Create appropriate command for the debugger */
-  if (e_deb_type == 0 || e_deb_type == 3)
-  {
-   sprintf(str1, "p %s\n", e_d_swtchs[l]);
-  }
-  else if (e_deb_type == 1)
-  {
-   sprintf(str1, "%s/\n", e_d_swtchs[l]);
-  }
-  else if (e_deb_type == 2)
-  {
-   sprintf(str1, "print %s\n", e_d_swtchs[l]);
-  }
-
-  /* Send command to debugger */
-  if(e_d_swtch)
-  {
-   int n = strlen(str1);
-   if (n != write(rfildes[1], str1, n)) {
-      printf("[e_d_p_watches]: write to debugger failed for '%s'.\n", str1);
-   }
-  }
-
-  /* If no debugger or no response, give message of no symbol in context */
-  if (!e_d_swtch || (ret = e_d_line_read(wfildes[0], str1, 256, 0, 0)) == 1)
-  {
-   strcpy(str1, e_d_msg[ERR_NOSYMBOL]);
-   k = 0;
-  }
-  else /* Debugger successfully returned a value */
-  {
-   if (ret == -1)
-   {
-    return(ret); /* BUG? e_d_nrwtchs not initialized if this return is taken */
-   }
-   str = malloc(strlen(str1) + 1);
-   strcpy(str, str1);
-   while ((ret = e_d_line_read(wfildes[0], str1, 256, 0, 0)) == 0 || ret == 2)
-   {
-    if (ret == -1) return(ret); /* BUG? e_d_nrwtchs not initialized if this return is taken */
-    if (ret == 2) e_d_error(str1);
-    str = realloc(str, (k = strlen(str)) + strlen(str1) + 1);
-    if (str[k-1] == '\n') str[k-1] = ' ';
-    strcat(str, str1);
-   }
-
-   /* Find the beginning of the information (depends on debugger output
-     format) */
-   if (e_deb_type == 0 || e_deb_type == 2 || e_deb_type == 3)
-   {
-    if (e_deb_type == 3 && str[0] == '0')
-    {
-     for(k = 1; str[k] != '\0' && !isspace(str[k]); k++);
-    }
-    else
-     for(k = 0; str[k] != '\0' && str[k] != '='; k++);
-    if (str[k] == '\0')
-    {
-     if (str != str1) free(str);
-     str = str1;
-     strcpy(str, e_d_msg[ERR_NOSYMBOL]);
-     k = 0;
-    }
-    for(k++; str[k] != '\0' && isspace(str[k]); k++);
-   }
-   else if(e_deb_type == 1)
-   {
-    for (k = 0; str[k] != '\0' && str[k] != ':'; k++);
-    if (str[k] == '\0') k = 0;
-    else k++;
-   }
-  }
-
-  /* Print variable name */
-  for ( ; str[k] != '\0' && isspace(str[k]); k++);
-  str2 = malloc(strlen(e_d_swtchs[l]) + strlen(str + k) + 4);
-  sprintf(str2, "%s: %s", e_d_swtchs[l], str + k);
-
-  e_d_nrwtchs[l] = b->mxlines;
-  print_to_end_of_buffer(b, str2, b->mx.x);
-
-  /* Free any allocated string */
-  free(str2);
-  if(str != str1)
-  {
-   free(str);
-  }
- }
-
- e_new_line(b->mxlines, b);
- fk_cursor(1);
- if (sw && iw != cn->mxedt) e_switch_window(cn->edt[iw], cn->f[cn->mxedt]);
- else e_rep_win_tree(cn);
- return(0);
+    e_rep_win_tree (cn);
+  return (0);
 }
 
-int e_p_show_watches(FENSTER *f)
+int
+e_p_show_watches (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0; i--)
-  if (!strcmp(f->ed->f[i]->datnam, "Watches"))
-  {
-   e_switch_window(f->ed->edt[i], f->ed->f[f->ed->mxedt]);
-   break;
-  }
- if (i <= 0 && e_edit(f->ed, "Watches"))
- {
-  return(-1);
- }
- return(0);
+  for (i = f->ed->mxedt; i > 0; i--)
+    if (!strcmp (f->ed->f[i]->datnam, "Watches"))
+      {
+	e_switch_window (f->ed->edt[i], f->ed->f[f->ed->mxedt]);
+	break;
+      }
+  if (i <= 0 && e_edit (f->ed, "Watches"))
+    {
+      return (-1);
+    }
+  return (0);
 }
 
 /***************************************/
 /***  reinitialize watches from prj  ***/
-int e_d_reinit_watches(FENSTER * f,char * prj)
+int
+e_d_reinit_watches (FENSTER * f, char *prj)
 {
- int i,e,g,q,r;
- char * prj2;
+  int i, e, g, q, r;
+  char *prj2;
 
- for(i = f->ed->mxedt; i > 0; i--)
- {
-  if (!strcmp(f->ed->f[i]->datnam, "Watches"))
-  {
-   e_remove_all_watches(f->ed->f[f->ed->edt[i]]);
-   break;
-  }
- }
- g=strlen(prj);
- prj2=malloc(sizeof(char)*(g+1));
- strcpy(prj2,prj);
- q=0;
- r=0;
- while(q<g)
- {
-  e=q;
-  while(prj2[e]!=';' && e<g) e++;
-  prj2[e]='\0';
-  q=e+1;
-  r++;
- }
- e_d_nwtchs=r;
- e_d_swtchs = (char **) malloc(e_d_nwtchs * sizeof(char *));
- e_d_nrwtchs =(int *) malloc(e_d_nwtchs * sizeof(int));
+  for (i = f->ed->mxedt; i > 0; i--)
+    {
+      if (!strcmp (f->ed->f[i]->datnam, "Watches"))
+	{
+	  e_remove_all_watches (f->ed->f[f->ed->edt[i]]);
+	  break;
+	}
+    }
+  g = strlen (prj);
+  prj2 = malloc (sizeof (char) * (g + 1));
+  strcpy (prj2, prj);
+  q = 0;
+  r = 0;
+  while (q < g)
+    {
+      e = q;
+      while (prj2[e] != ';' && e < g)
+	e++;
+      prj2[e] = '\0';
+      q = e + 1;
+      r++;
+    }
+  e_d_nwtchs = r;
+  e_d_swtchs = (char **) malloc (e_d_nwtchs * sizeof (char *));
+  e_d_nrwtchs = (int *) malloc (e_d_nwtchs * sizeof (int));
 
- for(e=0,q=0;e<r;e++)
- {
-  e_d_swtchs[e] = malloc(strlen(prj2+q)+1);
-  strcpy(e_d_swtchs[e], prj2+q);
-  q+=strlen(prj2+q)+1;
- }
- free(prj2);
- e_d_p_watches(f, 1);
- return 0;
+  for (e = 0, q = 0; e < r; e++)
+    {
+      e_d_swtchs[e] = malloc (strlen (prj2 + q) + 1);
+      strcpy (e_d_swtchs[e], prj2 + q);
+      q += strlen (prj2 + q) + 1;
+    }
+  free (prj2);
+  e_d_p_watches (f, 1);
+  return 0;
 }
+
 /***************************************/
 
 /*  stack   */
-int e_deb_stack(FENSTER *f)
+int
+e_deb_stack (FENSTER * f)
 {
- e_d_switch_out(0);
- return(e_d_p_stack(f, 1));
+  e_d_switch_out (0);
+  return (e_d_p_stack (f, 1));
 }
 
-int e_d_p_stack(FENSTER *f, int sw)
+int
+e_d_p_stack (FENSTER * f, int sw)
 {
- ECNT *cn = f->ed;
- BUFFER *b;
- SCHIRM *s;
- int is, i, j, k, l, ret;
- char str[256];
+  ECNT *cn = f->ed;
+  BUFFER *b;
+  SCHIRM *s;
+  int is, i, j, k, l, ret;
+  char str[256];
 
- if (e_d_swtch < 3)
-  return(e_error(e_d_msg[ERR_NOTRUNNING], 0, f->fb));
- for (i = 0; i < SVLINES; i++)
-  e_d_out_str[i][0] = '\0';
- for (is = cn->mxedt; is > 0 && strcmp(cn->f[is]->datnam, "Stack"); is--)
-  ;
- if (!sw && is == 0)
-  return(0);
- if(is == 0)
- {
-  if (e_edit(cn, "Stack"))
-   return(-1);
-  else
-   is = cn->mxedt;
- }
- f = cn->f[is];
- b = cn->f[is]->b;
- s = cn->f[is]->s;
- if (!e_d_swtch)
-  return(0);
- int n;
- char *cstr = 0;
- if (e_deb_type == 0)
-  cstr = "bt\n";
- else if (e_deb_type == 1 || e_deb_type == 3)
-  cstr = "t\n";
- else if (e_deb_type == 2)
-  cstr = "where\n";
- if (cstr) {
-   n = strlen(cstr);
-   if (n != write(rfildes[1], cstr, n)) {
-      printf("[e_d_p_stack]: write of debugger command failed: %s", cstr);
-   }
- }
- while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 2)
-  e_d_error(str);
- if (ret == -1)
-  return(-1);
- i = j = 0;
- if (ret == 1)
- {
-  e_d_error(e_d_msg[ERR_PROGEXIT]);
-  return(e_d_quit(f));
- }
- while(ret != 1)
- {
-  k = 0;
-  do
-  {
-   if (i >= b->mxlines)
-    e_new_line(i, b);
-   if ((i > 0 && j == 0 && *(b->bf[i-1].s+b->bf[i-1].len-1) == '\\') ||
-     (!e_deb_type && j == 0 && (k > 0 || str[k] != '#')))
-   {
-    for(j = 0; j < 3; j++)
-     b->bf[i].s[j] = ' ';
-   }
-   for(; isspace(str[k]); k++)
+  if (e_d_swtch < 3)
+    return (e_error (e_d_msg[ERR_NOTRUNNING], 0, f->fb));
+  for (i = 0; i < SVLINES; i++)
+    e_d_out_str[i][0] = '\0';
+  for (is = cn->mxedt; is > 0 && strcmp (cn->f[is]->datnam, "Stack"); is--)
     ;
-   for(; j < NUM_COLS_ON_SCREEN_SAFE - 2 && str[k] != '\n' && str[k] != '\0';
-     j++, k++)
-    *(b->bf[i].s+j) = str[k];
-   if (str[k] != '\0')
-   {
-    if (str[k] != '\n')
+  if (!sw && is == 0)
+    return (0);
+  if (is == 0)
     {
-     for(l = j-1; l > 2 && !isspace(b->bf[i].s[l]) && b->bf[i].s[l] != '=';
-       l--)
-      ;
-     if (l > 2)
-     {
-      k -= (j - l - 1);
-      for (l++; l < j; l++)
-       b->bf[i].s[l] = ' ';
-     }
-     *(b->bf[i].s+j) = '\\';
-     *(b->bf[i].s+j+1) = '\n';
-     *(b->bf[i].s+j+2) = '\0';
-     j++;
-    }
-    else
-    {
-     *(b->bf[i].s+j) = '\n';
-     *(b->bf[i].s+j+1) = '\0';
-    }
-   }
-   b->bf[i].len = j;
-   b->bf[i].nrc = j + 1;
-   if (j != 0 && str[k] != '\0')
-   {
-    i++;
-    j = 0;
-   }
-   else
-    j--;
-  }
-  while (str[k] != '\n' && str[k] != '\0');
-  while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 2)
-   e_d_error(str);
-  if (ret == -1)
-   return(-1);
- }
- for (; i < b->mxlines; i++)
-  e_del_line(i, b, s);
- if (sw && is != cn->mxedt)
-  e_switch_window(cn->edt[is], cn->f[cn->mxedt]);
- e_rep_win_tree(cn);
- return(0);
-}
-
-int e_make_stack(FENSTER *f)
-{
-   char file[128], str[128], *tmpstr = malloc(1);
-   int i, ret, line = 0, dif;
-   BUFFER *b = f->ed->f[f->ed->mxedt]->b;
-   e_d_switch_out(0);
-   if(e_deb_type != 1)
-   {  tmpstr[0] = '\0';
-      if(e_deb_type == 0)
-      {  for(i = dif = 0; i <= b->b.y; i++)
-	    if(b->bf[i].s[0] == '#') dif = atoi((char *) (b->bf[i].s + 1));
-	 for(i = b->b.y; i >= 0 && b->bf[i].s[0] != '#'; i--);
-	 if(i < 0) return(1);
-	 for(; i < b->mxlines; i++)
-	 {  if(!(tmpstr = realloc(tmpstr, strlen(tmpstr) + b->bf[i].len + 2)))
-	    {  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-	    strcat(tmpstr, (char *) b->bf[i].s);
-	    if(i == b->mxlines-1 || b->bf[i+1].s[0] == '#') break;
-	    else if(tmpstr[strlen(tmpstr)-2] == '\\')
-	       tmpstr[strlen(tmpstr)-2] = '\0';
-	    else if(tmpstr[strlen(tmpstr)-1] == '\n')
-	       tmpstr[strlen(tmpstr)-1] = '\0';
-	 }
-      }
+      if (e_edit (cn, "Stack"))
+	return (-1);
       else
-      {  for(i = 1, dif = 0; i <= b->b.y; i++)
-	    if(b->bf[i-1].s[b->bf[i-1].len - 1] != '\\') dif++;
-	 for(i = b->b.y; i > 0 && b->bf[i-1].s[b->bf[i-1].len - 1] == '\\';
-	    i--);
-	 if(i == 0 && b->bf[i].len == 0) return(1);
-	 for(; i < b->mxlines; i++)
-	 {  if(!(tmpstr = realloc(tmpstr, strlen(tmpstr) + b->bf[i].len + 2)))
-	    {  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-	    strcat(tmpstr, (char *) b->bf[i].s);
-	    if(i == b->mxlines-1 || b->bf[i].s[b->bf[i].len - 1] != '\\')
-	       break;
-	    else if(tmpstr[strlen(tmpstr)-2] == '\\')
-	       tmpstr[strlen(tmpstr)-2] = '\0';
-	    else if(tmpstr[strlen(tmpstr)-1] == '\n')
-	       tmpstr[strlen(tmpstr)-1] = '\0';
-	 }
-      }
-
-      if(e_deb_type == 3 && (line = e_make_line_num2(tmpstr, file)) < 0)
-	 return(e_error(e_d_msg[ERR_NOSOURCE], 0, f->fb));
-      else if(e_deb_type != 3 && (line = e_make_line_num(tmpstr, file)) < 0)
-	 return(e_error(e_d_msg[ERR_NOSOURCE], 0, f->fb));
-      if(dif > e_d_nstack)
-	 sprintf(str, "%s %d\n",
-	 e_deb_type != 3 ? "up" : "down", dif - e_d_nstack);
-      else if(dif < e_d_nstack)
-	 sprintf(str, "%s %d\n",
-	 e_deb_type != 3 ? "down" : "up", e_d_nstack - dif);
-      if(dif != e_d_nstack)
-      {
-	 int n = strlen(str);
-         if (n != write(rfildes[1], str, n)) {
-		printf("[e_make_stack]: write to debugger failed: %s.\n", str);
-	 }
-	 while((ret = e_d_line_read(wfildes[0], str, 128, 0, 0)) == 0 || ret == 2)
-	    if( ret == 2) e_d_error(str);
-	 if(ret == -1) return(ret);
-	 e_d_nstack = dif;
-      }
-   }
-   else if(e_deb_type == 1)
-   {  for(i = b->b.y; i >= 0 && (line =
-	 e_make_line_num2((char *)b->bf[i].s, file)) < 0; i--);
-   }
-   if(e_d_p_watches(f, 0) == -1) return(-1);
-   e_d_goto_break(file, line, f);
-   return(0);
+	is = cn->mxedt;
+    }
+  f = cn->f[is];
+  b = cn->f[is]->b;
+  s = cn->f[is]->s;
+  if (!e_d_swtch)
+    return (0);
+  int n;
+  char *cstr = 0;
+  if (e_deb_type == 0)
+    cstr = "bt\n";
+  else if (e_deb_type == 1 || e_deb_type == 3)
+    cstr = "t\n";
+  else if (e_deb_type == 2)
+    cstr = "where\n";
+  if (cstr)
+    {
+      n = strlen (cstr);
+      if (n != write (rfildes[1], cstr, n))
+	{
+	  printf ("[e_d_p_stack]: write of debugger command failed: %s",
+		  cstr);
+	}
+    }
+  while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 2)
+    e_d_error (str);
+  if (ret == -1)
+    return (-1);
+  i = j = 0;
+  if (ret == 1)
+    {
+      e_d_error (e_d_msg[ERR_PROGEXIT]);
+      return (e_d_quit (f));
+    }
+  while (ret != 1)
+    {
+      k = 0;
+      do
+	{
+	  if (i >= b->mxlines)
+	    e_new_line (i, b);
+	  if ((i > 0 && j == 0
+	       && *(b->bf[i - 1].s + b->bf[i - 1].len - 1) == '\\')
+	      || (!e_deb_type && j == 0 && (k > 0 || str[k] != '#')))
+	    {
+	      for (j = 0; j < 3; j++)
+		b->bf[i].s[j] = ' ';
+	    }
+	  for (; isspace (str[k]); k++)
+	    ;
+	  for (;
+	       j < NUM_COLS_ON_SCREEN_SAFE - 2 && str[k] != '\n'
+	       && str[k] != '\0'; j++, k++)
+	    *(b->bf[i].s + j) = str[k];
+	  if (str[k] != '\0')
+	    {
+	      if (str[k] != '\n')
+		{
+		  for (l = j - 1;
+		       l > 2 && !isspace (b->bf[i].s[l])
+		       && b->bf[i].s[l] != '='; l--)
+		    ;
+		  if (l > 2)
+		    {
+		      k -= (j - l - 1);
+		      for (l++; l < j; l++)
+			b->bf[i].s[l] = ' ';
+		    }
+		  *(b->bf[i].s + j) = '\\';
+		  *(b->bf[i].s + j + 1) = '\n';
+		  *(b->bf[i].s + j + 2) = '\0';
+		  j++;
+		}
+	      else
+		{
+		  *(b->bf[i].s + j) = '\n';
+		  *(b->bf[i].s + j + 1) = '\0';
+		}
+	    }
+	  b->bf[i].len = j;
+	  b->bf[i].nrc = j + 1;
+	  if (j != 0 && str[k] != '\0')
+	    {
+	      i++;
+	      j = 0;
+	    }
+	  else
+	    j--;
+	}
+      while (str[k] != '\n' && str[k] != '\0');
+      while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 2)
+	e_d_error (str);
+      if (ret == -1)
+	return (-1);
+    }
+  for (; i < b->mxlines; i++)
+    e_del_line (i, b, s);
+  if (sw && is != cn->mxedt)
+    e_switch_window (cn->edt[is], cn->f[cn->mxedt]);
+  e_rep_win_tree (cn);
+  return (0);
 }
+
+int
+e_make_stack (FENSTER * f)
+{
+  char file[128], str[128], *tmpstr = malloc (1);
+  int i, ret, line = 0, dif;
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  e_d_switch_out (0);
+  if (e_deb_type != 1)
+    {
+      tmpstr[0] = '\0';
+      if (e_deb_type == 0)
+	{
+	  for (i = dif = 0; i <= b->b.y; i++)
+	    if (b->bf[i].s[0] == '#')
+	      dif = atoi ((char *) (b->bf[i].s + 1));
+	  for (i = b->b.y; i >= 0 && b->bf[i].s[0] != '#'; i--);
+	  if (i < 0)
+	    return (1);
+	  for (; i < b->mxlines; i++)
+	    {
+	      if (!
+		  (tmpstr =
+		   realloc (tmpstr, strlen (tmpstr) + b->bf[i].len + 2)))
+		{
+		  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		  return (-1);
+		}
+	      strcat (tmpstr, (char *) b->bf[i].s);
+	      if (i == b->mxlines - 1 || b->bf[i + 1].s[0] == '#')
+		break;
+	      else if (tmpstr[strlen (tmpstr) - 2] == '\\')
+		tmpstr[strlen (tmpstr) - 2] = '\0';
+	      else if (tmpstr[strlen (tmpstr) - 1] == '\n')
+		tmpstr[strlen (tmpstr) - 1] = '\0';
+	    }
+	}
+      else
+	{
+	  for (i = 1, dif = 0; i <= b->b.y; i++)
+	    if (b->bf[i - 1].s[b->bf[i - 1].len - 1] != '\\')
+	      dif++;
+	  for (i = b->b.y;
+	       i > 0 && b->bf[i - 1].s[b->bf[i - 1].len - 1] == '\\'; i--);
+	  if (i == 0 && b->bf[i].len == 0)
+	    return (1);
+	  for (; i < b->mxlines; i++)
+	    {
+	      if (!
+		  (tmpstr =
+		   realloc (tmpstr, strlen (tmpstr) + b->bf[i].len + 2)))
+		{
+		  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		  return (-1);
+		}
+	      strcat (tmpstr, (char *) b->bf[i].s);
+	      if (i == b->mxlines - 1 || b->bf[i].s[b->bf[i].len - 1] != '\\')
+		break;
+	      else if (tmpstr[strlen (tmpstr) - 2] == '\\')
+		tmpstr[strlen (tmpstr) - 2] = '\0';
+	      else if (tmpstr[strlen (tmpstr) - 1] == '\n')
+		tmpstr[strlen (tmpstr) - 1] = '\0';
+	    }
+	}
+
+      if (e_deb_type == 3 && (line = e_make_line_num2 (tmpstr, file)) < 0)
+	return (e_error (e_d_msg[ERR_NOSOURCE], 0, f->fb));
+      else if (e_deb_type != 3 && (line = e_make_line_num (tmpstr, file)) < 0)
+	return (e_error (e_d_msg[ERR_NOSOURCE], 0, f->fb));
+      if (dif > e_d_nstack)
+	sprintf (str, "%s %d\n",
+		 e_deb_type != 3 ? "up" : "down", dif - e_d_nstack);
+      else if (dif < e_d_nstack)
+	sprintf (str, "%s %d\n",
+		 e_deb_type != 3 ? "down" : "up", e_d_nstack - dif);
+      if (dif != e_d_nstack)
+	{
+	  int n = strlen (str);
+	  if (n != write (rfildes[1], str, n))
+	    {
+	      printf ("[e_make_stack]: write to debugger failed: %s.\n", str);
+	    }
+	  while ((ret = e_d_line_read (wfildes[0], str, 128, 0, 0)) == 0
+		 || ret == 2)
+	    if (ret == 2)
+	      e_d_error (str);
+	  if (ret == -1)
+	    return (ret);
+	  e_d_nstack = dif;
+	}
+    }
+  else if (e_deb_type == 1)
+    {
+      for (i = b->b.y; i >= 0 && (line =
+				  e_make_line_num2 ((char *) b->bf[i].s,
+						    file)) < 0; i--);
+    }
+  if (e_d_p_watches (f, 0) == -1)
+    return (-1);
+  e_d_goto_break (file, line, f);
+  return (0);
+}
+
 /*******************************************************/
 /** resyncing schirm - screen output with breakpoints **/
 
-int e_brk_schirm(FENSTER *f)
+int
+e_brk_schirm (FENSTER * f)
 {
- int i;
- int n;
+  int i;
+  int n;
 
- SCHIRM *s = f->s;
- s->brp= realloc(s->brp, sizeof(int));
- s->brp[0]=0;
- for(i=0;i<e_d_nbrpts;i++)
- {
-  if(!strcmp(f->datnam,e_d_sbrpts[i]))
-  {
-   for(n=1;n<= (s->brp[0]);n++) if(e_d_ybrpts[i]==(s->brp[n])) break;
-   if(n>s->brp[0])
-   {
+  SCHIRM *s = f->s;
+  s->brp = realloc (s->brp, sizeof (int));
+  s->brp[0] = 0;
+  for (i = 0; i < e_d_nbrpts; i++)
+    {
+      if (!strcmp (f->datnam, e_d_sbrpts[i]))
+	{
+	  for (n = 1; n <= (s->brp[0]); n++)
+	    if (e_d_ybrpts[i] == (s->brp[n]))
+	      break;
+	  if (n > s->brp[0])
+	    {
     /****  New break, not in schirm  ****/
-    (s->brp[0])++;
-    s->brp = realloc(s->brp, (s->brp[0]+1) * sizeof(int));
-    s->brp[s->brp[0]] = e_d_ybrpts[i]-1;
-   }
-  }
- }
- return 0;
+	      (s->brp[0])++;
+	      s->brp = realloc (s->brp, (s->brp[0] + 1) * sizeof (int));
+	      s->brp[s->brp[0]] = e_d_ybrpts[i] - 1;
+	    }
+	}
+    }
+  return 0;
 }
+
 /*****************************************/
 
 /*******************************************/
 /***  reinitialize breakpoints from prj  ***/
-int e_d_reinit_brks(FENSTER * f,char * prj)
+int
+e_d_reinit_brks (FENSTER * f, char *prj)
 {
-   int line,e,g,q,r;
-   char * p,*name,*prj2;
+  int line, e, g, q, r;
+  char *p, *name, *prj2;
 /***  remove breakpoints, schirms will be synced later  ***/
 
-   e_remove_breakpoints(f);
-   g=strlen(prj);
-   prj2=malloc(sizeof(char)*(g+1));
-   strcpy(prj2,prj);
-   q=0;
-   r=0;
-   while(q<g)
-   {
-     e=q;
-     while(prj2[e]!=';' && e<g) e++;
-     prj2[e]='\0';
-     q=e+1;
-     r++;
-   }
+  e_remove_breakpoints (f);
+  g = strlen (prj);
+  prj2 = malloc (sizeof (char) * (g + 1));
+  strcpy (prj2, prj);
+  q = 0;
+  r = 0;
+  while (q < g)
+    {
+      e = q;
+      while (prj2[e] != ';' && e < g)
+	e++;
+      prj2[e] = '\0';
+      q = e + 1;
+      r++;
+    }
 /**** for sure ****/
-   e_d_nbrpts=0;
+  e_d_nbrpts = 0;
 
 /**** allocate memory for breakpoints ****/
-   e_d_sbrpts = malloc(sizeof(char *) * r);
-   e_d_ybrpts = malloc(sizeof(int) * r);
-   e_d_nrbrpts = malloc(sizeof(int) * r);
+  e_d_sbrpts = malloc (sizeof (char *) * r);
+  e_d_ybrpts = malloc (sizeof (int) * r);
+  e_d_nrbrpts = malloc (sizeof (int) * r);
 
-   name=prj2;
-   for(q=0;q<r;q++)
-   {
-     p=strrchr(name,':');
-     e=strlen(name);
-     if(p!=NULL)
-     {
-       *p='\0';
-       {
-         p++;
-         line=atoi(p);
-         if(line>0) {
+  name = prj2;
+  for (q = 0; q < r; q++)
+    {
+      p = strrchr (name, ':');
+      e = strlen (name);
+      if (p != NULL)
+	{
+	  *p = '\0';
+	  {
+	    p++;
+	    line = atoi (p);
+	    if (line > 0)
+	      {
 /**** hopefully we have filename and line number ****/
 
-	   e_d_ybrpts[e_d_nbrpts]=line;
-	   e_d_sbrpts[e_d_nbrpts]=malloc(sizeof(char)*(strlen(name)+1));
-	   strcpy(e_d_sbrpts[e_d_nbrpts],name);
-	   e_d_nbrpts++;
+		e_d_ybrpts[e_d_nbrpts] = line;
+		e_d_sbrpts[e_d_nbrpts] =
+		  malloc (sizeof (char) * (strlen (name) + 1));
+		strcpy (e_d_sbrpts[e_d_nbrpts], name);
+		e_d_nbrpts++;
 
 /**** needed to keep schirm in sync ****/
 
-	   for(g = f->ed->mxedt; g > 0; g--)
-            if(!strcmp(f->ed->f[g]->datnam, name))
-            {
-              e_brk_schirm(f->ed->f[g]);
-            }
-         }
-       }
-     }
-     name+=e+1;
-   }
-   free(prj2);
-   return 0;
+		for (g = f->ed->mxedt; g > 0; g--)
+		  if (!strcmp (f->ed->f[g]->datnam, name))
+		    {
+		      e_brk_schirm (f->ed->f[g]);
+		    }
+	      }
+	  }
+	}
+      name += e + 1;
+    }
+  free (prj2);
+  return 0;
 }
 
 
 /**** Recalculate breakpoints , because of line/block
     deleting/adding ****/
-int e_brk_recalc(FENSTER *f, int start, int len)
+int
+e_brk_recalc (FENSTER * f, int start, int len)
 {
- ECNT *cn = f->ed;
- BUFFER *b;
- int n, rend, count, yline;
- int *br_lines;
+  ECNT *cn = f->ed;
+  BUFFER *b;
+  int n, rend, count, yline;
+  int *br_lines;
 
- if ((len == 0) || (cn == NULL))
-  return 1;
- b = cn->f[cn->mxedt]->b;
+  if ((len == 0) || (cn == NULL))
+    return 1;
+  b = cn->f[cn->mxedt]->b;
 
- rend = start - 1 + abs(len);
- yline = b->b.y;
+  rend = start - 1 + abs (len);
+  yline = b->b.y;
 
 /**** deleting removed breakpoints ****/
- if (len < 0)
- {
-  for (n = 0; n < e_d_nbrpts; n++)
-   if ((!strcmp(f->datnam, e_d_sbrpts[n])) &&
-     (e_d_ybrpts[n] <= (rend + 1)) && (e_d_ybrpts[n] >= (start + 1)))
-   {
-    b->b.y = e_d_ybrpts[n] - 1;
-    e_make_breakpoint(f, 0);
-   }
- }
+  if (len < 0)
+    {
+      for (n = 0; n < e_d_nbrpts; n++)
+	if ((!strcmp (f->datnam, e_d_sbrpts[n])) &&
+	    (e_d_ybrpts[n] <= (rend + 1)) && (e_d_ybrpts[n] >= (start + 1)))
+	  {
+	    b->b.y = e_d_ybrpts[n] - 1;
+	    e_make_breakpoint (f, 0);
+	  }
+    }
 
 /**** scanning for breakpoints to move ****/
- for (count = 0, n = 0; n < e_d_nbrpts; n++)
-  if ((!strcmp(f->datnam, e_d_sbrpts[n])) && (e_d_ybrpts[n] >= (start + 1)))
-   count++;
- if (count == 0)
-  return 1;
- br_lines = (int*)malloc(sizeof(int) * count);
- for (n = 0, count = 0; n < e_d_nbrpts; n++)
-  if ((!strcmp(f->datnam, e_d_sbrpts[n])) && (e_d_ybrpts[n] >= (start + 1)))
-  {
-   br_lines[count++] = e_d_ybrpts[n];
-  }
+  for (count = 0, n = 0; n < e_d_nbrpts; n++)
+    if ((!strcmp (f->datnam, e_d_sbrpts[n]))
+	&& (e_d_ybrpts[n] >= (start + 1)))
+      count++;
+  if (count == 0)
+    return 1;
+  br_lines = (int *) malloc (sizeof (int) * count);
+  for (n = 0, count = 0; n < e_d_nbrpts; n++)
+    if ((!strcmp (f->datnam, e_d_sbrpts[n]))
+	&& (e_d_ybrpts[n] >= (start + 1)))
+      {
+	br_lines[count++] = e_d_ybrpts[n];
+      }
 
 /**** moving breakpoints ****/
- for(n = 0; n < count; n++)
- {
-  b->b.y = br_lines[n] - 1;
-  e_make_breakpoint(f, 0);
- }
- for(n = 0; n < count; n++)
- {
-  b->b.y = br_lines[n] + len - 1;
-  e_make_breakpoint(f, 0);
- }
- b->b.y = yline;
- free(br_lines);
- return 0;
+  for (n = 0; n < count; n++)
+    {
+      b->b.y = br_lines[n] - 1;
+      e_make_breakpoint (f, 0);
+    }
+  for (n = 0; n < count; n++)
+    {
+      b->b.y = br_lines[n] + len - 1;
+      e_make_breakpoint (f, 0);
+    }
+  b->b.y = yline;
+  free (br_lines);
+  return 0;
 }
+
 /*****************************************/
 
 /*  Breakpoints   */
-int e_breakpoint(FENSTER *f)
+int
+e_breakpoint (FENSTER * f)
 {
- return(e_make_breakpoint(f, 0));
+  return (e_make_breakpoint (f, 0));
 }
 
-int e_remove_breakpoints(FENSTER *f)
+int
+e_remove_breakpoints (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int i;
+  ECNT *cn = f->ed;
+  int i;
 
- if (e_d_swtch)
- {
-  int n;
-  char *cstr = 0;
-  if (!e_deb_type)
-   cstr = "d\ny\n";
-  else if (e_deb_type == 1)
-   cstr = "D\n";
-  else if (e_deb_type == 2)
-   cstr = "delete all\n";
-  else if (e_deb_type == 3)
-   cstr = "db *\n";
-  if (cstr) {
-    n = strlen(cstr);
-    if (n != write(rfildes[1], cstr, n)) {
-  	printf("[e_remove_breakpoints]: Write to debugger failed for %s.\n", cstr);
-    }
-  }
- }
- for (i = 0; i < e_d_nbrpts; i++)
-  free(e_d_sbrpts[i]);
- for (i = cn->mxedt; i >= 0; i--)
-  if (DTMD_ISTEXT(cn->f[i]->dtmd))
-   cn->f[i]->s->brp[0] = 0;
- e_d_nbrpts = 0;
- if (e_d_sbrpts)
- {
-  free(e_d_sbrpts);
-  e_d_sbrpts = NULL;
- }
- if (e_d_ybrpts)
- {
-  free(e_d_ybrpts);
-  e_d_ybrpts = NULL;
- }
- if (e_d_nrbrpts)
- {
-  free(e_d_nrbrpts);
-  e_d_nrbrpts = NULL;
- }
- e_rep_win_tree(cn);
- return(0);
-}
-
-int e_mk_brk_main(FENSTER *f, int sw)
-{
- UNUSED(f);
- int i, ret;
- char eing[128], str[256];
-
- if (sw)
- {
   if (e_d_swtch)
-  {
-   if (e_deb_type == 0) sprintf(eing, "d %d\n", e_d_nrbrpts[sw-1]);
-   else if (e_deb_type == 2)
-    sprintf(eing, "delete %d\n", e_d_nrbrpts[sw-1]);
-   else if (e_deb_type == 3)
-    sprintf(eing, "db %d\n", e_d_nrbrpts[sw-1]);
-   else if (e_deb_type == 1)
-   {
-    sprintf(eing, "e main\n");
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_mk_brk_main]: write to debugger failed for %s.\n", eing);
-    }
-    if (e_d_dum_read() == -1) return(-1);
-    sprintf(eing, "%d d\n", e_d_ybrpts[sw-1]);
-   }
-   int n = strlen(eing);
-   if (n != write(rfildes[1], eing, n)) {
-	printf("[e_mk_brk_main]: Write to debugger failed for: %s.\n", eing);
-   }
-   if (e_d_dum_read() == -1) return(-1);
-  }
-  free(e_d_sbrpts[sw-1]);
-  for (i = sw-1; i < e_d_nbrpts - 1; i++)
-  {
-   e_d_sbrpts[i] = e_d_sbrpts[i+1];
-   e_d_ybrpts[i] = e_d_ybrpts[i+1];
-   e_d_nrbrpts[i] = e_d_nrbrpts[i+1];
-  }
-  e_d_nbrpts--;
-  if (e_d_nbrpts == 0)
-  {
-   free(e_d_sbrpts);
-   e_d_sbrpts = NULL;
-   free(e_d_ybrpts);
-   e_d_ybrpts = NULL;
-   free(e_d_nrbrpts);
-   e_d_nrbrpts = NULL;
-  }
- }
- else
- {
-  e_d_nbrpts++;
-  if (e_d_nbrpts == 1)
-  {
-   e_d_sbrpts = malloc(sizeof(char *));
-   e_d_ybrpts = malloc(sizeof(int));
-   e_d_nrbrpts = malloc(sizeof(int));
-  }
-  else
-  {
-   e_d_sbrpts = realloc(e_d_sbrpts, e_d_nbrpts * sizeof(char *));
-   e_d_ybrpts = realloc(e_d_ybrpts, e_d_nbrpts * sizeof(int));
-   e_d_nrbrpts = realloc(e_d_nrbrpts, e_d_nbrpts * sizeof(int));
-  }
-  e_d_sbrpts[e_d_nbrpts - 1] = malloc(1);
-  if (e_d_swtch)
-  {
-   if (e_deb_type == 0)
-   {
-    sprintf(eing, "b main\n");
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[]: Write to debugger failed for %s.\n", eing);
-    }
-    while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-      strncmp(str, "Breakpoint", 10))
-     ;
-    if (ret == -1) return(ret);
-    if (ret == 2) e_d_error(str);
-    e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+11);
-    if (ret != 1 && e_d_dum_read() == -1) return(-1);
-   }
-   else if (e_deb_type == 2)
-   {
-    sprintf(eing, "stop in main\n");
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_mk_brk_main]: Write to debugger failed for %s.\n", eing);
-    }
-    while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-      str[0] != '(')
-     ;
-    if (ret == -1) return(ret);
-    if (ret == 2) e_d_error(str);
-    e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+1);
-    if (ret != 1 && e_d_dum_read() == -1) return(-1);
-   }
-   else if (e_deb_type == 3)
-   {
-    sprintf(eing, "b main\n");
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_mk_brk_main]: Write to debugger failed for %s.\n", eing);
-    }
-    while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-      strncmp(str, "Added:", 6))
-     ;
-    ret = e_d_line_read(wfildes[0], str, 256, 0, 0);
-    if (ret == -1) return(ret);
-    if (ret == 2) e_d_error(str);
-    e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+1);
-    if (ret != 1 && e_d_dum_read() == -1) return(-1);
-   }
-   else if (e_deb_type == 1)
-   {
-    sprintf(eing, "e main\n");
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_mk_brk_main]: write to debugger failed for %s.\n", eing);
-    }
-    if (e_d_dum_read() == -1) return(-1);
-    sprintf(eing, "b\n");
-    n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_mk_brk_main]: Write to debugger failed for %s.\n", eing);
-    }
-    if ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == -1)
-     return(ret);
-    if (ret == 2) e_d_error(str);
-    if (ret != 1)
     {
-     for (i = 0; str[i] && str[i] != ':'; i++)
-      ;
-     if (str[i])
-      e_d_ybrpts[e_d_nbrpts - 1] = atoi(str+i+1);
-     if (e_d_dum_read() == -1) return(-1);
+      int n;
+      char *cstr = 0;
+      if (!e_deb_type)
+	cstr = "d\ny\n";
+      else if (e_deb_type == 1)
+	cstr = "D\n";
+      else if (e_deb_type == 2)
+	cstr = "delete all\n";
+      else if (e_deb_type == 3)
+	cstr = "db *\n";
+      if (cstr)
+	{
+	  n = strlen (cstr);
+	  if (n != write (rfildes[1], cstr, n))
+	    {
+	      printf
+		("[e_remove_breakpoints]: Write to debugger failed for %s.\n",
+		 cstr);
+	    }
+	}
     }
-   }
-  }
- }
- return(sw ? 0 : e_d_nbrpts);
+  for (i = 0; i < e_d_nbrpts; i++)
+    free (e_d_sbrpts[i]);
+  for (i = cn->mxedt; i >= 0; i--)
+    if (DTMD_ISTEXT (cn->f[i]->dtmd))
+      cn->f[i]->s->brp[0] = 0;
+  e_d_nbrpts = 0;
+  if (e_d_sbrpts)
+    {
+      free (e_d_sbrpts);
+      e_d_sbrpts = NULL;
+    }
+  if (e_d_ybrpts)
+    {
+      free (e_d_ybrpts);
+      e_d_ybrpts = NULL;
+    }
+  if (e_d_nrbrpts)
+    {
+      free (e_d_nrbrpts);
+      e_d_nrbrpts = NULL;
+    }
+  e_rep_win_tree (cn);
+  return (0);
 }
 
-int e_make_breakpoint(FENSTER *f, int sw)
+int
+e_mk_brk_main (FENSTER * f, int sw)
 {
- ECNT *cn = f->ed;
- SCHIRM *s = cn->f[cn->mxedt]->s;
- BUFFER *b = cn->f[cn->mxedt]->b;
- int ret, i;
- char eing[128], str[256];
+  UNUSED (f);
+  int i, ret;
+  char eing[128], str[256];
 
- if (!sw)
- {
-  if (!e_check_c_file(f->datnam))
-   return(e_error(e_p_msg[ERR_NO_CFILE], 0, f->fb));
-  for(i = 0; i < s->brp[0] && s->brp[i+1] != b->b.y; i++)
-   ;
-  if (i < s->brp[0])
-  {
-   for (i++; i < s->brp[0]; i++) s->brp[i] = s->brp[i+1];
-   (s->brp[0])--;
-   for (i = 0; i < e_d_nbrpts && (strcmp(e_d_sbrpts[i], f->datnam) ||
-     e_d_ybrpts[i] != b->b.y+1); i++)
-    ;
-   if (e_d_swtch)
-   {
-    if (e_deb_type == 0) sprintf(eing, "d %d\n", e_d_nrbrpts[i]);
-    else if (e_deb_type == 2)
-     sprintf(eing, "delete %d\n", e_d_nrbrpts[i]);
-    else if (e_deb_type == 3)
-     sprintf(eing, "db %d\n", e_d_nrbrpts[i]);
-    else if (e_deb_type == 1)
+  if (sw)
     {
-     sprintf(eing, "e %s\n", e_d_sbrpts[i]);
-     int n = strlen(eing);
-     if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-     }
-     if (e_d_dum_read() == -1) return(-1);
-     sprintf(eing, "%d d\n", e_d_ybrpts[i]);
+      if (e_d_swtch)
+	{
+	  if (e_deb_type == 0)
+	    sprintf (eing, "d %d\n", e_d_nrbrpts[sw - 1]);
+	  else if (e_deb_type == 2)
+	    sprintf (eing, "delete %d\n", e_d_nrbrpts[sw - 1]);
+	  else if (e_deb_type == 3)
+	    sprintf (eing, "db %d\n", e_d_nrbrpts[sw - 1]);
+	  else if (e_deb_type == 1)
+	    {
+	      sprintf (eing, "e main\n");
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_mk_brk_main]: write to debugger failed for %s.\n",
+		     eing);
+		}
+	      if (e_d_dum_read () == -1)
+		return (-1);
+	      sprintf (eing, "%d d\n", e_d_ybrpts[sw - 1]);
+	    }
+	  int n = strlen (eing);
+	  if (n != write (rfildes[1], eing, n))
+	    {
+	      printf ("[e_mk_brk_main]: Write to debugger failed for: %s.\n",
+		      eing);
+	    }
+	  if (e_d_dum_read () == -1)
+	    return (-1);
+	}
+      free (e_d_sbrpts[sw - 1]);
+      for (i = sw - 1; i < e_d_nbrpts - 1; i++)
+	{
+	  e_d_sbrpts[i] = e_d_sbrpts[i + 1];
+	  e_d_ybrpts[i] = e_d_ybrpts[i + 1];
+	  e_d_nrbrpts[i] = e_d_nrbrpts[i + 1];
+	}
+      e_d_nbrpts--;
+      if (e_d_nbrpts == 0)
+	{
+	  free (e_d_sbrpts);
+	  e_d_sbrpts = NULL;
+	  free (e_d_ybrpts);
+	  e_d_ybrpts = NULL;
+	  free (e_d_nrbrpts);
+	  e_d_nrbrpts = NULL;
+	}
     }
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-    }
-    if (e_d_dum_read() == -1) return(-1);
-   }
-   free(e_d_sbrpts[i]);
-   for (; i < e_d_nbrpts - 1; i++)
-   {
-    e_d_sbrpts[i] = e_d_sbrpts[i+1];
-    e_d_ybrpts[i] = e_d_ybrpts[i+1];
-    e_d_nrbrpts[i] = e_d_nrbrpts[i+1];
-   }
-   e_d_nbrpts--;
-   if (e_d_nbrpts == 0)
-   {
-    free(e_d_sbrpts);
-    e_d_sbrpts = NULL;
-    free(e_d_ybrpts);
-    e_d_ybrpts = NULL;
-    free(e_d_nrbrpts);
-    e_d_nrbrpts = NULL;
-   }
-  }
   else
-  {
-   e_d_nbrpts++;
-   if (e_d_nbrpts == 1)
-   {
-    e_d_sbrpts = malloc(sizeof(char *));
-    e_d_ybrpts = malloc(sizeof(int));
-    e_d_nrbrpts = malloc(sizeof(int));
-   }
-   else
-   {
-    e_d_sbrpts = realloc(e_d_sbrpts, e_d_nbrpts * sizeof(char *));
-    e_d_ybrpts = realloc(e_d_ybrpts, e_d_nbrpts * sizeof(int));
-    e_d_nrbrpts = realloc(e_d_nrbrpts, e_d_nbrpts * sizeof(int));
-   }
-   e_d_sbrpts[e_d_nbrpts - 1] = malloc(strlen(f->datnam) + 1);
-   strcpy(e_d_sbrpts[e_d_nbrpts - 1], f->datnam);
-   e_d_ybrpts[e_d_nbrpts - 1] = b->b.y + 1;
-   if (e_d_swtch)
-   {
-    if (e_deb_type == 0)
     {
-     sprintf(eing, "b %s:%d\n", f->datnam, b->b.y + 1);
-     int n = strlen(eing);
-     if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-     }
-     while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-       strncmp(str, "Breakpoint", 10))
-      ;
-     if (ret == -1) return(ret);
-     if (ret == 2) e_d_error(str);
-     e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+11);
-     if (ret != 1 && e_d_dum_read() == -1) return(-1);
+      e_d_nbrpts++;
+      if (e_d_nbrpts == 1)
+	{
+	  e_d_sbrpts = malloc (sizeof (char *));
+	  e_d_ybrpts = malloc (sizeof (int));
+	  e_d_nrbrpts = malloc (sizeof (int));
+	}
+      else
+	{
+	  e_d_sbrpts = realloc (e_d_sbrpts, e_d_nbrpts * sizeof (char *));
+	  e_d_ybrpts = realloc (e_d_ybrpts, e_d_nbrpts * sizeof (int));
+	  e_d_nrbrpts = realloc (e_d_nrbrpts, e_d_nbrpts * sizeof (int));
+	}
+      e_d_sbrpts[e_d_nbrpts - 1] = malloc (1);
+      if (e_d_swtch)
+	{
+	  if (e_deb_type == 0)
+	    {
+	      sprintf (eing, "b main\n");
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf ("[]: Write to debugger failed for %s.\n", eing);
+		}
+	      while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+		     && strncmp (str, "Breakpoint", 10))
+		;
+	      if (ret == -1)
+		return (ret);
+	      if (ret == 2)
+		e_d_error (str);
+	      e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 11);
+	      if (ret != 1 && e_d_dum_read () == -1)
+		return (-1);
+	    }
+	  else if (e_deb_type == 2)
+	    {
+	      sprintf (eing, "stop in main\n");
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_mk_brk_main]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+		     && str[0] != '(')
+		;
+	      if (ret == -1)
+		return (ret);
+	      if (ret == 2)
+		e_d_error (str);
+	      e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 1);
+	      if (ret != 1 && e_d_dum_read () == -1)
+		return (-1);
+	    }
+	  else if (e_deb_type == 3)
+	    {
+	      sprintf (eing, "b main\n");
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_mk_brk_main]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+		     && strncmp (str, "Added:", 6))
+		;
+	      ret = e_d_line_read (wfildes[0], str, 256, 0, 0);
+	      if (ret == -1)
+		return (ret);
+	      if (ret == 2)
+		e_d_error (str);
+	      e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 1);
+	      if (ret != 1 && e_d_dum_read () == -1)
+		return (-1);
+	    }
+	  else if (e_deb_type == 1)
+	    {
+	      sprintf (eing, "e main\n");
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_mk_brk_main]: write to debugger failed for %s.\n",
+		     eing);
+		}
+	      if (e_d_dum_read () == -1)
+		return (-1);
+	      sprintf (eing, "b\n");
+	      n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_mk_brk_main]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      if ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == -1)
+		return (ret);
+	      if (ret == 2)
+		e_d_error (str);
+	      if (ret != 1)
+		{
+		  for (i = 0; str[i] && str[i] != ':'; i++)
+		    ;
+		  if (str[i])
+		    e_d_ybrpts[e_d_nbrpts - 1] = atoi (str + i + 1);
+		  if (e_d_dum_read () == -1)
+		    return (-1);
+		}
+	    }
+	}
     }
-    else if (e_deb_type == 2)
+  return (sw ? 0 : e_d_nbrpts);
+}
+
+int
+e_make_breakpoint (FENSTER * f, int sw)
+{
+  ECNT *cn = f->ed;
+  SCHIRM *s = cn->f[cn->mxedt]->s;
+  BUFFER *b = cn->f[cn->mxedt]->b;
+  int ret, i;
+  char eing[128], str[256];
+
+  if (!sw)
     {
-     sprintf(eing, "stop at \"%s\":%d\n", f->datnam, b->b.y + 1);
-     int n = strlen(eing);
-     if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-     }
-     while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-       str[0] != '(')
-      ;
-     if (ret == -1) return(ret);
-     if (ret == 2) e_d_error(str);
-     e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+1);
-     if (ret != 1 && e_d_dum_read() == -1) return(-1);
+      if (!e_check_c_file (f->datnam))
+	return (e_error (e_p_msg[ERR_NO_CFILE], 0, f->fb));
+      for (i = 0; i < s->brp[0] && s->brp[i + 1] != b->b.y; i++)
+	;
+      if (i < s->brp[0])
+	{
+	  for (i++; i < s->brp[0]; i++)
+	    s->brp[i] = s->brp[i + 1];
+	  (s->brp[0])--;
+	  for (i = 0; i < e_d_nbrpts && (strcmp (e_d_sbrpts[i], f->datnam) ||
+					 e_d_ybrpts[i] != b->b.y + 1); i++)
+	    ;
+	  if (e_d_swtch)
+	    {
+	      if (e_deb_type == 0)
+		sprintf (eing, "d %d\n", e_d_nrbrpts[i]);
+	      else if (e_deb_type == 2)
+		sprintf (eing, "delete %d\n", e_d_nrbrpts[i]);
+	      else if (e_deb_type == 3)
+		sprintf (eing, "db %d\n", e_d_nrbrpts[i]);
+	      else if (e_deb_type == 1)
+		{
+		  sprintf (eing, "e %s\n", e_d_sbrpts[i]);
+		  int n = strlen (eing);
+		  if (n != write (rfildes[1], eing, n))
+		    {
+		      printf
+			("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+			 eing);
+		    }
+		  if (e_d_dum_read () == -1)
+		    return (-1);
+		  sprintf (eing, "%d d\n", e_d_ybrpts[i]);
+		}
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      if (e_d_dum_read () == -1)
+		return (-1);
+	    }
+	  free (e_d_sbrpts[i]);
+	  for (; i < e_d_nbrpts - 1; i++)
+	    {
+	      e_d_sbrpts[i] = e_d_sbrpts[i + 1];
+	      e_d_ybrpts[i] = e_d_ybrpts[i + 1];
+	      e_d_nrbrpts[i] = e_d_nrbrpts[i + 1];
+	    }
+	  e_d_nbrpts--;
+	  if (e_d_nbrpts == 0)
+	    {
+	      free (e_d_sbrpts);
+	      e_d_sbrpts = NULL;
+	      free (e_d_ybrpts);
+	      e_d_ybrpts = NULL;
+	      free (e_d_nrbrpts);
+	      e_d_nrbrpts = NULL;
+	    }
+	}
+      else
+	{
+	  e_d_nbrpts++;
+	  if (e_d_nbrpts == 1)
+	    {
+	      e_d_sbrpts = malloc (sizeof (char *));
+	      e_d_ybrpts = malloc (sizeof (int));
+	      e_d_nrbrpts = malloc (sizeof (int));
+	    }
+	  else
+	    {
+	      e_d_sbrpts = realloc (e_d_sbrpts, e_d_nbrpts * sizeof (char *));
+	      e_d_ybrpts = realloc (e_d_ybrpts, e_d_nbrpts * sizeof (int));
+	      e_d_nrbrpts = realloc (e_d_nrbrpts, e_d_nbrpts * sizeof (int));
+	    }
+	  e_d_sbrpts[e_d_nbrpts - 1] = malloc (strlen (f->datnam) + 1);
+	  strcpy (e_d_sbrpts[e_d_nbrpts - 1], f->datnam);
+	  e_d_ybrpts[e_d_nbrpts - 1] = b->b.y + 1;
+	  if (e_d_swtch)
+	    {
+	      if (e_deb_type == 0)
+		{
+		  sprintf (eing, "b %s:%d\n", f->datnam, b->b.y + 1);
+		  int n = strlen (eing);
+		  if (n != write (rfildes[1], eing, n))
+		    {
+		      printf
+			("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+			 eing);
+		    }
+		  while ((ret =
+			  e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+			 && strncmp (str, "Breakpoint", 10))
+		    ;
+		  if (ret == -1)
+		    return (ret);
+		  if (ret == 2)
+		    e_d_error (str);
+		  e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 11);
+		  if (ret != 1 && e_d_dum_read () == -1)
+		    return (-1);
+		}
+	      else if (e_deb_type == 2)
+		{
+		  sprintf (eing, "stop at \"%s\":%d\n", f->datnam,
+			   b->b.y + 1);
+		  int n = strlen (eing);
+		  if (n != write (rfildes[1], eing, n))
+		    {
+		      printf
+			("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+			 eing);
+		    }
+		  while ((ret =
+			  e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+			 && str[0] != '(')
+		    ;
+		  if (ret == -1)
+		    return (ret);
+		  if (ret == 2)
+		    e_d_error (str);
+		  e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 1);
+		  if (ret != 1 && e_d_dum_read () == -1)
+		    return (-1);
+		}
+	      else if (e_deb_type == 3)
+		{
+		  sprintf (eing, "b %s:%d\n", f->datnam, b->b.y + 1);
+		  int n = strlen (eing);
+		  if (n != write (rfildes[1], eing, n))
+		    {
+		      printf
+			("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+			 eing);
+		    }
+		  while ((ret =
+			  e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+			 && strncmp (str, "Added:", 6))
+		    ;
+		  ret = e_d_line_read (wfildes[0], str, 256, 0, 0);
+		  if (ret == -1)
+		    return (ret);
+		  if (ret == 2)
+		    e_d_error (str);
+		  e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 1);
+		  if (ret != 1 && e_d_dum_read () == -1)
+		    return (-1);
+		}
+	      else if (e_deb_type == 1)
+		{
+		  sprintf (eing, "e %s\n", f->datnam);
+		  int n = strlen (eing);
+		  if (n != write (rfildes[1], eing, n))
+		    {
+		      printf
+			("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+			 eing);
+		    }
+		  if (e_d_dum_read () == -1)
+		    return (-1);
+		  sprintf (eing, "%d b\n", b->b.y + 1);
+		  n = strlen (eing);
+		  if (n != write (rfildes[1], eing, n))
+		    {
+		      printf
+			("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+			 eing);
+		    }
+		  if (e_d_dum_read () == -1)
+		    return (-1);
+		}
+	    }
+	  (s->brp[0])++;
+	  s->brp = realloc (s->brp, (s->brp[0] + 1) * sizeof (int));
+	  s->brp[s->brp[0]] = b->b.y;
+	}
     }
-    else if (e_deb_type == 3)
-    {
-     sprintf(eing, "b %s:%d\n", f->datnam, b->b.y + 1);
-     int n = strlen(eing);
-     if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-     }
-     while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-       strncmp(str, "Added:", 6))
-      ;
-     ret = e_d_line_read(wfildes[0], str, 256, 0, 0);
-     if (ret == -1) return(ret);
-     if (ret == 2) e_d_error(str);
-     e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+1);
-     if (ret != 1 && e_d_dum_read() == -1) return(-1);
-    }
-    else if (e_deb_type == 1)
-    {
-     sprintf(eing, "e %s\n", f->datnam);
-     int n = strlen(eing);
-     if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-     }
-     if (e_d_dum_read() == -1) return(-1);
-     sprintf(eing, "%d b\n", b->b.y + 1);
-     n = strlen(eing);
-     if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-     }
-     if (e_d_dum_read() == -1) return(-1);
-    }
-   }
-   (s->brp[0])++;
-   s->brp = realloc(s->brp, (s->brp[0]+1) * sizeof(int));
-   s->brp[s->brp[0]] = b->b.y;
-  }
- }
- else
- {
-  if(e_deb_type == 0)
-  {
-   for (i = 0; i < e_d_nbrpts; i++)
-   {
-    sprintf(eing, "b %s:%d\n", e_d_sbrpts[i], e_d_ybrpts[i]);
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-    }
-    while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-      strncmp(str, "Breakpoint", 10))
-     ;
-    if (ret == -1) return(ret);
-    if (ret == 2) e_d_error(str);
-    e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+11);
-    if (ret != 1 && e_d_dum_read() == -1) return(-1);
-   }
-  }
-  else if (e_deb_type == 2)
-  {
-   for (i = 0; i < e_d_nbrpts; i++)
-   {
-    sprintf(eing, "stop at \"%s\":%d\n", e_d_sbrpts[i], e_d_ybrpts[i]);
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-    }
-    while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-      str[0] != '(')
-     ;
-    if (ret == -1) return(ret);
-    if (ret == 2) e_d_error(str);
-    e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+1);
-    if (ret != 1 && e_d_dum_read() == -1) return(-1);
-   }
-  }
-  else if (e_deb_type == 3)
-  {
-   for (i = 0; i < e_d_nbrpts; i++)
-   {
-    sprintf(eing, "b %s:%d\n", f->datnam, b->b.y + 1);
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-    }
-    while ((ret = e_d_line_read(wfildes[0], str, 256, 0, 0)) == 0 &&
-      strncmp(str, "Added:", 6))
-     ;
-    ret = e_d_line_read(wfildes[0], str, 256, 0, 0);
-    if (ret == -1) return(ret);
-    if (ret == 2) e_d_error(str);
-    e_d_nrbrpts[e_d_nbrpts - 1] = atoi(str+1);
-    if (ret != 1 && e_d_dum_read() == -1) return(-1);
-   }
-  }
   else
-  {
-   for (i = 0; i < e_d_nbrpts; i++)
-   {
-    sprintf(eing, "e %s\n", e_d_sbrpts[i]);
-    int n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
+    {
+      if (e_deb_type == 0)
+	{
+	  for (i = 0; i < e_d_nbrpts; i++)
+	    {
+	      sprintf (eing, "b %s:%d\n", e_d_sbrpts[i], e_d_ybrpts[i]);
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+		     && strncmp (str, "Breakpoint", 10))
+		;
+	      if (ret == -1)
+		return (ret);
+	      if (ret == 2)
+		e_d_error (str);
+	      e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 11);
+	      if (ret != 1 && e_d_dum_read () == -1)
+		return (-1);
+	    }
+	}
+      else if (e_deb_type == 2)
+	{
+	  for (i = 0; i < e_d_nbrpts; i++)
+	    {
+	      sprintf (eing, "stop at \"%s\":%d\n", e_d_sbrpts[i],
+		       e_d_ybrpts[i]);
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+		     && str[0] != '(')
+		;
+	      if (ret == -1)
+		return (ret);
+	      if (ret == 2)
+		e_d_error (str);
+	      e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 1);
+	      if (ret != 1 && e_d_dum_read () == -1)
+		return (-1);
+	    }
+	}
+      else if (e_deb_type == 3)
+	{
+	  for (i = 0; i < e_d_nbrpts; i++)
+	    {
+	      sprintf (eing, "b %s:%d\n", f->datnam, b->b.y + 1);
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      while ((ret = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 0
+		     && strncmp (str, "Added:", 6))
+		;
+	      ret = e_d_line_read (wfildes[0], str, 256, 0, 0);
+	      if (ret == -1)
+		return (ret);
+	      if (ret == 2)
+		e_d_error (str);
+	      e_d_nrbrpts[e_d_nbrpts - 1] = atoi (str + 1);
+	      if (ret != 1 && e_d_dum_read () == -1)
+		return (-1);
+	    }
+	}
+      else
+	{
+	  for (i = 0; i < e_d_nbrpts; i++)
+	    {
+	      sprintf (eing, "e %s\n", e_d_sbrpts[i]);
+	      int n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      if (e_d_dum_read () == -1)
+		return (-1);
+	      sprintf (eing, "%d b\n", e_d_ybrpts[i]);
+	      n = strlen (eing);
+	      if (n != write (rfildes[1], eing, n))
+		{
+		  printf
+		    ("[e_make_breakpoint]: Write to debugger failed for %s.\n",
+		     eing);
+		}
+	      if (e_d_dum_read () == -1)
+		return (-1);
+	    }
+	}
     }
-    if (e_d_dum_read() == -1) return(-1);
-    sprintf(eing, "%d b\n", e_d_ybrpts[i]);
-    n = strlen(eing);
-    if (n != write(rfildes[1], eing, n)) {
-	printf("[e_make_breakpoint]: Write to debugger failed for %s.\n", eing);
-    }
-    if (e_d_dum_read() == -1) return(-1);
-   }
-  }
- }
- e_schirm(f, 1);
- return(1);
+  e_schirm (f, 1);
+  return (1);
 }
 
 /*   start Debugger   */
-int e_exec_deb(FENSTER *f, char *prog)
+int
+e_exec_deb (FENSTER * f, char *prog)
 {
- int i;
+  int i;
 
- if (e_d_swtch)
-  return(1);
- e_d_swtch = 1;
- fflush(stdout);
- if (WpeIsXwin())
- {
-  for (i = 0; i < 5; i++)
-  {
-   if (npipe[i])
-    free(npipe[i]);
-   npipe[i] = malloc(128);
-   sprintf(npipe[i], "%s/we_pipe%d", e_tmp_dir, i);
-   remove(npipe[i]);
-  }
-  if (mkfifo(npipe[0], S_IRUSR | S_IWUSR) < 0 ||
-    mkfifo(npipe[1], S_IRUSR | S_IWUSR) < 0 ||
-    mkfifo(npipe[2], S_IRUSR | S_IWUSR) < 0 ||
-    mkfifo(npipe[3], S_IRUSR | S_IWUSR) < 0 ||
-    mkfifo(npipe[4], S_IRUSR | S_IWUSR) < 0)
-  {
-   e_error(e_d_msg[ERR_CANTPIPE], 0, f->fb);
-   return(0);
-  }
- }
- else
- {
-  if (pipe(rfildes))
-  {
-   e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-   return(0);
-  }
-  if (pipe(wfildes))
-  {
-   e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-   return(0);
-  }
-  if (pipe(efildes))
-  {
-   e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-   return(0);
-  }
- }
+  if (e_d_swtch)
+    return (1);
+  e_d_swtch = 1;
+  fflush (stdout);
+  if (WpeIsXwin ())
+    {
+      for (i = 0; i < 5; i++)
+	{
+	  if (npipe[i])
+	    free (npipe[i]);
+	  npipe[i] = malloc (128);
+	  sprintf (npipe[i], "%s/we_pipe%d", e_tmp_dir, i);
+	  remove (npipe[i]);
+	}
+      if (mkfifo (npipe[0], S_IRUSR | S_IWUSR) < 0 ||
+	  mkfifo (npipe[1], S_IRUSR | S_IWUSR) < 0 ||
+	  mkfifo (npipe[2], S_IRUSR | S_IWUSR) < 0 ||
+	  mkfifo (npipe[3], S_IRUSR | S_IWUSR) < 0 ||
+	  mkfifo (npipe[4], S_IRUSR | S_IWUSR) < 0)
+	{
+	  e_error (e_d_msg[ERR_CANTPIPE], 0, f->fb);
+	  return (0);
+	}
+    }
+  else
+    {
+      if (pipe (rfildes))
+	{
+	  e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+	  return (0);
+	}
+      if (pipe (wfildes))
+	{
+	  e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+	  return (0);
+	}
+      if (pipe (efildes))
+	{
+	  e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+	  return (0);
+	}
+    }
 
- if ((e_d_pid = fork()) > 0)
- {
-  if (WpeIsXwin())
-  {
-   if ((wfildes[0] = open(npipe[1], O_RDONLY)) < 0)
-   {
-    e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-    return(0);
-   }
-   for (i = 0;
-     i < 80 && read(wfildes[0], &e_d_tty[i], 1) == 1 && e_d_tty[i] != '\0' &&
-       e_d_tty[i] != '\n';
-     i++)
-    ;
-   if (e_d_tty[i] == '\n')
-    e_d_tty[i] = '\0';
-   if ((rfildes[0] = open(e_d_tty, O_RDONLY)) < 0 ||
-     (wfildes[1] = open(e_d_tty, O_WRONLY)) < 0)
-   {
-    e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-    return(0);
-   }
-   if ((rfildes[1] = open(npipe[0], O_WRONLY)) < 0 ||
-     (wfildes[0] = open(npipe[1], O_RDONLY)) < 0 ||
-     (efildes[0] = open(npipe[2], O_RDONLY)) < 0)
-   {
-    e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-    return(0);
-   }
-   if (e_deb_mode)
-   {
-    tcgetattr(rfildes[0], &ntermio);
+  if ((e_d_pid = fork ()) > 0)
+    {
+      if (WpeIsXwin ())
+	{
+	  if ((wfildes[0] = open (npipe[1], O_RDONLY)) < 0)
+	    {
+	      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+	      return (0);
+	    }
+	  for (i = 0;
+	       i < 80 && read (wfildes[0], &e_d_tty[i], 1) == 1
+	       && e_d_tty[i] != '\0' && e_d_tty[i] != '\n'; i++)
+	    ;
+	  if (e_d_tty[i] == '\n')
+	    e_d_tty[i] = '\0';
+	  if ((rfildes[0] = open (e_d_tty, O_RDONLY)) < 0 ||
+	      (wfildes[1] = open (e_d_tty, O_WRONLY)) < 0)
+	    {
+	      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+	      return (0);
+	    }
+	  if ((rfildes[1] = open (npipe[0], O_WRONLY)) < 0 ||
+	      (wfildes[0] = open (npipe[1], O_RDONLY)) < 0 ||
+	      (efildes[0] = open (npipe[2], O_RDONLY)) < 0)
+	    {
+	      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+	      return (0);
+	    }
+	  if (e_deb_mode)
+	    {
+	      tcgetattr (rfildes[0], &ntermio);
 /*   ioctl(rfildes[0], TCGETA, &ntermio);*/
-    ntermio.c_iflag = 0;
-    ntermio.c_oflag = 0;
-    ntermio.c_lflag = 0;
-    ntermio.c_cc[VMIN] = 1;
-    ntermio.c_cc[VTIME] = 0;
+	      ntermio.c_iflag = 0;
+	      ntermio.c_oflag = 0;
+	      ntermio.c_lflag = 0;
+	      ntermio.c_cc[VMIN] = 1;
+	      ntermio.c_cc[VTIME] = 0;
 #ifdef VSWTCH
-    ntermio.c_cc[VSWTCH] = 0;
+	      ntermio.c_cc[VSWTCH] = 0;
 #endif
 /*   ioctl(rfildes[0], TCSETA, &ntermio);*/
-    tcsetattr(rfildes[0], TCSADRAIN, &ntermio);
-   }
-  }
-  else
-  {
-   FILE *fpp;
+	      tcsetattr (rfildes[0], TCSADRAIN, &ntermio);
+	    }
+	}
+      else
+	{
+	  FILE *fpp;
 
-   if (!(fpp = popen("tty", "r")))
-   {
-    e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-    return(0);
-   }
-   if (!fgets(e_d_tty, 80, fpp)) {
-	printf("[e_exec_deb]: reading 80 chars from tty failed.\n");
-   }
-   pclose(fpp);
-  }
-  return(wfildes[1]);
- }
- else if (e_d_pid < 0)
- {
-  e_error(e_p_msg[ERR_PROCESS], 0, f->fb);
-  return(0);
- }
+	  if (!(fpp = popen ("tty", "r")))
+	    {
+	      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+	      return (0);
+	    }
+	  if (!fgets (e_d_tty, 80, fpp))
+	    {
+	      printf ("[e_exec_deb]: reading 80 chars from tty failed.\n");
+	    }
+	  pclose (fpp);
+	}
+      return (wfildes[1]);
+    }
+  else if (e_d_pid < 0)
+    {
+      e_error (e_p_msg[ERR_PROCESS], 0, f->fb);
+      return (0);
+    }
 
 #ifndef NO_XWINDOWS
- if (WpeIsXwin())
- {
-  FILE *fp;
-  char file[128];
+  if (WpeIsXwin ())
+    {
+      FILE *fp;
+      char file[128];
 
-  sprintf(file, "%s/we_sys", e_tmp_dir);
-  fp = fopen(file, "w+");
-  fprintf(fp, "#!/bin/sh\n");
-  fprintf(fp, "tty > %s\n", npipe[1]);
-  if (!e_deb_swtch)
-   fprintf(fp,
-     "%s %s < %s > %s 2> %s\necho type \\<Return\\> to continue\nread i\n",
-     e_debugger, prog, npipe[0], npipe[1], npipe[2]);
+      sprintf (file, "%s/we_sys", e_tmp_dir);
+      fp = fopen (file, "w+");
+      fprintf (fp, "#!/bin/sh\n");
+      fprintf (fp, "tty > %s\n", npipe[1]);
+      if (!e_deb_swtch)
+	fprintf (fp,
+		 "%s %s < %s > %s 2> %s\necho type \\<Return\\> to continue\nread i\n",
+		 e_debugger, prog, npipe[0], npipe[1], npipe[2]);
+      else
+	fprintf (fp,
+		 "%s %s %s < %s > %s 2> %s\necho type \\<Return\\> to continue\nread i\n",
+		 e_debugger, e_deb_swtch, prog, npipe[0], npipe[1], npipe[2]);
+      fprintf (fp, "rm -f %s\n", file);
+      fclose (fp);
+      chmod (file, 0755);
+
+      execlp (XTERM_CMD, XTERM_CMD, "+sb", "-geometry", "80x25-0-0", "-e",
+	      user_shell, "-c", file, NULL);
+      remove (file);
+    }
   else
-   fprintf(fp,
-     "%s %s %s < %s > %s 2> %s\necho type \\<Return\\> to continue\nread i\n",
-     e_debugger, e_deb_swtch, prog, npipe[0], npipe[1], npipe[2]);
-  fprintf(fp, "rm -f %s\n", file);
-  fclose(fp);
-  chmod(file, 0755);
-
-  execlp(XTERM_CMD, XTERM_CMD, "+sb", "-geometry", "80x25-0-0", "-e",
-    user_shell, "-c", file, NULL);
-  remove(file);
- }
- else
 #endif
- {
-  int kbdflgs;
+    {
+      int kbdflgs;
 
-  close(0);
-  if (fcntl(rfildes[0], F_DUPFD, 0) != 0)
-  {
-   fprintf(stderr, e_p_msg[ERR_PIPEEXEC], rfildes[0]);
-   exit(1);
-  }
-  close(1);
-  if (fcntl(wfildes[1], F_DUPFD, 1) != 1)
-  {
-   fprintf(stderr, e_p_msg[ERR_PIPEEXEC], wfildes[1]);
-   exit(1);
-  }
-  close(2);
-  if (fcntl(efildes[1], F_DUPFD, 2) != 2)
-  {
-   fprintf(stderr, e_p_msg[ERR_PIPEEXEC], efildes[1]);
-   exit(1);
-  }
-  kbdflgs = fcntl(1, F_GETFL, 0 );
-  fcntl(1, F_SETFL, kbdflgs | O_NONBLOCK);
-  kbdflgs = fcntl(2, F_GETFL, 0 );
-  fcntl( 2, F_SETFL, kbdflgs | O_NONBLOCK);
-  if (!e_deb_swtch)
-   execlp(e_debugger, e_debugger, prog, NULL);
-  else
-   execlp(e_debugger, e_debugger, e_deb_swtch, prog, NULL);
- }
- fprintf(stderr,"%s %s %s\n", e_p_msg[ERR_IN_COMMAND], e_debugger, prog);
- exit(1);
+      close (0);
+      if (fcntl (rfildes[0], F_DUPFD, 0) != 0)
+	{
+	  fprintf (stderr, e_p_msg[ERR_PIPEEXEC], rfildes[0]);
+	  exit (1);
+	}
+      close (1);
+      if (fcntl (wfildes[1], F_DUPFD, 1) != 1)
+	{
+	  fprintf (stderr, e_p_msg[ERR_PIPEEXEC], wfildes[1]);
+	  exit (1);
+	}
+      close (2);
+      if (fcntl (efildes[1], F_DUPFD, 2) != 2)
+	{
+	  fprintf (stderr, e_p_msg[ERR_PIPEEXEC], efildes[1]);
+	  exit (1);
+	}
+      kbdflgs = fcntl (1, F_GETFL, 0);
+      fcntl (1, F_SETFL, kbdflgs | O_NONBLOCK);
+      kbdflgs = fcntl (2, F_GETFL, 0);
+      fcntl (2, F_SETFL, kbdflgs | O_NONBLOCK);
+      if (!e_deb_swtch)
+	execlp (e_debugger, e_debugger, prog, NULL);
+      else
+	execlp (e_debugger, e_debugger, e_deb_swtch, prog, NULL);
+    }
+  fprintf (stderr, "%s %s %s\n", e_p_msg[ERR_IN_COMMAND], e_debugger, prog);
+  exit (1);
 }
 
-int e_start_debug(FENSTER *f)
+int
+e_start_debug (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int i, file;
- char estr[128];
+  ECNT *cn = f->ed;
+  int i, file;
+  char estr[128];
 
- efildes[0] = efildes[1] = -1;
- wfildes[0] = wfildes[1] = -1;
- rfildes[0] = rfildes[1] = -1;
- if (e_d_swtch)
-  return(0);
+  efildes[0] = efildes[1] = -1;
+  wfildes[0] = wfildes[1] = -1;
+  rfildes[0] = rfildes[1] = -1;
+  if (e_d_swtch)
+    return (0);
 /*    e_copy_prog(&e_sv_prog, &e_prog);  */
- if (e_p_make(f))
-  return(-1);
- if (!e__project)
- {
-  for (i = cn->mxedt; i > 0; i--)
-   if (e_check_c_file(cn->f[i]->datnam))
-    break;
-  if (i > 0)
-   strcpy(e_d_file, cn->f[i]->datnam);
- }
- else
-  strcpy(e_d_file, cn->f[cn->mxedt-1]->datnam);
- f = cn->f[cn->mxedt-1];
- for (i = 0; i < SVLINES; i++)
- {  e_d_sp[i] = e_d_out_str[i];  e_d_out_str[i][0] = '\0';  }
- if (e_deb_type == 1) {  e_debugger = "sdb";  e_deb_swtch = NULL;  }
- else if (e_deb_type == 2) {  e_debugger = "dbx";  e_deb_swtch = "-i";  }
- else if (e_deb_type == 3) {  e_debugger = "xdb";  e_deb_swtch = "-L";  }
- else {  e_debugger = "gdb";  e_deb_swtch = NULL;  }
- e_d_pid = 0;
- if (e_test_command(e_debugger))
- {
-  sprintf(estr, "Debugger \'%s\' not in Path", e_debugger);
-  e_error(estr, 0, f->fb);
-  return(-1);
- }
- (*e_u_sys_ini)();
- if (e__project && (file = e_exec_deb(f, e_s_prog.exe_name )) == 0)
- {
-  (*e_u_sys_end)();
-  return(-2);
- }
- else if (!e__project)
- {
-  if (e_s_prog.exe_name && e_s_prog.exe_name[0])
-  {
-   strcpy(estr, e_s_prog.exe_name);
-  }
+  if (e_p_make (f))
+    return (-1);
+  if (!e__project)
+    {
+      for (i = cn->mxedt; i > 0; i--)
+	if (e_check_c_file (cn->f[i]->datnam))
+	  break;
+      if (i > 0)
+	strcpy (e_d_file, cn->f[i]->datnam);
+    }
   else
-  {
-   strcpy(estr, f->datnam);
-   WpeStringCutChar(estr, '.');
-   strcat(estr, ".e");
-  }
-  if ((file = e_exec_deb(f, estr)) == 0)
-  {
-   (*e_u_sys_end)();
-   return(-2);
-  }
- }
- (*e_u_sys_end)();
- e_d_p_message(e_d_msg[ERR_STARTDEBUG], f, 1);
- WpeMouseChangeShape(WpeDebuggingShape);
- if (cn->mxedt > 1)
-  e_switch_window(cn->edt[cn->mxedt - 1], cn->f[cn->mxedt]);
- return(0);
+    strcpy (e_d_file, cn->f[cn->mxedt - 1]->datnam);
+  f = cn->f[cn->mxedt - 1];
+  for (i = 0; i < SVLINES; i++)
+    {
+      e_d_sp[i] = e_d_out_str[i];
+      e_d_out_str[i][0] = '\0';
+    }
+  if (e_deb_type == 1)
+    {
+      e_debugger = "sdb";
+      e_deb_swtch = NULL;
+    }
+  else if (e_deb_type == 2)
+    {
+      e_debugger = "dbx";
+      e_deb_swtch = "-i";
+    }
+  else if (e_deb_type == 3)
+    {
+      e_debugger = "xdb";
+      e_deb_swtch = "-L";
+    }
+  else
+    {
+      e_debugger = "gdb";
+      e_deb_swtch = NULL;
+    }
+  e_d_pid = 0;
+  if (e_test_command (e_debugger))
+    {
+      sprintf (estr, "Debugger \'%s\' not in Path", e_debugger);
+      e_error (estr, 0, f->fb);
+      return (-1);
+    }
+  (*e_u_sys_ini) ();
+  if (e__project && (file = e_exec_deb (f, e_s_prog.exe_name)) == 0)
+    {
+      (*e_u_sys_end) ();
+      return (-2);
+    }
+  else if (!e__project)
+    {
+      if (e_s_prog.exe_name && e_s_prog.exe_name[0])
+	{
+	  strcpy (estr, e_s_prog.exe_name);
+	}
+      else
+	{
+	  strcpy (estr, f->datnam);
+	  WpeStringCutChar (estr, '.');
+	  strcat (estr, ".e");
+	}
+      if ((file = e_exec_deb (f, estr)) == 0)
+	{
+	  (*e_u_sys_end) ();
+	  return (-2);
+	}
+    }
+  (*e_u_sys_end) ();
+  e_d_p_message (e_d_msg[ERR_STARTDEBUG], f, 1);
+  WpeMouseChangeShape (WpeDebuggingShape);
+  if (cn->mxedt > 1)
+    e_switch_window (cn->edt[cn->mxedt - 1], cn->f[cn->mxedt]);
+  return (0);
 }
 
-int e_run_debug(FENSTER *f)
+int
+e_run_debug (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int kbdflgs, ret;
+  ECNT *cn = f->ed;
+  int kbdflgs, ret;
 
- if (e_d_swtch < 1 && (ret = e_start_debug(f)) < 0) return(ret);
- if (e_d_swtch < 2)
- {
-  kbdflgs = fcntl(efildes[0], F_GETFL, 0);
-  fcntl( efildes[0], F_SETFL, kbdflgs | O_NONBLOCK);
-  kbdflgs = fcntl(wfildes[0], F_GETFL, 0);
-  fcntl( wfildes[0], F_SETFL, kbdflgs | O_NONBLOCK);
+  if (e_d_swtch < 1 && (ret = e_start_debug (f)) < 0)
+    return (ret);
+  if (e_d_swtch < 2)
+    {
+      kbdflgs = fcntl (efildes[0], F_GETFL, 0);
+      fcntl (efildes[0], F_SETFL, kbdflgs | O_NONBLOCK);
+      kbdflgs = fcntl (wfildes[0], F_GETFL, 0);
+      fcntl (wfildes[0], F_SETFL, kbdflgs | O_NONBLOCK);
 
-  if (e_d_dum_read() == -1) return(-1);
-  if (e_deb_type == 3)
-  {
-   char *cstr = "sm\n";
-   int n = strlen(cstr);
-   if (n != write(rfildes[1], cstr, n)) {
-	printf("[e_run_debug]: write to debugger failed for %s.\n", cstr);
-   }
-   if (e_d_dum_read() == -1) return(-1);
-  }
-  if (e_make_breakpoint(cn->f[cn->mxedt], 1) == -1) return(-1);
-  e_d_swtch = 2;
- }
- return(0);
+      if (e_d_dum_read () == -1)
+	return (-1);
+      if (e_deb_type == 3)
+	{
+	  char *cstr = "sm\n";
+	  int n = strlen (cstr);
+	  if (n != write (rfildes[1], cstr, n))
+	    {
+	      printf ("[e_run_debug]: write to debugger failed for %s.\n",
+		      cstr);
+	    }
+	  if (e_d_dum_read () == -1)
+	    return (-1);
+	}
+      if (e_make_breakpoint (cn->f[cn->mxedt], 1) == -1)
+	return (-1);
+      e_d_swtch = 2;
+    }
+  return (0);
 }
 
 /*  Run  */
-int e_deb_run(FENSTER *f)
+int
+e_deb_run (FENSTER * f)
 {
- ECNT *cn = f->ed;
- char eing[256];
- int ret, len, prsw = 0;
+  ECNT *cn = f->ed;
+  char eing[256];
+  int ret, len, prsw = 0;
 
- if (e_d_swtch < 2 && (ret = e_run_debug(f)) < 0)
- {
-  e_d_quit(f);
-  if (ret == -1) {  e_show_error(0, f);  return(ret);  }
-  return(e_error(e_d_msg[ERR_CANTDEBUG], 0, f->fb));
- }
- for (ret = 0; isspace(e_d_tty[ret]); ret++)
-  ;
- if (e_d_tty[ret] != DIRC)
- {
-  e_d_quit(f);
-  sprintf(eing, "tty error: %s", e_d_tty);
-  return(e_d_error(eing));
- }
- if (e_deb_type == 2)
- {
-  if (e_d_swtch < 3)
-  {
-   if (e_prog.arguments)
-    sprintf(eing, "run %s > %s\n", e_prog.arguments, e_d_tty);
-   else
-    sprintf(eing, "run > %s\n", e_d_tty);
-  }
-  else
-  {
-   strcpy(eing, "cont\n");
-   prsw = 1;
-  }
- }
- else
- {
-  if (e_d_swtch < 3)
-  {
-   if (e_prog.arguments)
-    sprintf(eing, "r %s > %s\n", e_prog.arguments, e_d_tty);
-   else
-    sprintf(eing, "r > %s\n", e_d_tty);
-  }
-  else
-  {
-   strcpy(eing, "c\n");
-   prsw = 1;
-  }
- }
- f = cn->f[cn->mxedt];
- e_d_nstack = 0;
- e_d_delbreak(f);
- e_d_switch_out(1);
- int n = strlen(eing);
- if (n != write(rfildes[1], eing, n)) {
-	printf("[e_deb_run]: write to debugger failed for %s.\n", eing);
- }
- if (e_deb_type == 0 || ((e_deb_type == 2  || e_deb_type == 3) && !prsw))
- {
-  while((ret = e_d_line_read(wfildes[0], eing, 256, 0, 0)) == 2 ||
-    !eing[0] || (!e_deb_type && prsw && ((len = (strlen(eing)-12)) < 0 ||
-    strcmp(eing + len, e_d_msg[ERR_CONTINUE]))) ||
-    (e_d_swtch < 3 && ((!e_deb_type && strncmp(e_d_msg[ERR_STARTPROG],eing, 17)) ||
-    (e_deb_type == 2 && strncmp("Running:",eing, 8)))))
-  {
-   if (ret == 2)
-    e_d_error(eing);
-   else if (ret < 0)
-    return(e_d_quit(f));
-  }
- }
- if (!prsw)
-  e_d_p_message(eing, f, 0);
- if (e_d_swtch < 3 && ((!e_deb_type && strncmp(e_d_msg[ERR_STARTPROG],eing, 17)) ||
-   (e_deb_type == 2 && strncmp("Running:",eing, 8))))
- {
-  e_d_quit(f);
-  return(e_error(e_d_msg[ERR_CANTPROG], 0, f->fb));
- }
- e_d_swtch = 3;
- return(e_read_output(f));
-}
-
-int e_deb_trace(FENSTER *f)
-{
- return(e_d_step_next(f, 0));
-}
-
-int e_deb_next(FENSTER *f)
-{
- return(e_d_step_next(f, 1));
-}
-
-int e_d_step_next(FENSTER *f, int sw)
-{
- int ret, main_brk = 0;
-
- if (e_d_swtch < 2 && (ret = e_run_debug(f)) < 0)
- {
-  e_d_quit(f);
-  if (ret == -1)
-  {  e_show_error(0, f);  return(ret);  }
-  return(e_error(e_d_msg[ERR_CANTDEBUG], 0, f->fb));
- }
- if (e_d_swtch < 3)
- {
-  if ((main_brk = e_mk_brk_main(f, 0)) < -1) return(main_brk);
-  ret = e_deb_run(f);
-  e_mk_brk_main(f, main_brk);
-  return(ret);
- }
- e_d_delbreak(f);
- e_d_switch_out(1);
- char *cstr = 0;
- if (sw && e_deb_type == 0) cstr = "n\n";
- else if (sw && (e_deb_type == 1 || e_deb_type == 3)) cstr = "S\n";
- else if (sw && e_deb_type == 2) cstr = "next\n";
- else if (e_deb_type == 2) cstr = "step\n";
- else cstr = "s\n";
- if (cstr) {
- 	int n = strlen(cstr);
-	if (n != write(rfildes[1], cstr, n)) {
-		printf("[e_d_step_next]: Write to debugger for %s failed.\n", cstr);
+  if (e_d_swtch < 2 && (ret = e_run_debug (f)) < 0)
+    {
+      e_d_quit (f);
+      if (ret == -1)
+	{
+	  e_show_error (0, f);
+	  return (ret);
 	}
- }
- e_d_nstack = 0;
- return(e_read_output(f));
-}
-
-int e_d_goto_func(FENSTER *f, int flag)
-{
- ECNT *cn = f->ed;
- BUFFER *b = cn->f[cn->mxedt]->b;
- int ret = 0, main_brk = 0;
- char str[128];
-
- if (e_deb_type!=0)/* if gdb */
-  return 0;
- if (e_d_swtch < 2 && (ret = e_run_debug(f)) < 0)
- {
-  e_d_quit(f);
-  if (ret == -1)
-  {  e_show_error(0, f);  return(ret);  }
-  return(e_error(e_d_msg[ERR_CANTDEBUG], 0, f->fb));
- }
- if (e_d_swtch < 3)
- {
-  if ((main_brk = e_mk_brk_main(f, 0)) < -1)
-   return(main_brk);
-  ret = e_deb_run(f);
-  e_mk_brk_main(f, main_brk);
-  return(ret);
- }
- e_d_delbreak(f);
- e_d_switch_out(1);
- switch(flag)
- {
-  case 'U':
-   sprintf(str,"until %d\n",b->b.y+1);
-   break;
-  case 'F':
-   sprintf(str,"finish\n");
-   break;
-  default:
-   *str=0;
-   break;
- }
- e_d_nstack = 0;
- if (*str)
- {
-  int n = strlen(str);
-  if (n != write(rfildes[1], str, n)) {
-	printf("[e_d_goto_func]: write to debugger failed for %s.\n", str);
-  }
-  ret=e_read_output(f);
-  /* Executing Finish twice may not work properly. */
- }
- return ret;
-}
-
-int e_d_goto_cursor(FENSTER *f)
-{
- return e_d_goto_func(f,'U');
-}
-
-int e_d_finish_func(FENSTER *f)
-{
- return e_d_goto_func(f,'F');
-}
-
-int e_d_fst_check(FENSTER *f)
-{
- int i, j, k = 0, l, ret = 0;
-
- e_d_switch_out(0);
- for (i = 0; i < SVLINES - 1; i++)
- {
-  if ((e_deb_type != 2 && !strncmp(e_d_sp[i], e_d_msg[ERR_PROGEXIT], 14)) ||
-    ((e_deb_type == 2 && !strncmp(e_d_sp[i], e_d_msg[ERR_PROGEXIT2], 14)) ||
-    (e_deb_type == 3 && !strncmp(e_d_sp[i], e_d_msg[ERR_NORMALTERM], strlen(e_d_msg[ERR_NORMALTERM])))))
-  {
-   e_d_error(e_d_sp[i]);		/*  Program exited   */
-   e_d_quit(f);
-   return(i);
-  }
-  else if ((e_deb_type == 0 || e_deb_type == 1) && !strncmp(e_d_sp[i], e_d_msg[ERR_PROGTERM], 18))
-  {
-   e_error(e_d_msg[ERR_PROGTERM], 0, f->fb);
-   e_d_quit(f);
-   return(i);
-  }
-  else if (e_deb_type == 0 && !strncmp(e_d_sp[i], e_d_msg[ERR_PROGSIGNAL], 23))
-  {
-   e_d_pr_sig(e_d_sp[i], f);
-   return(i);
-  }
-  else if (e_deb_type == 3 && !strncmp(e_d_sp[i], e_d_msg[ERR_SOFTTERM], strlen(e_d_msg[ERR_SOFTTERM])))
-  {
-   e_d_pr_sig(e_d_sp[i], f);
-   return(i);
-  }
-  else if (e_deb_type == 2 && (!strncmp(e_d_sp[i], e_d_msg[ERR_SIGNAL], 6) ||
-    !strncmp(e_d_sp[i], e_d_msg[ERR_INTERRUPT], 9)))
-  {
-   e_d_pr_sig(e_d_sp[i], f);
-   return(i);
-  }
-  else if (e_deb_type == 1 && strstr(e_d_sp[i], e_d_msg[ERR_SIGNAL]))
-  {
-   e_d_pr_sig(e_d_sp[i], f);
-   return(i);
-  }
-  else if (e_deb_type == 3 && i == SVLINES-2 && strstr(e_d_sp[i], ": "))
-  {
-   e_d_pr_sig(e_d_sp[i-1], f);
-   return(i-1);
-  }
-  else if (!strncmp(e_d_sp[i], e_d_msg[ERR_BREAKPOINT], 10) ||
-    (e_deb_type == 1 && !strncmp(e_d_sp[i], e_d_msg[ERR_BREAKPOINT2], 10)))
-  {
-   if (!e_deb_type)
-   {
-    for (j = SVLINES - 2; j > i; j--)      /*  Breakpoint   */
-    {
-     if ((ret = atoi(e_d_sp[j])) > 0)
-      for(k = 0; e_d_sp[j][k] && isdigit(e_d_sp[j][k]); k++)
-       ;
-     if (e_d_sp[j][k] == '\t')
-      break;
+      return (e_error (e_d_msg[ERR_CANTDEBUG], 0, f->fb));
     }
-    if (j > i)
-    {
-     for (k = strlen(e_d_sp[j-1]); k >= 0 && e_d_sp[j-1][k] != ':'; k--)
-      ;
-     if (k >= 0 && atoi(e_d_sp[j-1]+k+1) == ret)
-     {
-      if (e_make_line_num(e_d_sp[j-1], e_d_sp[SVLINES-1]) >= 0)
-       strcpy(e_d_file, e_d_sp[SVLINES-1]);
-     }
-     if (e_d_p_watches(f, 0) == -1)
-      return(-1);
-     e_d_goto_break(e_d_file, ret, f);
-     return(i > 0 ? i-1 : 0);
-    }
-   }
-   else if (e_deb_type == 1)	      /*  Breakpoint   */
-   {
-    if(!strncmp(e_d_sp[i]+10, " at", 3) &&
-      (ret = e_make_line_num(e_d_sp[i+1], e_d_sp[SVLINES-1])) >= 0)
-    {
-     strcpy(e_d_file, e_d_sp[SVLINES-1]);
-     if (e_d_p_watches(f, 0) == -1)
-      return(-1);
-     e_d_goto_break(e_d_file, ret, f);
-     return(i);
-    }
-   }
-  }
-  else if (e_deb_type == 2 && !strncmp(e_d_sp[i], e_d_msg[ERR_STOPPEDIN], 10))
-  {
-   for (j = i + 1; j < SVLINES - 1; j++)		      /*  Breakpoint   */
-   {
-    for (k = 0; e_d_sp[j][k] == ' ' && e_d_sp[j][k] != '\0'; k++)
-     ;
-    if ((ret = atoi(e_d_sp[j]+k)) > 0)
-    {
-     if (!strstr(e_d_sp[j-1], " line "))
-      break;
-     for (k = strlen(e_d_sp[j-1]); k >= 0 && e_d_sp[j-1][k] != '\"'; k--)
-      ;
-     for(k--; k >= 0 && e_d_sp[j-1][k] != '\"'; k--)
-      ;
-     if (k >= 0)
-     {
-      for(k++, l = 0; e_d_sp[j-1][k] != '\0' && e_d_sp[j-1][k] != '\"';
-        k++, l++)
-       e_d_file[l] = e_d_sp[j-1][k];
-      e_d_file[l] = '\0';
-     }
-     if (e_d_p_watches(f, 0) == -1)
-      return(-1);
-     e_d_goto_break(e_d_file, ret, f);
-     return(i);
-    }
-   }
-  }
- }
- return(-2);
-}
-
-int e_d_snd_check(FENSTER *f)
-{
- int i, j, k, ret;
-
- e_d_switch_out(0);
- for (i = SVLINES - 2; i >= 0; i--)
- {
-  if (!e_deb_type && (ret = atoi(e_d_sp[i])) > 0)
-  {
-   for (k = 0; e_d_sp[i][k] && isdigit(e_d_sp[i][k]); k++)
+  for (ret = 0; isspace (e_d_tty[ret]); ret++)
     ;
-   if (e_d_sp[i][k] != '\t')
-    continue;
-   if (i > 0)
-   {
-    for (k = strlen(e_d_sp[i-1]); k >= 0 && e_d_sp[i-1][k] != ':'; k--)
-     ;
-    if (k >= 0 && atoi(e_d_sp[i-1]+k+1) == ret)
+  if (e_d_tty[ret] != DIRC)
     {
-     i--;
-     if (e_make_line_num(e_d_sp[i], e_d_sp[SVLINES-1]) >= 0)
-      strcpy(e_d_file, e_d_sp[SVLINES-1]);
-     do
-     {
-      for (; k >= 0 && e_d_sp[i][k] != ')'; k--)
-       ;
-      if (k < 0)
-      {  i--;  k = strlen(e_d_sp[i]);  }
+      e_d_quit (f);
+      sprintf (eing, "tty error: %s", e_d_tty);
+      return (e_d_error (eing));
+    }
+  if (e_deb_type == 2)
+    {
+      if (e_d_swtch < 3)
+	{
+	  if (e_prog.arguments)
+	    sprintf (eing, "run %s > %s\n", e_prog.arguments, e_d_tty);
+	  else
+	    sprintf (eing, "run > %s\n", e_d_tty);
+	}
       else
-       break;
-     }  while (i >= 0);
-     do
-     {
-      for (j = 1, k--; k >= 0 && j > 0; k--)
-      {
-       if (e_d_sp[i][k] == ')')
-        j++;
-       else if (e_d_sp[i][k] == '(')
-        j--;
-      }
-      if (k < 0)
-      {  i--;  k = strlen(e_d_sp[i]);  }
-     } while (i >= 0 && j > 0);
-     if (k == 0 && i > 0)
-     {  i--;  k = strlen(e_d_sp[i]);  }
-     for (k--; k >= 0 && isspace(e_d_sp[i][k]); k--)
-      ;
-     if (k < 0 && i > 0)
-      i--;
+	{
+	  strcpy (eing, "cont\n");
+	  prsw = 1;
+	}
     }
-   }
-   if (e_d_p_watches(f, 0) == -1)
-    return(-1);
-   e_d_goto_break(e_d_file, ret, f);
-   return(i);
-  }
-  else if (e_deb_type == 1 && (ret = atoi(e_d_sp[i])) > 0)
-  {
-   for (; i > 0; i--)
-   {
-    for (j = strlen(e_d_sp[i-1])-1; j >= 0 && isspace(e_d_sp[i-1][j]); j--)
-     ;
-    if (j < 0)
-    {  i--;  continue;  }
-    for (j--; j >= 0 && !isspace(e_d_sp[i-1][j]); j--)
-     ;
-    if (j < 0)
-     i--;
-    for (j--; j >= 0 && isspace(e_d_sp[i-1][j]); j--)
-     ;
-    if (j < 0)
-     i--;
-    for (j--; j >= 0 && !isspace(e_d_sp[i-1][j]); j--)
-     ;
-    if (!strncmp(e_d_sp[i-1]+j+1, "in ", 3))
+  else
     {
-     strcpy(e_d_file, e_d_sp[i-1]+j+4);
-     for (k = i+2; !e_d_file[0]; k++)
-      strcpy(e_d_file, e_d_sp[i-1]+j+4);
-     for (k = strlen(e_d_file)-1; k >= 0 && isspace(e_d_file[k]); k--)
-      ;
-     e_d_file[k+1] = '\0';
-     if (e_d_p_watches(f, 0) == -1)
-      return(-1);
-     e_d_goto_break(e_d_file, ret, f);
-     return(i);
+      if (e_d_swtch < 3)
+	{
+	  if (e_prog.arguments)
+	    sprintf (eing, "r %s > %s\n", e_prog.arguments, e_d_tty);
+	  else
+	    sprintf (eing, "r > %s\n", e_d_tty);
+	}
+      else
+	{
+	  strcpy (eing, "c\n");
+	  prsw = 1;
+	}
     }
-   }
-   return(-2);
-  }
-  else if (e_deb_type == 3 && i == SVLINES-2 &&
-    (ret = e_make_line_num(e_d_sp[i], e_d_sp[SVLINES-1])) >= 0)
-  {
-   strcpy(e_d_file, e_d_sp[SVLINES-1]);
-   if (e_d_p_watches(f, 0) == -1)
-    return(-1);
-   e_d_goto_break(e_d_file, ret, f);
-   return(i);
-  }
- }
- return(-2);
+  f = cn->f[cn->mxedt];
+  e_d_nstack = 0;
+  e_d_delbreak (f);
+  e_d_switch_out (1);
+  int n = strlen (eing);
+  if (n != write (rfildes[1], eing, n))
+    {
+      printf ("[e_deb_run]: write to debugger failed for %s.\n", eing);
+    }
+  if (e_deb_type == 0 || ((e_deb_type == 2 || e_deb_type == 3) && !prsw))
+    {
+      while ((ret = e_d_line_read (wfildes[0], eing, 256, 0, 0)) == 2 ||
+	     !eing[0] || (!e_deb_type && prsw
+			  && ((len = (strlen (eing) - 12)) < 0
+			      || strcmp (eing + len, e_d_msg[ERR_CONTINUE])))
+	     || (e_d_swtch < 3
+		 &&
+		 ((!e_deb_type && strncmp (e_d_msg[ERR_STARTPROG], eing, 17))
+		  || (e_deb_type == 2 && strncmp ("Running:", eing, 8)))))
+	{
+	  if (ret == 2)
+	    e_d_error (eing);
+	  else if (ret < 0)
+	    return (e_d_quit (f));
+	}
+    }
+  if (!prsw)
+    e_d_p_message (eing, f, 0);
+  if (e_d_swtch < 3
+      && ((!e_deb_type && strncmp (e_d_msg[ERR_STARTPROG], eing, 17))
+	  || (e_deb_type == 2 && strncmp ("Running:", eing, 8))))
+    {
+      e_d_quit (f);
+      return (e_error (e_d_msg[ERR_CANTPROG], 0, f->fb));
+    }
+  e_d_swtch = 3;
+  return (e_read_output (f));
 }
 
-int e_d_trd_check(FENSTER *f)
+int
+e_deb_trace (FENSTER * f)
 {
- int ret;
- char str[256];
-
- str[0] = '\0';
- e_d_switch_out(0);
- if ((ret = e_d_pr_sig(str, f)) == -1) return(-1);
- else if (ret == -2) e_d_error(e_d_msg[ERR_NOSOURCE]);
- return(0);
+  return (e_d_step_next (f, 0));
 }
 
-int e_read_output(FENSTER *f)
+int
+e_deb_next (FENSTER * f)
 {
- char *spt;
- int i, ret;
-
- for (i = 0; i < SVLINES; i++)
- {  e_d_sp[i] = e_d_out_str[i];  e_d_out_str[i][0] = '\0';  }
- while ((ret = e_d_line_read(wfildes[0], e_d_sp[SVLINES-1], 256, 0, 0)) == 2)
-  e_d_error(e_d_sp[SVLINES-1]);
- if (ret < 0) return(-1);
- e_d_switch_out(0);
- while(ret != 1)
- {
-  spt = e_d_sp[0];
-  for (i = 1; i < SVLINES; i++)
-   e_d_sp[i-1] = e_d_sp[i];
-  e_d_sp[SVLINES-1] = spt;
-  do
-  {
-   while((ret = e_d_line_read(wfildes[0], e_d_sp[SVLINES-1], 256, 0, 0)) == 2)
-    e_d_error(e_d_sp[SVLINES-1]);
-   if (ret < 0) return(-1);
-  } while(!ret && !*e_d_sp[SVLINES-1]);
- }
- if ((i = e_d_fst_check(f)) == -1) return(-1);
- if (i < 0 && (i = e_d_snd_check(f)) == -1) return(-1);
- if (i < 0 && (i = e_d_trd_check(f)) == -1) return(-1);
- if (i < 0)
- {
-  e_d_switch_out(0);
-  i = e_message(1, e_d_msg[ERR_UNKNOWNBRK], f);
-  if (i == 'Y') return(e_d_quit(f));
- }
- return(0);
+  return (e_d_step_next (f, 1));
 }
 
-int e_d_pr_sig(char *str, FENSTER *f)
+int
+e_d_step_next (FENSTER * f, int sw)
 {
- int i, line = -1, ret = 0;
- char file[128], str2[256];
+  int ret, main_brk = 0;
 
- if (str && str[0])
-  e_d_error(str);
- for (i = 0; i < SVLINES; i++)
-  e_d_out_str[i][0] = '\0';
- if (e_deb_type != 1 && e_deb_type != 3)
- {
-  char *cstr = "where\n";
-  int n = strlen(cstr);
-  if (n != write(rfildes[1], cstr, n)) {
-	printf("[e_d_pr_sig]: write to debugger failed for %s.\n", cstr);
-  }
-  for (i = 0; ((ret = e_d_line_read(wfildes[0], str, 256, 0, 1)) == 0 &&
-    (line = e_make_line_num(str, file)) < 0) || ret == 2; i++)
-  {
-   if (!strncmp(str, e_d_msg[ERR_NOSTACK], 9))
-   {
-    e_error(e_d_msg[ERR_PROGEXIT], 0, f->fb);
-    while (ret == 0 || ret == 2)
-     if ((ret = e_d_line_read(wfildes[0], str2, 256, 0, 0)) == 2)
-      e_d_error(str2);
-    e_d_quit(f);
-    return(0);
-   }
-   else if (ret == 2)
-    e_d_error(str);
-  }
- }
- else
- {
-  char *cstr = "t\n";
-  int n = strlen(cstr);
-  if (n != write(rfildes[1], cstr, n)) {
-	printf("[e_d_pr_sig]: write to debugger failed for %s.\n", cstr);
-  }
-  for (i = 0; ((ret = e_d_line_read(wfildes[0], str, 256, 0, 1)) == 0 &&
-    (line = e_make_line_num2(str, file)) < 0) || ret == 2; i++)
-  {
-   if (!strncmp(str, e_d_msg[ERR_NOPROCESS], 10))
-   {
-    e_error(e_d_msg[ERR_PROGEXIT], 0, f->fb);
-    while (ret == 0 || ret == 2)
-     if ((ret = e_d_line_read(wfildes[0], str2, 256, 0, 0)) == 2)
-      e_d_error(str2);
-    e_d_quit(f);
-    return(0);
-   }
-   else if (ret == 2)
-    e_d_error(str);
-  }
- }
- if (ret == 1 && i == 0)
- {
-  e_d_error(e_d_msg[ERR_PROGEXIT]);
-  return(e_d_quit(f));
- }
- while (ret == 0 || ret == 2)
-  if ((ret = e_d_line_read(wfildes[0], str2, 256, 0, 0)) == 2)
-   e_d_error(str2);
- if (ret == -1)
-  return(ret);
- if (line >= 0)
- {
-  strcpy(e_d_file, file);
-  e_d_goto_break(file, line, f);
-  return(0);
- }
- else
-  return(-2);
+  if (e_d_swtch < 2 && (ret = e_run_debug (f)) < 0)
+    {
+      e_d_quit (f);
+      if (ret == -1)
+	{
+	  e_show_error (0, f);
+	  return (ret);
+	}
+      return (e_error (e_d_msg[ERR_CANTDEBUG], 0, f->fb));
+    }
+  if (e_d_swtch < 3)
+    {
+      if ((main_brk = e_mk_brk_main (f, 0)) < -1)
+	return (main_brk);
+      ret = e_deb_run (f);
+      e_mk_brk_main (f, main_brk);
+      return (ret);
+    }
+  e_d_delbreak (f);
+  e_d_switch_out (1);
+  char *cstr = 0;
+  if (sw && e_deb_type == 0)
+    cstr = "n\n";
+  else if (sw && (e_deb_type == 1 || e_deb_type == 3))
+    cstr = "S\n";
+  else if (sw && e_deb_type == 2)
+    cstr = "next\n";
+  else if (e_deb_type == 2)
+    cstr = "step\n";
+  else
+    cstr = "s\n";
+  if (cstr)
+    {
+      int n = strlen (cstr);
+      if (n != write (rfildes[1], cstr, n))
+	{
+	  printf ("[e_d_step_next]: Write to debugger for %s failed.\n",
+		  cstr);
+	}
+    }
+  e_d_nstack = 0;
+  return (e_read_output (f));
 }
 
-int e_make_line_num(char *str, char *file)
+int
+e_d_goto_func (FENSTER * f, int flag)
 {
- char *sp;
- int i, n, num;
+  ECNT *cn = f->ed;
+  BUFFER *b = cn->f[cn->mxedt]->b;
+  int ret = 0, main_brk = 0;
+  char str[128];
 
- if (e_deb_type == 0)
- {
-  for (n = strlen(str); n >= 0 && str[n] != ':'; n--)
-   ;
-  if (n < 0)
-   return(-1);
-  for (i = n-1; i >= 0 && !isspace(str[i]); i--)
-   ;
-  for (n = i+1; str[n] != ':'; n++)
-   file[n-i-1] = str[n];
-  file[n-i-1] = '\0';
-  return(atoi(str+n+1));
- }
- else if (e_deb_type == 2)
- {
-  if (!(sp = strstr(str, " line ")))
-   return(-1);
-  if (!(num = atoi(sp+6)))
-   return(-1);
-  for (i = 6;  sp[i] != '\"'; i++)
-   ;
-  sp += (i+1);
-  for (i = 0; (file[i] = sp[i]) != '\"' && file[i] != '\0'; i++)
-   ;
-  if (file[i] == '\0')
-   return(-1);
-  file[i] = '\0';
-  return(num);
- }
- else if (e_deb_type == 3)
- {
-  for (sp = str, i = 0; (file[i] = sp[i]) && sp[i] != ':'; i++)
-   ;
-  if (!sp[i])
-   return(-1);
-  file[i] = '\0';
-  for (i++; sp[i] && sp[i] != ':'; i++)
-   ;
-  if (!sp[i])
-   return(-1);
-  for (i++; sp[i] && isspace(sp[i]); i++)
-   ;
-  if (!isdigit(sp[i]))
-   return(-1);
-  sp += i;
-  return(atoi(sp));
- }
- else
- {
-  for (i = 0; str[i] != '\0' && str[i] != ':'; i++)
-   ;
-  if ((!str[i]) || (num = atoi(str+i+1)) < 0)
-   return(-1);
-  char *cstr = "e\n";
-  n = strlen(cstr);
-  if (n != write(rfildes[1], cstr, n)) {
-	printf("[e_make_line_num]: Write to debugger failed for %s.\n", cstr);
-  }
-  while ((i = e_d_line_read(wfildes[0], str, 256, 0, 0)) ==  2)
-   e_d_error(str);
+  if (e_deb_type != 0)		/* if gdb */
+    return 0;
+  if (e_d_swtch < 2 && (ret = e_run_debug (f)) < 0)
+    {
+      e_d_quit (f);
+      if (ret == -1)
+	{
+	  e_show_error (0, f);
+	  return (ret);
+	}
+      return (e_error (e_d_msg[ERR_CANTDEBUG], 0, f->fb));
+    }
+  if (e_d_swtch < 3)
+    {
+      if ((main_brk = e_mk_brk_main (f, 0)) < -1)
+	return (main_brk);
+      ret = e_deb_run (f);
+      e_mk_brk_main (f, main_brk);
+      return (ret);
+    }
+  e_d_delbreak (f);
+  e_d_switch_out (1);
+  switch (flag)
+    {
+    case 'U':
+      sprintf (str, "until %d\n", b->b.y + 1);
+      break;
+    case 'F':
+      sprintf (str, "finish\n");
+      break;
+    default:
+      *str = 0;
+      break;
+    }
+  e_d_nstack = 0;
+  if (*str)
+    {
+      int n = strlen (str);
+      if (n != write (rfildes[1], str, n))
+	{
+	  printf ("[e_d_goto_func]: write to debugger failed for %s.\n", str);
+	}
+      ret = e_read_output (f);
+      /* Executing Finish twice may not work properly. */
+    }
+  return ret;
+}
+
+int
+e_d_goto_cursor (FENSTER * f)
+{
+  return e_d_goto_func (f, 'U');
+}
+
+int
+e_d_finish_func (FENSTER * f)
+{
+  return e_d_goto_func (f, 'F');
+}
+
+int
+e_d_fst_check (FENSTER * f)
+{
+  int i, j, k = 0, l, ret = 0;
+
+  e_d_switch_out (0);
+  for (i = 0; i < SVLINES - 1; i++)
+    {
+      if ((e_deb_type != 2 && !strncmp (e_d_sp[i], e_d_msg[ERR_PROGEXIT], 14))
+	  ||
+	  ((e_deb_type == 2
+	    && !strncmp (e_d_sp[i], e_d_msg[ERR_PROGEXIT2], 14))
+	   || (e_deb_type == 3
+	       && !strncmp (e_d_sp[i], e_d_msg[ERR_NORMALTERM],
+			    strlen (e_d_msg[ERR_NORMALTERM])))))
+	{
+	  e_d_error (e_d_sp[i]);	/*  Program exited   */
+	  e_d_quit (f);
+	  return (i);
+	}
+      else if ((e_deb_type == 0 || e_deb_type == 1)
+	       && !strncmp (e_d_sp[i], e_d_msg[ERR_PROGTERM], 18))
+	{
+	  e_error (e_d_msg[ERR_PROGTERM], 0, f->fb);
+	  e_d_quit (f);
+	  return (i);
+	}
+      else if (e_deb_type == 0
+	       && !strncmp (e_d_sp[i], e_d_msg[ERR_PROGSIGNAL], 23))
+	{
+	  e_d_pr_sig (e_d_sp[i], f);
+	  return (i);
+	}
+      else if (e_deb_type == 3
+	       && !strncmp (e_d_sp[i], e_d_msg[ERR_SOFTTERM],
+			    strlen (e_d_msg[ERR_SOFTTERM])))
+	{
+	  e_d_pr_sig (e_d_sp[i], f);
+	  return (i);
+	}
+      else if (e_deb_type == 2
+	       && (!strncmp (e_d_sp[i], e_d_msg[ERR_SIGNAL], 6)
+		   || !strncmp (e_d_sp[i], e_d_msg[ERR_INTERRUPT], 9)))
+	{
+	  e_d_pr_sig (e_d_sp[i], f);
+	  return (i);
+	}
+      else if (e_deb_type == 1 && strstr (e_d_sp[i], e_d_msg[ERR_SIGNAL]))
+	{
+	  e_d_pr_sig (e_d_sp[i], f);
+	  return (i);
+	}
+      else if (e_deb_type == 3 && i == SVLINES - 2
+	       && strstr (e_d_sp[i], ": "))
+	{
+	  e_d_pr_sig (e_d_sp[i - 1], f);
+	  return (i - 1);
+	}
+      else if (!strncmp (e_d_sp[i], e_d_msg[ERR_BREAKPOINT], 10) ||
+	       (e_deb_type == 1
+		&& !strncmp (e_d_sp[i], e_d_msg[ERR_BREAKPOINT2], 10)))
+	{
+	  if (!e_deb_type)
+	    {
+	      for (j = SVLINES - 2; j > i; j--)	/*  Breakpoint   */
+		{
+		  if ((ret = atoi (e_d_sp[j])) > 0)
+		    for (k = 0; e_d_sp[j][k] && isdigit (e_d_sp[j][k]); k++)
+		      ;
+		  if (e_d_sp[j][k] == '\t')
+		    break;
+		}
+	      if (j > i)
+		{
+		  for (k = strlen (e_d_sp[j - 1]);
+		       k >= 0 && e_d_sp[j - 1][k] != ':'; k--)
+		    ;
+		  if (k >= 0 && atoi (e_d_sp[j - 1] + k + 1) == ret)
+		    {
+		      if (e_make_line_num (e_d_sp[j - 1], e_d_sp[SVLINES - 1])
+			  >= 0)
+			strcpy (e_d_file, e_d_sp[SVLINES - 1]);
+		    }
+		  if (e_d_p_watches (f, 0) == -1)
+		    return (-1);
+		  e_d_goto_break (e_d_file, ret, f);
+		  return (i > 0 ? i - 1 : 0);
+		}
+	    }
+	  else if (e_deb_type == 1)	/*  Breakpoint   */
+	    {
+	      if (!strncmp (e_d_sp[i] + 10, " at", 3) &&
+		  (ret =
+		   e_make_line_num (e_d_sp[i + 1], e_d_sp[SVLINES - 1])) >= 0)
+		{
+		  strcpy (e_d_file, e_d_sp[SVLINES - 1]);
+		  if (e_d_p_watches (f, 0) == -1)
+		    return (-1);
+		  e_d_goto_break (e_d_file, ret, f);
+		  return (i);
+		}
+	    }
+	}
+      else if (e_deb_type == 2
+	       && !strncmp (e_d_sp[i], e_d_msg[ERR_STOPPEDIN], 10))
+	{
+	  for (j = i + 1; j < SVLINES - 1; j++)	/*  Breakpoint   */
+	    {
+	      for (k = 0; e_d_sp[j][k] == ' ' && e_d_sp[j][k] != '\0'; k++)
+		;
+	      if ((ret = atoi (e_d_sp[j] + k)) > 0)
+		{
+		  if (!strstr (e_d_sp[j - 1], " line "))
+		    break;
+		  for (k = strlen (e_d_sp[j - 1]);
+		       k >= 0 && e_d_sp[j - 1][k] != '\"'; k--)
+		    ;
+		  for (k--; k >= 0 && e_d_sp[j - 1][k] != '\"'; k--)
+		    ;
+		  if (k >= 0)
+		    {
+		      for (k++, l = 0;
+			   e_d_sp[j - 1][k] != '\0'
+			   && e_d_sp[j - 1][k] != '\"'; k++, l++)
+			e_d_file[l] = e_d_sp[j - 1][k];
+		      e_d_file[l] = '\0';
+		    }
+		  if (e_d_p_watches (f, 0) == -1)
+		    return (-1);
+		  e_d_goto_break (e_d_file, ret, f);
+		  return (i);
+		}
+	    }
+	}
+    }
+  return (-2);
+}
+
+int
+e_d_snd_check (FENSTER * f)
+{
+  int i, j, k, ret;
+
+  e_d_switch_out (0);
+  for (i = SVLINES - 2; i >= 0; i--)
+    {
+      if (!e_deb_type && (ret = atoi (e_d_sp[i])) > 0)
+	{
+	  for (k = 0; e_d_sp[i][k] && isdigit (e_d_sp[i][k]); k++)
+	    ;
+	  if (e_d_sp[i][k] != '\t')
+	    continue;
+	  if (i > 0)
+	    {
+	      for (k = strlen (e_d_sp[i - 1]);
+		   k >= 0 && e_d_sp[i - 1][k] != ':'; k--)
+		;
+	      if (k >= 0 && atoi (e_d_sp[i - 1] + k + 1) == ret)
+		{
+		  i--;
+		  if (e_make_line_num (e_d_sp[i], e_d_sp[SVLINES - 1]) >= 0)
+		    strcpy (e_d_file, e_d_sp[SVLINES - 1]);
+		  do
+		    {
+		      for (; k >= 0 && e_d_sp[i][k] != ')'; k--)
+			;
+		      if (k < 0)
+			{
+			  i--;
+			  k = strlen (e_d_sp[i]);
+			}
+		      else
+			break;
+		    }
+		  while (i >= 0);
+		  do
+		    {
+		      for (j = 1, k--; k >= 0 && j > 0; k--)
+			{
+			  if (e_d_sp[i][k] == ')')
+			    j++;
+			  else if (e_d_sp[i][k] == '(')
+			    j--;
+			}
+		      if (k < 0)
+			{
+			  i--;
+			  k = strlen (e_d_sp[i]);
+			}
+		    }
+		  while (i >= 0 && j > 0);
+		  if (k == 0 && i > 0)
+		    {
+		      i--;
+		      k = strlen (e_d_sp[i]);
+		    }
+		  for (k--; k >= 0 && isspace (e_d_sp[i][k]); k--)
+		    ;
+		  if (k < 0 && i > 0)
+		    i--;
+		}
+	    }
+	  if (e_d_p_watches (f, 0) == -1)
+	    return (-1);
+	  e_d_goto_break (e_d_file, ret, f);
+	  return (i);
+	}
+      else if (e_deb_type == 1 && (ret = atoi (e_d_sp[i])) > 0)
+	{
+	  for (; i > 0; i--)
+	    {
+	      for (j = strlen (e_d_sp[i - 1]) - 1;
+		   j >= 0 && isspace (e_d_sp[i - 1][j]); j--)
+		;
+	      if (j < 0)
+		{
+		  i--;
+		  continue;
+		}
+	      for (j--; j >= 0 && !isspace (e_d_sp[i - 1][j]); j--)
+		;
+	      if (j < 0)
+		i--;
+	      for (j--; j >= 0 && isspace (e_d_sp[i - 1][j]); j--)
+		;
+	      if (j < 0)
+		i--;
+	      for (j--; j >= 0 && !isspace (e_d_sp[i - 1][j]); j--)
+		;
+	      if (!strncmp (e_d_sp[i - 1] + j + 1, "in ", 3))
+		{
+		  strcpy (e_d_file, e_d_sp[i - 1] + j + 4);
+		  for (k = i + 2; !e_d_file[0]; k++)
+		    strcpy (e_d_file, e_d_sp[i - 1] + j + 4);
+		  for (k = strlen (e_d_file) - 1;
+		       k >= 0 && isspace (e_d_file[k]); k--)
+		    ;
+		  e_d_file[k + 1] = '\0';
+		  if (e_d_p_watches (f, 0) == -1)
+		    return (-1);
+		  e_d_goto_break (e_d_file, ret, f);
+		  return (i);
+		}
+	    }
+	  return (-2);
+	}
+      else if (e_deb_type == 3 && i == SVLINES - 2 &&
+	       (ret = e_make_line_num (e_d_sp[i], e_d_sp[SVLINES - 1])) >= 0)
+	{
+	  strcpy (e_d_file, e_d_sp[SVLINES - 1]);
+	  if (e_d_p_watches (f, 0) == -1)
+	    return (-1);
+	  e_d_goto_break (e_d_file, ret, f);
+	  return (i);
+	}
+    }
+  return (-2);
+}
+
+int
+e_d_trd_check (FENSTER * f)
+{
+  int ret;
+  char str[256];
+
+  str[0] = '\0';
+  e_d_switch_out (0);
+  if ((ret = e_d_pr_sig (str, f)) == -1)
+    return (-1);
+  else if (ret == -2)
+    e_d_error (e_d_msg[ERR_NOSOURCE]);
+  return (0);
+}
+
+int
+e_read_output (FENSTER * f)
+{
+  char *spt;
+  int i, ret;
+
+  for (i = 0; i < SVLINES; i++)
+    {
+      e_d_sp[i] = e_d_out_str[i];
+      e_d_out_str[i][0] = '\0';
+    }
+  while ((ret =
+	  e_d_line_read (wfildes[0], e_d_sp[SVLINES - 1], 256, 0, 0)) == 2)
+    e_d_error (e_d_sp[SVLINES - 1]);
+  if (ret < 0)
+    return (-1);
+  e_d_switch_out (0);
+  while (ret != 1)
+    {
+      spt = e_d_sp[0];
+      for (i = 1; i < SVLINES; i++)
+	e_d_sp[i - 1] = e_d_sp[i];
+      e_d_sp[SVLINES - 1] = spt;
+      do
+	{
+	  while ((ret =
+		  e_d_line_read (wfildes[0], e_d_sp[SVLINES - 1], 256, 0,
+				 0)) == 2)
+	    e_d_error (e_d_sp[SVLINES - 1]);
+	  if (ret < 0)
+	    return (-1);
+	}
+      while (!ret && !*e_d_sp[SVLINES - 1]);
+    }
+  if ((i = e_d_fst_check (f)) == -1)
+    return (-1);
+  if (i < 0 && (i = e_d_snd_check (f)) == -1)
+    return (-1);
+  if (i < 0 && (i = e_d_trd_check (f)) == -1)
+    return (-1);
   if (i < 0)
-   return(-1);
-  for (i = 0; str[i] != '\0' && str[i] != '\"'; i++)
-   ;
-  for (sp = str + i + 1, i = 0; (file[i] = sp[i]) && file[i] != '\"'; i++)
-   ;
+    {
+      e_d_switch_out (0);
+      i = e_message (1, e_d_msg[ERR_UNKNOWNBRK], f);
+      if (i == 'Y')
+	return (e_d_quit (f));
+    }
+  return (0);
+}
+
+int
+e_d_pr_sig (char *str, FENSTER * f)
+{
+  int i, line = -1, ret = 0;
+  char file[128], str2[256];
+
+  if (str && str[0])
+    e_d_error (str);
+  for (i = 0; i < SVLINES; i++)
+    e_d_out_str[i][0] = '\0';
+  if (e_deb_type != 1 && e_deb_type != 3)
+    {
+      char *cstr = "where\n";
+      int n = strlen (cstr);
+      if (n != write (rfildes[1], cstr, n))
+	{
+	  printf ("[e_d_pr_sig]: write to debugger failed for %s.\n", cstr);
+	}
+      for (i = 0; ((ret = e_d_line_read (wfildes[0], str, 256, 0, 1)) == 0 &&
+		   (line = e_make_line_num (str, file)) < 0) || ret == 2; i++)
+	{
+	  if (!strncmp (str, e_d_msg[ERR_NOSTACK], 9))
+	    {
+	      e_error (e_d_msg[ERR_PROGEXIT], 0, f->fb);
+	      while (ret == 0 || ret == 2)
+		if ((ret = e_d_line_read (wfildes[0], str2, 256, 0, 0)) == 2)
+		  e_d_error (str2);
+	      e_d_quit (f);
+	      return (0);
+	    }
+	  else if (ret == 2)
+	    e_d_error (str);
+	}
+    }
+  else
+    {
+      char *cstr = "t\n";
+      int n = strlen (cstr);
+      if (n != write (rfildes[1], cstr, n))
+	{
+	  printf ("[e_d_pr_sig]: write to debugger failed for %s.\n", cstr);
+	}
+      for (i = 0; ((ret = e_d_line_read (wfildes[0], str, 256, 0, 1)) == 0 &&
+		   (line = e_make_line_num2 (str, file)) < 0) || ret == 2;
+	   i++)
+	{
+	  if (!strncmp (str, e_d_msg[ERR_NOPROCESS], 10))
+	    {
+	      e_error (e_d_msg[ERR_PROGEXIT], 0, f->fb);
+	      while (ret == 0 || ret == 2)
+		if ((ret = e_d_line_read (wfildes[0], str2, 256, 0, 0)) == 2)
+		  e_d_error (str2);
+	      e_d_quit (f);
+	      return (0);
+	    }
+	  else if (ret == 2)
+	    e_d_error (str);
+	}
+    }
+  if (ret == 1 && i == 0)
+    {
+      e_d_error (e_d_msg[ERR_PROGEXIT]);
+      return (e_d_quit (f));
+    }
+  while (ret == 0 || ret == 2)
+    if ((ret = e_d_line_read (wfildes[0], str2, 256, 0, 0)) == 2)
+      e_d_error (str2);
+  if (ret == -1)
+    return (ret);
+  if (line >= 0)
+    {
+      strcpy (e_d_file, file);
+      e_d_goto_break (file, line, f);
+      return (0);
+    }
+  else
+    return (-2);
+}
+
+int
+e_make_line_num (char *str, char *file)
+{
+  char *sp;
+  int i, n, num;
+
+  if (e_deb_type == 0)
+    {
+      for (n = strlen (str); n >= 0 && str[n] != ':'; n--)
+	;
+      if (n < 0)
+	return (-1);
+      for (i = n - 1; i >= 0 && !isspace (str[i]); i--)
+	;
+      for (n = i + 1; str[n] != ':'; n++)
+	file[n - i - 1] = str[n];
+      file[n - i - 1] = '\0';
+      return (atoi (str + n + 1));
+    }
+  else if (e_deb_type == 2)
+    {
+      if (!(sp = strstr (str, " line ")))
+	return (-1);
+      if (!(num = atoi (sp + 6)))
+	return (-1);
+      for (i = 6; sp[i] != '\"'; i++)
+	;
+      sp += (i + 1);
+      for (i = 0; (file[i] = sp[i]) != '\"' && file[i] != '\0'; i++)
+	;
+      if (file[i] == '\0')
+	return (-1);
+      file[i] = '\0';
+      return (num);
+    }
+  else if (e_deb_type == 3)
+    {
+      for (sp = str, i = 0; (file[i] = sp[i]) && sp[i] != ':'; i++)
+	;
+      if (!sp[i])
+	return (-1);
+      file[i] = '\0';
+      for (i++; sp[i] && sp[i] != ':'; i++)
+	;
+      if (!sp[i])
+	return (-1);
+      for (i++; sp[i] && isspace (sp[i]); i++)
+	;
+      if (!isdigit (sp[i]))
+	return (-1);
+      sp += i;
+      return (atoi (sp));
+    }
+  else
+    {
+      for (i = 0; str[i] != '\0' && str[i] != ':'; i++)
+	;
+      if ((!str[i]) || (num = atoi (str + i + 1)) < 0)
+	return (-1);
+      char *cstr = "e\n";
+      n = strlen (cstr);
+      if (n != write (rfildes[1], cstr, n))
+	{
+	  printf ("[e_make_line_num]: Write to debugger failed for %s.\n",
+		  cstr);
+	}
+      while ((i = e_d_line_read (wfildes[0], str, 256, 0, 0)) == 2)
+	e_d_error (str);
+      if (i < 0)
+	return (-1);
+      for (i = 0; str[i] != '\0' && str[i] != '\"'; i++)
+	;
+      for (sp = str + i + 1, i = 0; (file[i] = sp[i]) && file[i] != '\"'; i++)
+	;
+      file[i] = '\0';
+      if (e_d_dum_read () == -1)
+	return (-1);
+      return (num);
+    }
+}
+
+int
+e_make_line_num2 (char *str, char *file)
+{
+  char *sp;
+  int i;
+
+  for (i = 0; str[i] != '[' && str[i] != '\0'; i++)
+    ;
+  if (!str[i])
+    return (-1);
+  for (sp = str + i + 1, i = 0; (file[i] = sp[i]) != ':' && file[i] != '\0';
+       i++)
+    ;
+  if (file[i] == '\0')
+    return (-1);
   file[i] = '\0';
-  if (e_d_dum_read() == -1)
-   return(-1);
-  return(num);
- }
+  for (i++; isspace (sp[i]); i++)
+    ;
+  return (atoi (sp + i));
 }
 
-int e_make_line_num2(char *str, char *file)
+int
+e_d_goto_break (char *file, int line, FENSTER * f)
 {
- char *sp;
- int i;
-
- for (i = 0; str[i] != '[' && str[i] != '\0'; i++)
-  ;
- if (!str[i]) return(-1);
- for (sp = str+i+1, i = 0; (file[i] = sp[i]) != ':' && file[i] != '\0'; i++)
-  ;
- if (file[i] == '\0') return(-1);
- file[i] = '\0';
- for (i++; isspace(sp[i]); i++)
-  ;
- return(atoi(sp+i));
-}
-
-int e_d_goto_break(char *file, int line, FENSTER *f)
-{
- ECNT *cn = f->ed;
- BUFFER *b;
- SCHIRM *s;
- FENSTER ftmp;
- int i;
- char str[120];
+  ECNT *cn = f->ed;
+  BUFFER *b;
+  SCHIRM *s;
+  FENSTER ftmp;
+  int i;
+  char str[120];
 
 /*   if(schirm != e_d_save_schirm) e_d_switch_out(0);  */
- e_d_switch_out(0);
- ftmp.ed = cn;
- ftmp.fb = f->fb;
- WpeFilenameToPathFile(file, &ftmp.dirct, &ftmp.datnam);
- for (i = 0; i < SVLINES; i++)
-  e_d_out_str[i][0] = '\0';
- for (i = cn->mxedt; i > 0; i--)
-  if (!strcmp(cn->f[i]->datnam, ftmp.datnam) &&
-    !strcmp(cn->f[i]->dirct, ftmp.dirct))
-  {
-   /*  for(j = 0; j <= cn->mxedt; j++)
-	 if(!strcmp(cn->f[j]->datnam, "Stack"))
-	 {  if(cn->f[i]->e.x > 2*MAXSCOL/3-1) cn->f[i]->e.x = 2*MAXSCOL/3-1;
-	 break;
-	 }  */
-   e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-   break;
-  }
- f = cn->f[cn->mxedt];
- free(ftmp.dirct);
- free(ftmp.datnam);
- if (i <= 0)
- {
-  if (access(file, F_OK))
-  {
-   sprintf(str, e_d_msg[ERR_CANTFILE], file);
-   return(e_error(str, 0, f->fb));
-  }
-  if (e_edit(cn, file))
-   return(WPE_ESC);
+  e_d_switch_out (0);
+  ftmp.ed = cn;
+  ftmp.fb = f->fb;
+  WpeFilenameToPathFile (file, &ftmp.dirct, &ftmp.datnam);
+  for (i = 0; i < SVLINES; i++)
+    e_d_out_str[i][0] = '\0';
+  for (i = cn->mxedt; i > 0; i--)
+    if (!strcmp (cn->f[i]->datnam, ftmp.datnam) &&
+	!strcmp (cn->f[i]->dirct, ftmp.dirct))
+      {
+	/*  for(j = 0; j <= cn->mxedt; j++)
+	   if(!strcmp(cn->f[j]->datnam, "Stack"))
+	   {  if(cn->f[i]->e.x > 2*MAXSCOL/3-1) cn->f[i]->e.x = 2*MAXSCOL/3-1;
+	   break;
+	   }  */
+	e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	break;
+      }
+  f = cn->f[cn->mxedt];
+  free (ftmp.dirct);
+  free (ftmp.datnam);
+  if (i <= 0)
+    {
+      if (access (file, F_OK))
+	{
+	  sprintf (str, e_d_msg[ERR_CANTFILE], file);
+	  return (e_error (str, 0, f->fb));
+	}
+      if (e_edit (cn, file))
+	return (WPE_ESC);
+      b = cn->f[cn->mxedt]->b;
+      s = cn->f[cn->mxedt]->s;
+    }
+  f = cn->f[cn->mxedt];
   b = cn->f[cn->mxedt]->b;
   s = cn->f[cn->mxedt]->s;
- }
- f = cn->f[cn->mxedt];
- b = cn->f[cn->mxedt]->b;
- s = cn->f[cn->mxedt]->s;
- s->da.y = b->b.y = line - 1;
- s->da.x = b->b.x = 0;
- s->de.x = MAXSCOL;
- e_schirm(f, 1);
- e_cursor(f, 1);
- return(0);
+  s->da.y = b->b.y = line - 1;
+  s->da.x = b->b.x = 0;
+  s->de.x = MAXSCOL;
+  e_schirm (f, 1);
+  e_cursor (f, 1);
+  return (0);
 }
 
-int e_d_delbreak(FENSTER *f)
+int
+e_d_delbreak (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int i;
+  ECNT *cn = f->ed;
+  int i;
 
- for (i = cn->mxedt; i >= 0; i--)
-  if (DTMD_ISTEXT(cn->f[i]->dtmd))
-   cn->f[i]->s->da.y = -1;
- e_rep_win_tree(cn);
- e_refresh();
- return(0);
+  for (i = cn->mxedt; i >= 0; i--)
+    if (DTMD_ISTEXT (cn->f[i]->dtmd))
+      cn->f[i]->s->da.y = -1;
+  e_rep_win_tree (cn);
+  e_refresh ();
+  return (0);
 }
 
-int e_d_error(char *s)
+int
+e_d_error (char *s)
 {
- int len;
+  int len;
 
- e_d_switch_out(0);
- if (s[(len = strlen(s) - 1)] == '\n')
-  s[len] = '\0';
- return(e_error(s, 0, WpeEditor->fb));
+  e_d_switch_out (0);
+  if (s[(len = strlen (s) - 1)] == '\n')
+    s[len] = '\0';
+  return (e_error (s, 0, WpeEditor->fb));
 }
 
-int e_d_putchar(int c)
+int
+e_d_putchar (int c)
 {
- if (!WpeIsXwin()) c = fk_putchar(c);
- else
- {
-  char cc = c;
-  c = write(wfildes[1], &cc, 1);
- }
- return(c);
+  if (!WpeIsXwin ())
+    c = fk_putchar (c);
+  else
+    {
+      char cc = c;
+      c = write (wfildes[1], &cc, 1);
+    }
+  return (c);
 }
 
-int e_deb_options(FENSTER *f)
+int
+e_deb_options (FENSTER * f)
 {
- int ret;
- W_OPTSTR *o = e_init_opt_kst(f);
+  int ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
 
- if (!o) return(-1);
- o->xa = 20;  o->ya = 4;  o->xe = 60;  o->ye = 13;
- o->bgsw = 0;
- o->name = "Debug-Options";
- o->crsw = AltO;
- e_add_txtstr(4, 2, "Debugger:", o);
- e_add_txtstr(20, 2, "Mode:", o);
- e_add_pswstr(0, 5, 3, 0, AltG, 0, "Gdb    ", o);
- e_add_pswstr(0, 5, 4, 0, AltS, 0, "Sdb    ", o);
+  if (!o)
+    return (-1);
+  o->xa = 20;
+  o->ya = 4;
+  o->xe = 60;
+  o->ye = 13;
+  o->bgsw = 0;
+  o->name = "Debug-Options";
+  o->crsw = AltO;
+  e_add_txtstr (4, 2, "Debugger:", o);
+  e_add_txtstr (20, 2, "Mode:", o);
+  e_add_pswstr (0, 5, 3, 0, AltG, 0, "Gdb    ", o);
+  e_add_pswstr (0, 5, 4, 0, AltS, 0, "Sdb    ", o);
 #ifdef XDB
- e_add_pswstr(0, 5, 5, 0, AltX, e_deb_type == 3 ? 2 : e_deb_type, "Xdb    ", o);
+  e_add_pswstr (0, 5, 5, 0, AltX, e_deb_type == 3 ? 2 : e_deb_type, "Xdb    ",
+		o);
 #else
- e_add_pswstr(0, 5, 5, 0, AltD, e_deb_type, "Dbx    ", o);
+  e_add_pswstr (0, 5, 5, 0, AltD, e_deb_type, "Dbx    ", o);
 #endif
- e_add_pswstr(1, 21, 3, 0, AltN, 0, "Normal     ", o);
- e_add_pswstr(1, 21, 4, 0, AltF, e_deb_mode, "Full Screen", o);
- e_add_bttstr(10, 7, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(25, 7, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
+  e_add_pswstr (1, 21, 3, 0, AltN, 0, "Normal     ", o);
+  e_add_pswstr (1, 21, 4, 0, AltF, e_deb_mode, "Full Screen", o);
+  e_add_bttstr (10, 7, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (25, 7, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
 #ifdef XDB
-  e_deb_type = o->pstr[0]->num == 2 ? 3 : o->pstr[0]->num;
+      e_deb_type = o->pstr[0]->num == 2 ? 3 : o->pstr[0]->num;
 #else
-  e_deb_type = o->pstr[0]->num;
+      e_deb_type = o->pstr[0]->num;
 #endif
-  e_deb_mode = o->pstr[1]->num;
- }
- freeostr(o);
- return(0);
+      e_deb_mode = o->pstr[1]->num;
+    }
+  freeostr (o);
+  return (0);
 }
 
-int e_g_sys_ini()
+int
+e_g_sys_ini ()
 {
- if (!e_d_swtch || e_deb_mode)
-  return(0);
- tcgetattr(0, &ttermio);
- return(tcsetattr(0, TCSADRAIN, &otermio));
+  if (!e_d_swtch || e_deb_mode)
+    return (0);
+  tcgetattr (0, &ttermio);
+  return (tcsetattr (0, TCSADRAIN, &otermio));
 }
 
-int e_g_sys_end()
+int
+e_g_sys_end ()
 {
- if (!e_d_swtch || e_deb_mode)
-  return(0);
- return(tcsetattr(0, TCSADRAIN, &ttermio));
+  if (!e_d_swtch || e_deb_mode)
+    return (0);
+  return (tcsetattr (0, TCSADRAIN, &ttermio));
 }
 
-int e_test_command(char *str)
+int
+e_test_command (char *str)
 {
- int i = -1, k;
- char tmp[256], *path = getenv("PATH");
+  int i = -1, k;
+  char tmp[256], *path = getenv ("PATH");
 
- if (!path) return(-2);
- do
- {
-  for(i++, k = 0; (tmp[k] = path[i]) && path[i] != ':'; k++, i++)
-   ;
-  if (k == 0)
-  {  tmp[0] = '.';  k++;  }
-  tmp[k] = '/';
-  tmp[k+1] = '\0';
-  strcat(tmp, str);
-  if (!access(tmp, X_OK)) return(0);
- } while(path[i]);
- return(-1);
+  if (!path)
+    return (-2);
+  do
+    {
+      for (i++, k = 0; (tmp[k] = path[i]) && path[i] != ':'; k++, i++)
+	;
+      if (k == 0)
+	{
+	  tmp[0] = '.';
+	  k++;
+	}
+      tmp[k] = '/';
+      tmp[k + 1] = '\0';
+      strcat (tmp, str);
+      if (!access (tmp, X_OK))
+	return (0);
+    }
+  while (path[i]);
+  return (-1);
 }
 #endif
-

--- a/src/we_debug.h
+++ b/src/we_debug.h
@@ -5,55 +5,55 @@
 #include "we_wind.h"
 
 #ifdef DEBUGGER
-int e_deb_inp(FENSTER *f);
-int e_e_line_read(int n, char *s, int max);
-int e_d_dum_read(void);
-int e_d_p_exec(FENSTER *f);
-int e_d_getchar(void);
+int e_deb_inp (FENSTER * f);
+int e_e_line_read (int n, char *s, int max);
+int e_d_dum_read (void);
+int e_d_p_exec (FENSTER * f);
+int e_d_getchar (void);
 /** return changed to void: no return was given and no one tested return. */
-void e_d_quit_basic(FENSTER *f);
-int e_d_quit(FENSTER *f);
-int e_d_add_watch(char *str, FENSTER *f);
-int e_remove_all_watches(FENSTER *f);
-int e_make_watches(FENSTER *f);
-int e_edit_watches(FENSTER *f);
-int e_delete_watches(FENSTER *f);
-int e_d_p_watches(FENSTER *f, int sw);
-int e_deb_stack(FENSTER *f);
-int e_d_p_stack(FENSTER *f, int sw);
-int e_make_stack(FENSTER *f);
-int e_breakpoint(FENSTER *f);
-int e_remove_breakpoints(FENSTER *f);
-int e_make_breakpoint(FENSTER *f, int sw);
-int e_exec_deb(FENSTER *f, char *prog);
-int e_start_debug(FENSTER *f);
-int e_run_debug(FENSTER *f);
-int e_deb_run(FENSTER *f);
-int e_deb_trace(FENSTER *f);
-int e_deb_next(FENSTER *f);
-int e_d_goto_cursor(FENSTER *f);
-int e_d_finish_func(FENSTER *f);
-int e_deb_options(FENSTER *f);
-int e_d_step_next(FENSTER *f, int sw);
-int e_read_output(FENSTER *f);
-int e_d_pr_sig(char *str, FENSTER *f);
-int e_make_line_num(char *str, char *file);
-int e_make_line_num2(char *str, char *file);
-int e_d_goto_break(char *file, int line, FENSTER *f);
-int e_d_is_watch(int c, FENSTER *f);
-int e_debug_switch(FENSTER *f, int c);
-int e_d_putchar(int c);
-int e_g_sys_ini(void);
-int e_g_sys_end(void);
-int e_test_command(char *str);
+void e_d_quit_basic (FENSTER * f);
+int e_d_quit (FENSTER * f);
+int e_d_add_watch (char *str, FENSTER * f);
+int e_remove_all_watches (FENSTER * f);
+int e_make_watches (FENSTER * f);
+int e_edit_watches (FENSTER * f);
+int e_delete_watches (FENSTER * f);
+int e_d_p_watches (FENSTER * f, int sw);
+int e_deb_stack (FENSTER * f);
+int e_d_p_stack (FENSTER * f, int sw);
+int e_make_stack (FENSTER * f);
+int e_breakpoint (FENSTER * f);
+int e_remove_breakpoints (FENSTER * f);
+int e_make_breakpoint (FENSTER * f, int sw);
+int e_exec_deb (FENSTER * f, char *prog);
+int e_start_debug (FENSTER * f);
+int e_run_debug (FENSTER * f);
+int e_deb_run (FENSTER * f);
+int e_deb_trace (FENSTER * f);
+int e_deb_next (FENSTER * f);
+int e_d_goto_cursor (FENSTER * f);
+int e_d_finish_func (FENSTER * f);
+int e_deb_options (FENSTER * f);
+int e_d_step_next (FENSTER * f, int sw);
+int e_read_output (FENSTER * f);
+int e_d_pr_sig (char *str, FENSTER * f);
+int e_make_line_num (char *str, char *file);
+int e_make_line_num2 (char *str, char *file);
+int e_d_goto_break (char *file, int line, FENSTER * f);
+int e_d_is_watch (int c, FENSTER * f);
+int e_debug_switch (FENSTER * f, int c);
+int e_d_putchar (int c);
+int e_g_sys_ini (void);
+int e_g_sys_end (void);
+int e_test_command (char *str);
 
 /**** functions for breakpoints resyncing, reloading etc ****/
-int e_brk_schirm(FENSTER *f);
-int e_brk_recalc(FENSTER *f,int start,int len);
-int e_d_reinit_brks(FENSTER *f,char * prj);
+int e_brk_schirm (FENSTER * f);
+int e_brk_recalc (FENSTER * f, int start, int len);
+int e_d_reinit_brks (FENSTER * f, char *prj);
 
 /**** for reloading watches ****/
-int e_d_reinit_watches(FENSTER *f,char * prj);
+int e_d_reinit_watches (FENSTER * f, char *prj);
 
 #endif // #ifdef DEBUGGER
 

--- a/src/we_e_aus.c
+++ b/src/we_e_aus.c
@@ -15,26 +15,28 @@
 
 /*
    draw entire screen with uniform chars and color */
-void e_cls(int frb, int chr)
+void
+e_cls (int frb, int chr)
 {
- int i, j;
+  int i, j;
 
- for (j = 0; j < MAXSLNS; j++)
-  for (i = 0; i < MAXSCOL; i++)
-   e_pr_char(i, j, chr, frb);
+  for (j = 0; j < MAXSLNS; j++)
+    for (i = 0; i < MAXSCOL; i++)
+      e_pr_char (i, j, chr, frb);
 }
 
 /*
    write text string */
-int e_puts(char *s, int xa, int ya, int frb)
+int
+e_puts (char *s, int xa, int ya, int frb)
 {
- int i;
+  int i;
 
- if (xa >= MAXSCOL || ya > MAXSLNS)
-  return(-1);
- for (i = 0; s[i] != '\0' && i < 2000; i++)
-  e_pr_char(i + xa, ya, s[i], frb);
- return(0);
+  if (xa >= MAXSCOL || ya > MAXSLNS)
+    return (-1);
+  for (i = 0; s[i] != '\0' && i < 2000; i++)
+    e_pr_char (i + xa, ya, s[i], frb);
+  return (0);
 }
 
 /* write text string (sic!, R.H.) 
@@ -44,35 +46,37 @@ int e_puts(char *s, int xa, int ya, int frb)
    - one character after the text is space with color 'col'
    - color 'col3' is used in old style
 */
-void e_pr_str(int x, int y, char *str, int col, int b2, int n2, int col2,
-  int col3)
+void
+e_pr_str (int x, int y, char *str, int col, int b2, int n2, int col2,
+	  int col3)
 {
- UNUSED(col3);
- int i, sw = 0;
+  UNUSED (col3);
+  int i, sw = 0;
 
- if (n2 < 0)
- {
-  sw = 1; n2 = -n2;
- }
- e_pr_char(x-1, y, 32, col);
- for (i=0; *(str+i) != '\0'; i++)
- {
-  if (i>=b2 && i<b2+n2)
-   e_pr_char(x+i, y, *(str+i), col2);
-  else
-   e_pr_char(x+i, y, *(str+i), col);
- }
- e_pr_char(x+i, y, 32, col);
- if (sw == 1 && WpeIsXwin())
+  if (n2 < 0)
+    {
+      sw = 1;
+      n2 = -n2;
+    }
+  e_pr_char (x - 1, y, 32, col);
+  for (i = 0; *(str + i) != '\0'; i++)
+    {
+      if (i >= b2 && i < b2 + n2)
+	e_pr_char (x + i, y, *(str + i), col2);
+      else
+	e_pr_char (x + i, y, *(str + i), col);
+    }
+  e_pr_char (x + i, y, 32, col);
+  if (sw == 1 && WpeIsXwin ())
 #ifdef NEWSTYLE
-  e_make_xrect(x-1, y, x+i, y, 0);
+    e_make_xrect (x - 1, y, x + i, y, 0);
 #else
- {
-  i++;
-  e_pr_char(x+i, y, SCR, col3);
-  for (; i >= 0; i--)
-   e_pr_char(x+i+MAXSCOL, y, SCD, col3);
- }
+    {
+      i++;
+      e_pr_char (x + i, y, SCR, col3);
+      for (; i >= 0; i--)
+	e_pr_char (x + i + MAXSCOL, y, SCD, col3);
+    }
 #endif
 }
 
@@ -81,388 +85,438 @@ void e_pr_str(int x, int y, char *str, int col, int b2, int n2, int col2,
    - spaces between bg and x are drawn with 'col'
    - spaces after text and before nd are drawnd with 'col'
 */
-int e_pr_str_wsd(int x, int y, char *str, int col, int b2, int n2, int col2,
-  int bg, int nd)
+int
+e_pr_str_wsd (int x, int y, char *str, int col, int b2, int n2, int col2,
+	      int bg, int nd)
 {
- int i;
+  int i;
 
- for (i = bg; i < x; i++)
-  e_pr_char(i, y, ' ', col);
- for (i = 0; str[i] && i <= nd-x; i++)
- {
-  if (i>=b2 && i<b2+n2)
-   e_pr_char(i+x, y, *(str+i), col2);
-  else
-   e_pr_char(i+x, y, *(str+i), col);
- }
- for (i+=x; i <= nd; i++)
-  e_pr_char(i, y, ' ', col);
+  for (i = bg; i < x; i++)
+    e_pr_char (i, y, ' ', col);
+  for (i = 0; str[i] && i <= nd - x; i++)
+    {
+      if (i >= b2 && i < b2 + n2)
+	e_pr_char (i + x, y, *(str + i), col2);
+      else
+	e_pr_char (i + x, y, *(str + i), col);
+    }
+  for (i += x; i <= nd; i++)
+    e_pr_char (i, y, ' ', col);
 #ifdef NEWSTYLE
- if (WpeIsXwin())
-  e_make_xrect(bg, y, nd, y, 0);
+  if (WpeIsXwin ())
+    e_make_xrect (bg, y, nd, y, 0);
 #endif
- return(0);
+  return (0);
 }
 
-int e_pr_str_scan(int x, int y, char *str, int col, int b2, int n2, int col2,
-  int bg, int nd)
+int
+e_pr_str_scan (int x, int y, char *str, int col, int b2, int n2, int col2,
+	       int bg, int nd)
 {
- char txt[30], *pt;
+  char txt[30], *pt;
 
- if (WpeIsXwin())
-  return(e_pr_str_wsd(x, y, str, col, b2, n2, col2, bg, nd));
- strcpy(txt, str);
- if ((pt = strstr(txt, "Alt")) != NULL)
- {
-  pt[0] = 'E'; pt[1] = 'S'; pt[2] = 'C';
- }
- else if (!strncmp(txt, "^F4 Close", 9))
-  strcpy(txt, "ESC X Cl.");
- return(e_pr_str_wsd(x, y, txt, col, b2, n2, col2, bg, nd));
+  if (WpeIsXwin ())
+    return (e_pr_str_wsd (x, y, str, col, b2, n2, col2, bg, nd));
+  strcpy (txt, str);
+  if ((pt = strstr (txt, "Alt")) != NULL)
+    {
+      pt[0] = 'E';
+      pt[1] = 'S';
+      pt[2] = 'C';
+    }
+  else if (!strncmp (txt, "^F4 Close", 9))
+    strcpy (txt, "ESC X Cl.");
+  return (e_pr_str_wsd (x, y, txt, col, b2, n2, col2, bg, nd));
 }
 
 /*
    write string of numbers */
-int e_pr_zstring(char *s, int x, int y, int n, int fb)
+int
+e_pr_zstring (char *s, int x, int y, int n, int fb)
 {
- int i, len = strlen(s);
+  int i, len = strlen (s);
 
- for (i = 0; i < n - len; i++)
-  e_pr_char(x+i, y, ' ', fb);
- for(; i < n; i++)
-  e_pr_char(x+i, y, s[i-n+len], fb);
+  for (i = 0; i < n - len; i++)
+    e_pr_char (x + i, y, ' ', fb);
+  for (; i < n; i++)
+    e_pr_char (x + i, y, s[i - n + len], fb);
 #ifdef NEWSTYLE
- if (WpeIsXwin())
-  e_make_xrect(x, y, x+n-1, y, 1);
+  if (WpeIsXwin ())
+    e_make_xrect (x, y, x + n - 1, y, 1);
 #endif
- return(len);
+  return (len);
 }
 
 /*
    Write N chars to screen */
-int e_schr_nchar(char *s, int x, int y, int n, int max, int frb)
+int
+e_schr_nchar (char *s, int x, int y, int n, int max, int frb)
 {
- int i, j;
+  int i, j;
 
- e_pr_char(x, y, ' ', frb);
- for (i = 1, j = 0; i < max-1 && s[n+j] !='\0'; i++, j++)
- {
-  if ((unsigned char) s[n+j] < ' ')
-  {
-   e_pr_char(x+i, y, '^', frb);
-   i++;
-   e_pr_char(x+i, y, s[n+j] + '@', frb);
-  }
-  else
-   e_pr_char(x+i, y, s[n+j], frb);
- }
- for (; i < max; i++)
-  e_pr_char(x+i, y, ' ', frb);
+  e_pr_char (x, y, ' ', frb);
+  for (i = 1, j = 0; i < max - 1 && s[n + j] != '\0'; i++, j++)
+    {
+      if ((unsigned char) s[n + j] < ' ')
+	{
+	  e_pr_char (x + i, y, '^', frb);
+	  i++;
+	  e_pr_char (x + i, y, s[n + j] + '@', frb);
+	}
+      else
+	e_pr_char (x + i, y, s[n + j], frb);
+    }
+  for (; i < max; i++)
+    e_pr_char (x + i, y, ' ', frb);
 #ifdef NEWSTYLE
- e_make_xrect(x, y, x+max-1, y, 1);
+  e_make_xrect (x, y, x + max - 1, y, 1);
 #endif
- return(i);
+  return (i);
 }
 
 /*
 	  Writing of a text string       */
-void e_pr_nstr(int x, int y, int n, char *str, int col, int col2)
+void
+e_pr_nstr (int x, int y, int n, char *str, int col, int col2)
 {
- int i;
+  int i;
 
- e_pr_char(x-1, y, ' ', col);
- for (i=0; *(str+i) != '\0' && i < n-1; i++)
-  e_pr_char(x+i, y, *(str+i), col);
- if (i < n-1)
-  e_pr_char(x+i, y, ' ', col);
- for (i++; i < n-1; i++)
-  e_pr_char(x+i, y, ' ', col2);
+  e_pr_char (x - 1, y, ' ', col);
+  for (i = 0; *(str + i) != '\0' && i < n - 1; i++)
+    e_pr_char (x + i, y, *(str + i), col);
+  if (i < n - 1)
+    e_pr_char (x + i, y, ' ', col);
+  for (i++; i < n - 1; i++)
+    e_pr_char (x + i, y, ' ', col2);
 }
 
 /*
    Enter digits */
-int e_schreib_zif(int *num, int x, int y, int max, int ft, int fs)
+int
+e_schreib_zif (int *num, int x, int y, int max, int ft, int fs)
 {
 #if  MOUSE
- extern struct mouse e_mouse;
+  extern struct mouse e_mouse;
 #endif
- int c, i, jc = max-1, ntmp = *num, nnum = WpeNumberOfPlaces(ntmp);
- int first = 1;
- char *s = malloc((max+1)*sizeof(char));
+  int c, i, jc = max - 1, ntmp = *num, nnum = WpeNumberOfPlaces (ntmp);
+  int first = 1;
+  char *s = malloc ((max + 1) * sizeof (char));
 
- e_pr_zstring(WpeNumberToString(ntmp, max, s), x, y, max, fs);
- fk_locate(x+jc, y);
- fk_cursor(1);
- while ((c = e_getch()) != WPE_ESC)
- {
+  e_pr_zstring (WpeNumberToString (ntmp, max, s), x, y, max, fs);
+  fk_locate (x + jc, y);
+  fk_cursor (1);
+  while ((c = e_getch ()) != WPE_ESC)
+    {
 #if  MOUSE
-  if (c < 0)
-  {
-   if (e_mouse.y == y && e_mouse.x >= x && e_mouse.x < x+max)
-   {
-    jc = e_mouse.x-x > max-nnum ? e_mouse.x-x : max-nnum;
-   }
-   else
-   {
-    if (c > -2)
-     *num = WpeStringToNumber(s);
-    free(s);
-    return(c);
-   }
-  }
+      if (c < 0)
+	{
+	  if (e_mouse.y == y && e_mouse.x >= x && e_mouse.x < x + max)
+	    {
+	      jc = e_mouse.x - x > max - nnum ? e_mouse.x - x : max - nnum;
+	    }
+	  else
+	    {
+	      if (c > -2)
+		*num = WpeStringToNumber (s);
+	      free (s);
+	      return (c);
+	    }
+	}
 #endif
-  if (c == 332) {  if(jc < max-1) jc++;  }
-  else if (c == 330) {  if(jc > max-nnum) jc--;  }
-  else if (c == 326) jc = max-nnum;
-  else if (c == 334) jc = max-1;
-  else if (c == WPE_DC)
-  {
-   if (jc > max-nnum)
-   {
-    for (i = jc-1; i > 0; i--)
-     s[i] = s[i-1];
-    s[0] = 32;
-    nnum--;
-   }
-  }
-  else if (c == ENTF)
-  {
-   if (nnum == 1)
-   {
-    s[jc] = '0';
-   }
-   else if (jc < max)
-   {
-    for (i = jc; i > 0; i--)
-     s[i] = s[i-1];
-    s[0] = 32;
-    nnum--;
-   }
-  }
-  else if (first == 1 && c >='0' && c <= '9')
-  {
-   for (i = 0; i < max - 1; i++)
-    s[i] = 32;
-   s[i] = c;
-   s[max] = '\0';
-   nnum = 1;
-  }
-  else if (c >='0' && c <= '9')
-  {
-   for (i = 0; i < jc; i++)
-    s[i] = s[i+1];
-   s[jc] = c;
-   if (nnum < max)
-    nnum++;
-  }
-  else if (c > 0 && (c < 32 || c > 255))
-  {
-   if (c != WPE_ESC)
-    *num = WpeStringToNumber(s);
-   free(s);
-   return(c);
-  }
-  if (jc > max -1)
-   jc = max-1;
-  else if (jc < max - nnum) jc = max-nnum;
+      if (c == 332)
+	{
+	  if (jc < max - 1)
+	    jc++;
+	}
+      else if (c == 330)
+	{
+	  if (jc > max - nnum)
+	    jc--;
+	}
+      else if (c == 326)
+	jc = max - nnum;
+      else if (c == 334)
+	jc = max - 1;
+      else if (c == WPE_DC)
+	{
+	  if (jc > max - nnum)
+	    {
+	      for (i = jc - 1; i > 0; i--)
+		s[i] = s[i - 1];
+	      s[0] = 32;
+	      nnum--;
+	    }
+	}
+      else if (c == ENTF)
+	{
+	  if (nnum == 1)
+	    {
+	      s[jc] = '0';
+	    }
+	  else if (jc < max)
+	    {
+	      for (i = jc; i > 0; i--)
+		s[i] = s[i - 1];
+	      s[0] = 32;
+	      nnum--;
+	    }
+	}
+      else if (first == 1 && c >= '0' && c <= '9')
+	{
+	  for (i = 0; i < max - 1; i++)
+	    s[i] = 32;
+	  s[i] = c;
+	  s[max] = '\0';
+	  nnum = 1;
+	}
+      else if (c >= '0' && c <= '9')
+	{
+	  for (i = 0; i < jc; i++)
+	    s[i] = s[i + 1];
+	  s[jc] = c;
+	  if (nnum < max)
+	    nnum++;
+	}
+      else if (c > 0 && (c < 32 || c > 255))
+	{
+	  if (c != WPE_ESC)
+	    *num = WpeStringToNumber (s);
+	  free (s);
+	  return (c);
+	}
+      if (jc > max - 1)
+	jc = max - 1;
+      else if (jc < max - nnum)
+	jc = max - nnum;
 
-  e_pr_zstring(s, x, y, max, ft);
-  fk_locate(x+jc, y);
-  first = 0;
- }
- return(c);
+      e_pr_zstring (s, x, y, max, ft);
+      fk_locate (x + jc, y);
+      first = 0;
+    }
+  return (c);
 }
 
 /*
    write chars in text line */
-int e_schreib_leiste(char *s, int x, int y, int n, int max, int ft, int fs)
+int
+e_schreib_leiste (char *s, int x, int y, int n, int max, int ft, int fs)
 {
 #if  MOUSE
- extern struct mouse e_mouse;
+  extern struct mouse e_mouse;
 #endif
- int c, i, ja = 0, jc, l = strlen(s);
- int jd;
- int sond = 0, first = 1;
- char *tmp = malloc(max+1);
+  int c, i, ja = 0, jc, l = strlen (s);
+  int jd;
+  int sond = 0, first = 1;
+  char *tmp = malloc (max + 1);
 
- fk_cursor(1);
- strcpy(tmp, s);
- jc = l;
- for (jd = 0, i = ja; tmp[i] && i <= n-3 + jd; i++)
-  if (tmp[i] < ' ') jd++;
- if (jc + jd > n-2) jc = n-3-jd;
- e_schr_nchar(tmp, x, y, 0, n, fs);
- e_pr_char(x, y, ' ', ft);
- e_pr_char(x+n-1, y, ' ', ft);
- fk_locate(x+jc+jd+1, y);
+  fk_cursor (1);
+  strcpy (tmp, s);
+  jc = l;
+  for (jd = 0, i = ja; tmp[i] && i <= n - 3 + jd; i++)
+    if (tmp[i] < ' ')
+      jd++;
+  if (jc + jd > n - 2)
+    jc = n - 3 - jd;
+  e_schr_nchar (tmp, x, y, 0, n, fs);
+  e_pr_char (x, y, ' ', ft);
+  e_pr_char (x + n - 1, y, ' ', ft);
+  fk_locate (x + jc + jd + 1, y);
 #ifdef NEWSTYLE
- e_make_xrect(x, y, x+n-1, y, 1);
+  e_make_xrect (x, y, x + n - 1, y, 1);
 #endif
- while ((c = e_getch()) != WPE_ESC)
- {
-#if  MOUSE
-  if (c < 0)
-  {
-   if (e_mouse.y == y && e_mouse.x > x && e_mouse.x < x+n)
-   {
-    jc = e_mouse.x-x-1 < l ? e_mouse.x-x-1 : l;
-    if (c == -2)
+  while ((c = e_getch ()) != WPE_ESC)
     {
-     int len = WpeEditor->f[0]->b->bf[0].len;
+#if  MOUSE
+      if (c < 0)
+	{
+	  if (e_mouse.y == y && e_mouse.x > x && e_mouse.x < x + n)
+	    {
+	      jc = e_mouse.x - x - 1 < l ? e_mouse.x - x - 1 : l;
+	      if (c == -2)
+		{
+		  int len = WpeEditor->f[0]->b->bf[0].len;
 #ifndef NO_XWINDOWS
-     if (bioskey() & 8)
-     e_cp_X_to_buffer(WpeEditor->f[WpeEditor->mxedt]);
+		  if (bioskey () & 8)
+		    e_cp_X_to_buffer (WpeEditor->f[WpeEditor->mxedt]);
 #endif
-     while (e_mshit())
-      ;
-     if (first == 1)
-     {
-      tmp[0] = '\0';
-      l = 0;
-      jc = 0;
-     }
-     if (len + l > max) len = max - l;
-     for (i = l; i >= jc; i--)
-      tmp[i+len] = tmp[i];
-     for (i = jc; i < jc + len; i++)
-      tmp[i] = WpeEditor->f[0]->b->bf[0].s[i-jc];
-     jc += len;
-     l += len;
-    }
-   }
-   else
-   {
-    if (c > -4) strcpy(s, tmp);
-    free(tmp);
-    fk_cursor(0);
-    return(c);
-   }
-  }
+		  while (e_mshit ())
+		    ;
+		  if (first == 1)
+		    {
+		      tmp[0] = '\0';
+		      l = 0;
+		      jc = 0;
+		    }
+		  if (len + l > max)
+		    len = max - l;
+		  for (i = l; i >= jc; i--)
+		    tmp[i + len] = tmp[i];
+		  for (i = jc; i < jc + len; i++)
+		    tmp[i] = WpeEditor->f[0]->b->bf[0].s[i - jc];
+		  jc += len;
+		  l += len;
+		}
+	    }
+	  else
+	    {
+	      if (c > -4)
+		strcpy (s, tmp);
+	      free (tmp);
+	      fk_cursor (0);
+	      return (c);
+	    }
+	}
 #endif
-  if (c == CRI || (!sond && c == CtrlF)) {  if(jc < l) jc++;  }
-  else if (c == CLE || (!sond && c == CtrlB)) {  if(jc > 0) jc--;  }
-  else if (c == CCLE && jc > 0) jc = e_su_rblk(jc, (unsigned char *)tmp);
-  else if (c == CCRI && jc < l) jc = e_su_lblk(jc, (unsigned char *)tmp);
-  else if (c == POS1 || (!sond && c == CtrlA)) jc = 0;
-  else if (c == ENDE || (!sond && c == CtrlE)) jc = l;
-  else if (c == AltJ || c == F9) sond = !sond;
-  else if (c == PASTE || c == ShiftEin || c == CtrlV || c == AltEin)
-  {
-   int len = WpeEditor->f[0]->b->bf[0].len;
+      if (c == CRI || (!sond && c == CtrlF))
+	{
+	  if (jc < l)
+	    jc++;
+	}
+      else if (c == CLE || (!sond && c == CtrlB))
+	{
+	  if (jc > 0)
+	    jc--;
+	}
+      else if (c == CCLE && jc > 0)
+	jc = e_su_rblk (jc, (unsigned char *) tmp);
+      else if (c == CCRI && jc < l)
+	jc = e_su_lblk (jc, (unsigned char *) tmp);
+      else if (c == POS1 || (!sond && c == CtrlA))
+	jc = 0;
+      else if (c == ENDE || (!sond && c == CtrlE))
+	jc = l;
+      else if (c == AltJ || c == F9)
+	sond = !sond;
+      else if (c == PASTE || c == ShiftEin || c == CtrlV || c == AltEin)
+	{
+	  int len = WpeEditor->f[0]->b->bf[0].len;
 #ifndef NO_XWINDOWS
-   if (WpeIsXwin() && c == AltEin)
-    e_cp_X_to_buffer(WpeEditor->f[WpeEditor->mxedt]);
+	  if (WpeIsXwin () && c == AltEin)
+	    e_cp_X_to_buffer (WpeEditor->f[WpeEditor->mxedt]);
 #endif
-   if (first == 1)
-   {
-    tmp[0] = '\0';
-    l = 0;
-    jc = 0;
-   }
-   if (len + l > max) len = max - l;
-   for (i = l; i >= jc; i--)
-    tmp[i+len] = tmp[i];
-   for (i = jc; i < jc + len; i++)
-    tmp[i] = WpeEditor->f[0]->b->bf[0].s[i-jc];
-   jc += len;
-   l += len;
-  }
-  else if (c == WPE_DC && !sond)
-  {
-   if (jc > 0)
-   {
-    for (i = jc-1; i < l; i++)
-     tmp[i] = tmp[i+1];
-    jc--;
-    l--;
-   }
-  }
-  else if (c == ENTF || (!sond && c == CtrlD))
-  {
-   if (jc < l)
-   {
-    for (i = jc; i < l; i++)
-     tmp[i] = tmp[i+1];
-    l--;
-   }
-  }
-  else if (!sond && c == CtrlT)
-  {
-   c = e_su_lblk(jc, (unsigned char *)tmp) - jc;
-   {
-    for (i = jc; i <= l-c; i++)
-     tmp[i] = tmp[i+c];
-    l -= c;
-   }
-  }
-  else if (!sond && c == CtrlO)
-  {
-   if ((c = e_getch()) != CtrlT && toupper(c) != 'T') continue;
-   c = jc - e_su_rblk(jc, (unsigned char *)tmp);
-   {
-    for( i = jc-c; i <= l-c; i++)
-    tmp[i] = tmp[i+c];
-    jc -= c;
-    l -= c;
-   }
-  }
-  else if (first == 1 &&
-    ((c != WPE_CR && c != CtrlP && c != CtrlN && c != WPE_TAB &&
-    c != WPE_BTAB) || sond) && c > 0 && c < 0x7f)
-  {
-   tmp[0] = c;
-   tmp[1] = '\0';
-   l = 1;
-   jc = 1;
-  }
-  else if (((c != WPE_CR && c != WPE_TAB && c != WPE_BTAB && c != CtrlP &&
-    c != CtrlN ) || sond) && c > 0 && c < 0xff)
-  {
-   if (l < max)
-   {
-    for (i = l; i >= jc; i--) {
-	tmp[i+1] = tmp[i];
-    }
-    tmp[jc] = c;
-    l++; jc++;
-   }
-  }
-  else if (c > 0)	
-  { 
-   if (c != WPE_ESC) strcpy(s, tmp);
-   free(tmp);fk_cursor(0);
-   if (c == CtrlP) c = CUP;
-   else if (c == CtrlN) c = CDO;
-   return(c);
-  }
-  for (jd = 0, i = ja; i < jc; i++) if(tmp[i] < ' ') jd++;
-  if (jc+jd-ja > n-3) ja=jc+jd-n+3 ;
-  else if (jc-ja < 0) ja = jc;
+	  if (first == 1)
+	    {
+	      tmp[0] = '\0';
+	      l = 0;
+	      jc = 0;
+	    }
+	  if (len + l > max)
+	    len = max - l;
+	  for (i = l; i >= jc; i--)
+	    tmp[i + len] = tmp[i];
+	  for (i = jc; i < jc + len; i++)
+	    tmp[i] = WpeEditor->f[0]->b->bf[0].s[i - jc];
+	  jc += len;
+	  l += len;
+	}
+      else if (c == WPE_DC && !sond)
+	{
+	  if (jc > 0)
+	    {
+	      for (i = jc - 1; i < l; i++)
+		tmp[i] = tmp[i + 1];
+	      jc--;
+	      l--;
+	    }
+	}
+      else if (c == ENTF || (!sond && c == CtrlD))
+	{
+	  if (jc < l)
+	    {
+	      for (i = jc; i < l; i++)
+		tmp[i] = tmp[i + 1];
+	      l--;
+	    }
+	}
+      else if (!sond && c == CtrlT)
+	{
+	  c = e_su_lblk (jc, (unsigned char *) tmp) - jc;
+	  {
+	    for (i = jc; i <= l - c; i++)
+	      tmp[i] = tmp[i + c];
+	    l -= c;
+	  }
+	}
+      else if (!sond && c == CtrlO)
+	{
+	  if ((c = e_getch ()) != CtrlT && toupper (c) != 'T')
+	    continue;
+	  c = jc - e_su_rblk (jc, (unsigned char *) tmp);
+	  {
+	    for (i = jc - c; i <= l - c; i++)
+	      tmp[i] = tmp[i + c];
+	    jc -= c;
+	    l -= c;
+	  }
+	}
+      else if (first == 1 &&
+	       ((c != WPE_CR && c != CtrlP && c != CtrlN && c != WPE_TAB &&
+		 c != WPE_BTAB) || sond) && c > 0 && c < 0x7f)
+	{
+	  tmp[0] = c;
+	  tmp[1] = '\0';
+	  l = 1;
+	  jc = 1;
+	}
+      else if (((c != WPE_CR && c != WPE_TAB && c != WPE_BTAB && c != CtrlP &&
+		 c != CtrlN) || sond) && c > 0 && c < 0xff)
+	{
+	  if (l < max)
+	    {
+	      for (i = l; i >= jc; i--)
+		{
+		  tmp[i + 1] = tmp[i];
+		}
+	      tmp[jc] = c;
+	      l++;
+	      jc++;
+	    }
+	}
+      else if (c > 0)
+	{
+	  if (c != WPE_ESC)
+	    strcpy (s, tmp);
+	  free (tmp);
+	  fk_cursor (0);
+	  if (c == CtrlP)
+	    c = CUP;
+	  else if (c == CtrlN)
+	    c = CDO;
+	  return (c);
+	}
+      for (jd = 0, i = ja; i < jc; i++)
+	if (tmp[i] < ' ')
+	  jd++;
+      if (jc + jd - ja > n - 3)
+	ja = jc + jd - n + 3;
+      else if (jc - ja < 0)
+	ja = jc;
 
-  e_schr_nchar(tmp, x, y, ja, n, ft);
+      e_schr_nchar (tmp, x, y, ja, n, ft);
 
-  e_pr_char(x, y, ja > 0 ? MCL : ' ', ft);
-  e_pr_char(x+n-1, y, l-ja > n-2 ? MCR : ' ', ft);
-  fk_locate(x+jc+jd-ja+1, y);
-  first = 0;
+      e_pr_char (x, y, ja > 0 ? MCL : ' ', ft);
+      e_pr_char (x + n - 1, y, l - ja > n - 2 ? MCR : ' ', ft);
+      fk_locate (x + jc + jd - ja + 1, y);
+      first = 0;
 #ifdef NEWSTYLE
-  e_make_xrect(x, y, x+n-1, y, 1);
+      e_make_xrect (x, y, x + n - 1, y, 1);
 #endif
- }
- fk_cursor(0);
- return(c);
+    }
+  fk_cursor (0);
+  return (c);
 }
 
-int e_schr_nzif(int num, int x, int y, int max, int col)
+int
+e_schr_nzif (int num, int x, int y, int max, int col)
 {
- char *str = malloc((max+1)*sizeof(char));
- int i, nt;
+  char *str = malloc ((max + 1) * sizeof (char));
+  int i, nt;
 
- for (i = 0, nt = 1; i < max; i++) nt *= 10;
- if (num >= nt)
-  num = nt - 1;
- e_pr_zstring(WpeNumberToString(num, max, str), x, y, max, col);
- free(str);
- return(0);
+  for (i = 0, nt = 1; i < max; i++)
+    nt *= 10;
+  if (num >= nt)
+    num = nt - 1;
+  e_pr_zstring (WpeNumberToString (num, max, str), x, y, max, col);
+  free (str);
+  return (0);
 }
-

--- a/src/we_e_aus.h
+++ b/src/we_e_aus.h
@@ -6,19 +6,19 @@
 #include "we_mouse.h"
 
 /*   we_e_aus.c   */
-void e_cls(int frb, int chr);
-int e_puts(char *s, int xa, int ya, int frb);
-void e_pr_str(int x, int y, char *str, int col, int b2, int n2, int col2,
-  int col3);
-int e_pr_zstring(char *s, int x, int y, int n, int fb);
-int e_schr_nchar(char *s, int x, int y, int n, int max, int frb);
-void e_pr_nstr(int x, int y, int n, char *str, int col, int col2);
-int e_schreib_zif(int *num, int x, int y, int max, int ft, int fs);
-int e_schreib_leiste(char *s, int x, int y, int n, int max, int ft, int fs);
-int e_schr_nzif(int num, int x, int y, int max, int col);
-int e_pr_str_wsd(int x, int y, char *str, int col, int b2, int n2, int col2,
-  int bg, int nd);
-int e_pr_str_scan(int x, int y, char *str, int col, int b2, int n2, int col2,
-  int bg, int nd);
+void e_cls (int frb, int chr);
+int e_puts (char *s, int xa, int ya, int frb);
+void e_pr_str (int x, int y, char *str, int col, int b2, int n2, int col2,
+	       int col3);
+int e_pr_zstring (char *s, int x, int y, int n, int fb);
+int e_schr_nchar (char *s, int x, int y, int n, int max, int frb);
+void e_pr_nstr (int x, int y, int n, char *str, int col, int col2);
+int e_schreib_zif (int *num, int x, int y, int max, int ft, int fs);
+int e_schreib_leiste (char *s, int x, int y, int n, int max, int ft, int fs);
+int e_schr_nzif (int num, int x, int y, int max, int col);
+int e_pr_str_wsd (int x, int y, char *str, int col, int b2, int n2, int col2,
+		  int bg, int nd);
+int e_pr_str_scan (int x, int y, char *str, int col, int b2, int n2, int col2,
+		   int bg, int nd);
 
 #endif

--- a/src/we_edit.c
+++ b/src/we_edit.c
@@ -19,17 +19,17 @@
 #include "WeString.h"
 
 #ifdef UNIX
-# include<sys/types.h> /*  included for digital station  */
-# include<sys/stat.h>
-# include <unistd.h>
+#include<sys/types.h>		/*  included for digital station  */
+#include<sys/stat.h>
+#include <unistd.h>
 #endif
 
 int e_undo_sw = 0, e_redo_sw = 0;
 
-char *e_make_postf();
-int e_del_a_ind();
-int e_tab_a_ind();
-int e_help_next();
+char *e_make_postf ();
+int e_del_a_ind ();
+int e_tab_a_ind ();
+int e_help_next ();
 
 #ifdef PROG
 BUFFER *e_p_m_buffer = NULL;
@@ -39,465 +39,501 @@ BUFFER *e_p_w_buffer = NULL;
 #endif
 
 /* open edit window */
-int e_edit(ECNT *cn, char *filename)
+int
+e_edit (ECNT * cn, char *filename)
 {
- extern char *e_hlp_str[];
- extern WOPT *eblst, *hblst, *mblst, *dblst;
- FILE *fp = NULL;
- FENSTER *f, *fo;
- char *complete_fname, *path, *file;
- int ftype = 0, i, j, st = 0;
- struct stat buf[1];
+  extern char *e_hlp_str[];
+  extern WOPT *eblst, *hblst, *mblst, *dblst;
+  FILE *fp = NULL;
+  FENSTER *f, *fo;
+  char *complete_fname, *path, *file;
+  int ftype = 0, i, j, st = 0;
+  struct stat buf[1];
 
- /* Allows project files to be open automatically */
- j = strlen(filename);
- if ((WpeIsProg()) && (j > 4) && (!strcmp(&filename[j - 4], ".prj")))
- {
-  if (!e_prog.project)
-  {
-   e_prog.project = malloc(1);
-   e_prog.project[0] = '\0';
-  }
-  else
-  {
-   for (i = cn->mxedt; i > 0 &&
-     (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
+  /* Allows project files to be open automatically */
+  j = strlen (filename);
+  if ((WpeIsProg ()) && (j > 4) && (!strcmp (&filename[j - 4], ".prj")))
+    {
+      if (!e_prog.project)
+	{
+	  e_prog.project = malloc (1);
+	  e_prog.project[0] = '\0';
+	}
+      else
+	{
+	  for (i = cn->mxedt; i > 0 &&
+	       (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
+	    ;
+	  if (i > 0)
+	    {
+	      e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	      e_close_window (cn->f[cn->mxedt]);
+	    }
+	}
+      e_prog.project = realloc (e_prog.project, j + 1);
+      strcpy (e_prog.project, filename);
+      e_make_prj_opt (cn->f[cn->mxedt]);
+/************************************/
+      e_rel_brkwtch (cn->f[cn->mxedt]);
+/************************************/
+      e_prj_ob_file (cn->f[cn->mxedt]);
+      return 0;
+    }
+
+  /* Check to see if the file is already opened BD */
+  WpeFilenameToPathFile (filename, &path, &file);
+  /* Should check for error here */
+  for (i = cn->mxedt; i >= 0; i--)
+    {
+      if ((strcmp (cn->f[i]->datnam, file) == 0) &&
+	  (strcmp (cn->f[i]->dirct, path) == 0))
+	{
+	  e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	  free (path);
+	  free (file);
+	  return (0);
+	}
+    }
+
+  if (cn->mxedt >= MAXEDT)
+    {
+      e_error (e_msg[ERR_MAXWINS], 0, cn->fb);
+      return (-1);
+    }
+  if (stat (filename, buf) == 0)
+    {
+      if (!S_ISREG (buf->st_mode))
+	{
+	  /* error message should go here */
+	  return (-1);
+	}
+    }
+  for (j = 1; j <= MAXEDT; j++)
+    {
+      for (i = 1; i <= cn->mxedt && cn->edt[i] != j; i++);
+      if (i > cn->mxedt)
+	break;
+    }
+  cn->curedt = j;
+  (cn->mxedt)++;
+  cn->edt[cn->mxedt] = j;
+
+  if ((f = (FENSTER *) malloc (sizeof (FENSTER))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+
+  f->fb = cn->fb;
+  cn->f[cn->mxedt] = f;
+
+  if ((f->b = (BUFFER *) malloc (sizeof (BUFFER))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  if ((f->s = (SCHIRM *) malloc (sizeof (SCHIRM))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  if ((f->b->bf = (STRING *) malloc (MAXLINES * sizeof (STRING))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+#ifdef PROG
+  for (i = cn->mxedt - 1;
+       i > 0 && (!strcmp (cn->f[i]->datnam, "Messages")
+		 || !DTMD_ISTEXT (cn->f[i]->dtmd)
+		 || !strcmp (cn->f[i]->datnam, "Watches")
+		 || !strcmp (cn->f[i]->datnam, "Stack")); i--)
     ;
-   if (i > 0)
-   {
-    e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-    e_close_window(cn->f[cn->mxedt]);
-   }
-  }
-  e_prog.project = realloc(e_prog.project, j + 1);
-  strcpy(e_prog.project, filename);
-  e_make_prj_opt(cn->f[cn->mxedt]);
-/************************************/  
-  e_rel_brkwtch(cn->f[cn->mxedt]);
-/************************************/  
-  e_prj_ob_file(cn->f[cn->mxedt]);
-  return 0;
- }
-
- /* Check to see if the file is already opened BD */
- WpeFilenameToPathFile(filename, &path, &file);
- /* Should check for error here */
- for (i = cn->mxedt; i >= 0; i--)
- {
-  if ((strcmp(cn->f[i]->datnam, file) == 0) &&
-    (strcmp(cn->f[i]->dirct, path) == 0))
-  {
-   e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-   free(path);
-   free(file);
-   return(0);
-  }
- }
-
- if (cn->mxedt >= MAXEDT)
- {
-  e_error(e_msg[ERR_MAXWINS], 0, cn->fb);
-  return(-1);
- }
- if (stat(filename, buf) == 0)
- {
-  if (!S_ISREG(buf->st_mode))
-  {
-   /* error message should go here */
-   return(-1);
-  }
- }
- for (j = 1; j <= MAXEDT; j++)
- {
-  for (i = 1; i <= cn->mxedt && cn->edt[i] != j; i++);
-  if( i > cn->mxedt) break;
- }
- cn->curedt=j;
- (cn->mxedt)++;
- cn->edt[cn->mxedt]=j;
-   
- if ((f = (FENSTER *)malloc(sizeof(FENSTER))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-   
- f->fb = cn->fb;
- cn->f[cn->mxedt] = f;
-
- if ((f->b = (BUFFER *)malloc(sizeof(BUFFER))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
- if ((f->s = (SCHIRM*)malloc(sizeof(SCHIRM))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
- if ((f->b->bf = (STRING *) malloc(MAXLINES*sizeof(STRING))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-#ifdef PROG
- for (i = cn->mxedt-1;
-   i > 0 && (!strcmp(cn->f[i]->datnam, "Messages") || !DTMD_ISTEXT(cn->f[i]->dtmd) ||
-     !strcmp(cn->f[i]->datnam, "Watches") ||
-     !strcmp(cn->f[i]->datnam, "Stack")); i--)
-  ;
- for (j = cn->mxedt-1; j > 0 && !st; j--)
-  if (!strcmp(cn->f[j]->datnam, "Stack"))
-   st = 1;
+  for (j = cn->mxedt - 1; j > 0 && !st; j--)
+    if (!strcmp (cn->f[j]->datnam, "Stack"))
+      st = 1;
 #else
- for(i = cn->mxedt-1; i > 0 && !DTMD_ISTEXT(cn->f[i]->dtmd); i--)
-  ;
+  for (i = cn->mxedt - 1; i > 0 && !DTMD_ISTEXT (cn->f[i]->dtmd); i--)
+    ;
 #endif
 #ifdef PROG
- if (WpeIsProg())
- {
-  if ((e_we_sw & 8) || !strcmp(filename, "Messages") ||
-    !strcmp(filename, "Watches"))
-  {
-   f->a = e_set_pnt(0, 2*MAXSLNS/3 + 1);
-   f->e = e_set_pnt(MAXSCOL-1, MAXSLNS-2);
-  }
-  else if (!strcmp(filename, "Stack"))
-  {
-   f->a = e_set_pnt(2*MAXSCOL/3, 1);
-   f->e = e_set_pnt(MAXSCOL-1, 2*MAXSLNS/3);
-  }
+  if (WpeIsProg ())
+    {
+      if ((e_we_sw & 8) || !strcmp (filename, "Messages") ||
+	  !strcmp (filename, "Watches"))
+	{
+	  f->a = e_set_pnt (0, 2 * MAXSLNS / 3 + 1);
+	  f->e = e_set_pnt (MAXSCOL - 1, MAXSLNS - 2);
+	}
+      else if (!strcmp (filename, "Stack"))
+	{
+	  f->a = e_set_pnt (2 * MAXSCOL / 3, 1);
+	  f->e = e_set_pnt (MAXSCOL - 1, 2 * MAXSLNS / 3);
+	}
+      else
+	{
+	  if (i < 1)
+	    {
+	      f->a = e_set_pnt (0, 1);
+	      f->e =
+		e_set_pnt (st ? 2 * MAXSCOL / 3 - 1 : MAXSCOL - 1,
+			   2 * MAXSLNS / 3);
+	    }
+	  else
+	    {
+	      f->a = e_set_pnt (cn->f[i]->a.x + 1, cn->f[i]->a.y + 1);
+	      f->e =
+		e_set_pnt (st ? 2 * MAXSCOL / 3 - 1 : cn->f[i]->e.x,
+			   cn->f[i]->e.y);
+	    }
+	}
+    }
   else
-  {
-   if (i < 1)
-   {
-    f->a = e_set_pnt(0, 1);
-    f->e = e_set_pnt(st ? 2*MAXSCOL/3-1 : MAXSCOL-1, 2*MAXSLNS/3);
-   }
-   else
-   {
-    f->a = e_set_pnt(cn->f[i]->a.x+1, cn->f[i]->a.y+1);
-    f->e = e_set_pnt(st ? 2*MAXSCOL/3-1 : cn->f[i]->e.x, cn->f[i]->e.y);
-   }
-  }
- }
- else
 #endif
- {
-  if (i < 1)
-  {
-   f->a = e_set_pnt(0, 1);
-   f->e = e_set_pnt(MAXSCOL-1, MAXSLNS-2);
-  }
-  else
-  {
-   f->a = e_set_pnt(cn->f[i]->a.x + 1, cn->f[i]->a.y + 1);
-   f->e = e_set_pnt(cn->f[i]->e.x, cn->f[i]->e.y);
-  }
- }
- if (NUM_COLS_ON_SCREEN < 26)
-  f->a.x = f->e.x - 26;
- if(NUM_LINES_ON_SCREEN < 3)
-  f->a.y = f->e.y - 3;
- f->winnum = cn->curedt;
- f->dtmd = cn->dtmd;
- f->ins = 1;
- f->save = 0;
- f->zoom = 0;
- f->ed = cn;
- f->pic = NULL;
- f->hlp_str = e_hlp_str[0];
- f->blst = eblst;
- f->nblst = 7;
- f->b->f = f;
- f->b->b = e_set_pnt(0, 0);
- f->b->cl = f->b->clsv = 0;
- f->b->mx = e_set_pnt(cn->maxcol, MAXLINES);
- f->b->mxlines = 0;
- f->b->fb = f->fb;
- f->b->cn = cn;
- f->b->ud = NULL;
- f->b->rd = NULL;
- f->fd.dirct = NULL;
- if (WpeIsProg())
-  e_add_synt_tl(filename, f);
- else
- {
-  f->c_st = NULL;
-  f->c_sw = NULL;
- }
- if ((f->ed->edopt & ED_ALWAYS_AUTO_INDENT) ||
-   ((f->ed->edopt & ED_SOURCE_AUTO_INDENT) && f->c_st))
- {
-  f->flg = 1;
- }
- else
- {
-  f->flg = 0;
- }
- f->s->c = e_set_pnt(0, 0);
- f->s->ks = e_set_pnt(0, 0);
- f->s->mark_begin = e_set_pnt(0, 0);
- f->s->mark_end = e_set_pnt(0, 0);
- f->s->fa = e_set_pnt(0, 0);
- f->s->fe = e_set_pnt(0, 0);
- f->s->fb = f->fb;
-#ifdef DEBUGGER
- f->s->brp = malloc(sizeof(int));
- f->s->brp[0] = 0;
- f->s->da.y = -1;
-#endif
- f->dirct = path;
- for (i = 0; i < 9; i++)
-  f->s->pt[i] = e_set_pnt(-1, -1);
- if (cn->mxedt == 0)    /*  Clipboard  */
- {
-  cn->curedt=0;
-  cn->edt[cn->mxedt]=0;
-  free(file);
-  file = f->datnam = WpeStrdup(BUFFER_NAME);
-#ifdef UNIX
-  f->filemode = 0600;
-#endif
-  e_new_line(0,f->b);
-  *(f->b->bf[0].s) = WPE_WR;
-  *(f->b->bf[0].s+1) = '\0';
-  f->b->bf[0].len = 0;
-  f->b->bf[0].nrc = 1;
-  return(0);
- }
- if (strcmp(file,"") == 0)
- {
-  free(file);
-  file = f->datnam = WpeStrdup("Noname");
- }
- else
- {
-  f->datnam = file;
- }
- if (strcmp(filename, "Help") == 0)
- {
-  complete_fname = e_mkfilename(LIBRARY_DIR, HELP_FILE);
-  f->dtmd = DTMD_HELP;
-  f->ins = 8;
-  f->hlp_str = e_hlp_str[25];
+    {
+      if (i < 1)
+	{
+	  f->a = e_set_pnt (0, 1);
+	  f->e = e_set_pnt (MAXSCOL - 1, MAXSLNS - 2);
+	}
+      else
+	{
+	  f->a = e_set_pnt (cn->f[i]->a.x + 1, cn->f[i]->a.y + 1);
+	  f->e = e_set_pnt (cn->f[i]->e.x, cn->f[i]->e.y);
+	}
+    }
+  if (NUM_COLS_ON_SCREEN < 26)
+    f->a.x = f->e.x - 26;
+  if (NUM_LINES_ON_SCREEN < 3)
+    f->a.y = f->e.y - 3;
+  f->winnum = cn->curedt;
+  f->dtmd = cn->dtmd;
+  f->ins = 1;
+  f->save = 0;
+  f->zoom = 0;
+  f->ed = cn;
+  f->pic = NULL;
+  f->hlp_str = e_hlp_str[0];
+  f->blst = eblst;
   f->nblst = 7;
-  f->blst = hblst;
-  ftype = 1;
- }
- else
-  complete_fname = e_mkfilename(f->dirct, f->datnam);
-#ifdef PROG
- if (WpeIsProg())
- {
-  if (!strcmp(filename, "Messages"))
-  {
-   f->ins = 8;
-   f->hlp_str = e_hlp_str[3];
-   f->nblst = 8;
-   f->blst = mblst;
-   ftype = 2;
-  }
-  else if (!strcmp(filename, "Watches"))
-  {
-   f->ins = 8;
-   f->hlp_str = e_hlp_str[1];
-   f->blst = dblst;
-   ftype = 3;
-  }
-  else if (!strcmp(filename, "Stack"))
-  {
-   f->ins = 8;
-   f->hlp_str = e_hlp_str[2];
-   f->blst = dblst;
-   ftype = 4;
-  }
- }
-#endif
- if (ftype != 1)
-  fp = fopen(complete_fname, "rb");
- if (fp != NULL && access(complete_fname, W_OK) != 0) f->ins = 8;
-#ifdef UNIX
- if (fp != NULL)
- {
-  stat(complete_fname, buf);
-  f->filemode = buf->st_mode;
- }
- else
- {
-  umask(i = umask(077));
-  f->filemode = 0666 & ~i;
- }
-#endif
- free(complete_fname);
-
- if (fp != NULL && ftype != 1)
- {
-  e_readin(0, 0, fp, f->b, &f->dtmd);
-  if (fclose(fp) != 0)
-   e_error(e_msg[ERR_FCLOSE], 0, cn->fb);
-  if (cn->dtmd == DTMD_HELP)
-   cn->dtmd = DTMD_NORMAL;
-#ifdef PROG
-  if (WpeIsProg())
-  {
-   if (e_we_sw & 8)
-   {
-    strcpy(f->datnam, "Messages");
-    e_we_sw &= ~8;
-   }
-   if (!strcmp(f->datnam, "Messages"))
-   {
-    e_make_error_list(f);
-    f->ins = 8;
-   }
-  }
-#endif
- }
- else
- {
-  e_new_line(0,f->b);
-  *(f->b->bf[0].s) = WPE_WR;
-  *(f->b->bf[0].s+1) = '\0';
-  f->b->bf[0].len = 0;
-  f->b->bf[0].nrc = 1;
- }
-#ifdef PROG
- if (ftype == 2)
- {
-  if(e_p_m_buffer != NULL)
-  {
-   e_close_buffer(f->b);
-   f->b = e_p_m_buffer;
-   f->b->f = f;
-  }
+  f->b->f = f;
+  f->b->b = e_set_pnt (0, 0);
+  f->b->cl = f->b->clsv = 0;
+  f->b->mx = e_set_pnt (cn->maxcol, MAXLINES);
+  f->b->mxlines = 0;
+  f->b->fb = f->fb;
+  f->b->cn = cn;
+  f->b->ud = NULL;
+  f->b->rd = NULL;
+  f->fd.dirct = NULL;
+  if (WpeIsProg ())
+    e_add_synt_tl (filename, f);
   else
-  {
-   e_p_m_buffer = f->b;
-   free(f->b->bf[0].s);
-   f->b->mxlines = 0;
-  }
- }
+    {
+      f->c_st = NULL;
+      f->c_sw = NULL;
+    }
+  if ((f->ed->edopt & ED_ALWAYS_AUTO_INDENT) ||
+      ((f->ed->edopt & ED_SOURCE_AUTO_INDENT) && f->c_st))
+    {
+      f->flg = 1;
+    }
+  else
+    {
+      f->flg = 0;
+    }
+  f->s->c = e_set_pnt (0, 0);
+  f->s->ks = e_set_pnt (0, 0);
+  f->s->mark_begin = e_set_pnt (0, 0);
+  f->s->mark_end = e_set_pnt (0, 0);
+  f->s->fa = e_set_pnt (0, 0);
+  f->s->fe = e_set_pnt (0, 0);
+  f->s->fb = f->fb;
 #ifdef DEBUGGER
- if (ftype == 3)
- {
-  if (e_p_w_buffer != NULL)
-  {
-   e_close_buffer(f->b);
-   f->b = e_p_w_buffer;
-   f->b->f = f;
-  }
+  f->s->brp = malloc (sizeof (int));
+  f->s->brp[0] = 0;
+  f->s->da.y = -1;
+#endif
+  f->dirct = path;
+  for (i = 0; i < 9; i++)
+    f->s->pt[i] = e_set_pnt (-1, -1);
+  if (cn->mxedt == 0)		/*  Clipboard  */
+    {
+      cn->curedt = 0;
+      cn->edt[cn->mxedt] = 0;
+      free (file);
+      file = f->datnam = WpeStrdup (BUFFER_NAME);
+#ifdef UNIX
+      f->filemode = 0600;
+#endif
+      e_new_line (0, f->b);
+      *(f->b->bf[0].s) = WPE_WR;
+      *(f->b->bf[0].s + 1) = '\0';
+      f->b->bf[0].len = 0;
+      f->b->bf[0].nrc = 1;
+      return (0);
+    }
+  if (strcmp (file, "") == 0)
+    {
+      free (file);
+      file = f->datnam = WpeStrdup ("Noname");
+    }
   else
-  {
-   e_p_w_buffer = f->b;
+    {
+      f->datnam = file;
+    }
+  if (strcmp (filename, "Help") == 0)
+    {
+      complete_fname = e_mkfilename (LIBRARY_DIR, HELP_FILE);
+      f->dtmd = DTMD_HELP;
+      f->ins = 8;
+      f->hlp_str = e_hlp_str[25];
+      f->nblst = 7;
+      f->blst = hblst;
+      ftype = 1;
+    }
+  else
+    complete_fname = e_mkfilename (f->dirct, f->datnam);
+#ifdef PROG
+  if (WpeIsProg ())
+    {
+      if (!strcmp (filename, "Messages"))
+	{
+	  f->ins = 8;
+	  f->hlp_str = e_hlp_str[3];
+	  f->nblst = 8;
+	  f->blst = mblst;
+	  ftype = 2;
+	}
+      else if (!strcmp (filename, "Watches"))
+	{
+	  f->ins = 8;
+	  f->hlp_str = e_hlp_str[1];
+	  f->blst = dblst;
+	  ftype = 3;
+	}
+      else if (!strcmp (filename, "Stack"))
+	{
+	  f->ins = 8;
+	  f->hlp_str = e_hlp_str[2];
+	  f->blst = dblst;
+	  ftype = 4;
+	}
+    }
+#endif
+  if (ftype != 1)
+    fp = fopen (complete_fname, "rb");
+  if (fp != NULL && access (complete_fname, W_OK) != 0)
+    f->ins = 8;
+#ifdef UNIX
+  if (fp != NULL)
+    {
+      stat (complete_fname, buf);
+      f->filemode = buf->st_mode;
+    }
+  else
+    {
+      umask (i = umask (077));
+      f->filemode = 0666 & ~i;
+    }
+#endif
+  free (complete_fname);
+
+  if (fp != NULL && ftype != 1)
+    {
+      e_readin (0, 0, fp, f->b, &f->dtmd);
+      if (fclose (fp) != 0)
+	e_error (e_msg[ERR_FCLOSE], 0, cn->fb);
+      if (cn->dtmd == DTMD_HELP)
+	cn->dtmd = DTMD_NORMAL;
+#ifdef PROG
+      if (WpeIsProg ())
+	{
+	  if (e_we_sw & 8)
+	    {
+	      strcpy (f->datnam, "Messages");
+	      e_we_sw &= ~8;
+	    }
+	  if (!strcmp (f->datnam, "Messages"))
+	    {
+	      e_make_error_list (f);
+	      f->ins = 8;
+	    }
+	}
+#endif
+    }
+  else
+    {
+      e_new_line (0, f->b);
+      *(f->b->bf[0].s) = WPE_WR;
+      *(f->b->bf[0].s + 1) = '\0';
+      f->b->bf[0].len = 0;
+      f->b->bf[0].nrc = 1;
+    }
+#ifdef PROG
+  if (ftype == 2)
+    {
+      if (e_p_m_buffer != NULL)
+	{
+	  e_close_buffer (f->b);
+	  f->b = e_p_m_buffer;
+	  f->b->f = f;
+	}
+      else
+	{
+	  e_p_m_buffer = f->b;
+	  free (f->b->bf[0].s);
+	  f->b->mxlines = 0;
+	}
+    }
+#ifdef DEBUGGER
+  if (ftype == 3)
+    {
+      if (e_p_w_buffer != NULL)
+	{
+	  e_close_buffer (f->b);
+	  f->b = e_p_w_buffer;
+	  f->b->f = f;
+	}
+      else
+	{
+	  e_p_w_buffer = f->b;
 /*  e_ins_nchar(f->b, f->s, "No Watches", 0, 0, 10);*/
-  }
- }
+	}
+    }
 #endif
 #endif
- if (f->c_sw) {
-   f->c_sw = e_sc_txt(f->c_sw, f->b);
- }
- if (cn->mxedt > 1)
- {
-  fo = cn->f[cn->mxedt-1];
-  e_ed_rahmen(fo, 0);
- }
- e_firstl(f, 1);
- e_zlsplt(f);
- e_brk_schirm(f);
- e_schirm(f, 1);
- e_cursor(f, 1);
- return(0);
+  if (f->c_sw)
+    {
+      f->c_sw = e_sc_txt (f->c_sw, f->b);
+    }
+  if (cn->mxedt > 1)
+    {
+      fo = cn->f[cn->mxedt - 1];
+      e_ed_rahmen (fo, 0);
+    }
+  e_firstl (f, 1);
+  e_zlsplt (f);
+  e_brk_schirm (f);
+  e_schirm (f, 1);
+  e_cursor (f, 1);
+  return (0);
 }
 
 /*   keyboard output routine */
-int e_eingabe(ECNT *e)
+int
+e_eingabe (ECNT * e)
 {
- BUFFER *b = e->f[e->mxedt]->b;
- SCHIRM *s = e->f[e->mxedt]->s;
- FENSTER *f = e->f[e->mxedt];
- int ret, c = 0;
- unsigned char cc;
+  BUFFER *b = e->f[e->mxedt]->b;
+  SCHIRM *s = e->f[e->mxedt]->s;
+  FENSTER *f = e->f[e->mxedt];
+  int ret, c = 0;
+  unsigned char cc;
 
- fk_cursor(1);
- while (c != WPE_ESC)
- {
-  if (e->mxedt < 1) c = WpeHandleMainmenu(-1, f);
-  else if (!DTMD_ISTEXT(f->dtmd)) return(0);
-  else
-  {
-   if (f->save > f->ed->maxchg) e_autosave(f);
+  fk_cursor (1);
+  while (c != WPE_ESC)
+    {
+      if (e->mxedt < 1)
+	c = WpeHandleMainmenu (-1, f);
+      else if (!DTMD_ISTEXT (f->dtmd))
+	return (0);
+      else
+	{
+	  if (f->save > f->ed->maxchg)
+	    e_autosave (f);
 #if  MOUSE
-   if ((c = e_getch()) < 0) cc = c = e_edt_mouse(c, f);
-   else cc = c;
+	  if ((c = e_getch ()) < 0)
+	    cc = c = e_edt_mouse (c, f);
+	  else
+	    cc = c;
 #else
-   cc = c = e_getch();
+	  cc = c = e_getch ();
 #endif
-  }
-  if ((c > 31 || (c == WPE_TAB && !(f->flg & 1)) ||
-    (f->ins > 1 && f->ins != 8)) && c < 255)
-  {
-   if (f->ins == 8) continue;
-   if (f->ins == 0 || f->ins == 2)  e_put_char(c, b, s);
-   else e_ins_nchar(b, s, &cc, b->b.x, b->b.y, 1);
-   e_schirm(f, 1);
-  }
-  else if (c == WPE_DC)
-  {
-   if (f->ins == 8)
-   {
-    if (f->dtmd == DTMD_HELP) e_help_last(f);
-    continue;
-   }
-   if (b->b.y > 0 || b->b.x > 0)
-   {
-    if (b->bf[b->b.y].len == 0)
-    {
-     e_del_line(b->b.y, b, s);
-     b->b.y--;
-     b->b.x = b->bf[b->b.y].len;
-     if (*(b->bf[b->b.y].s+b->b.x) == '\0') b->b.x--;
-    }
-    else
-    {
-     if (b->b.x > 0) b->b.x--;
-     else
-     {
-      b->b.y--;
-      b->b.x = b->bf[b->b.y].len;
-      if (*(b->bf[b->b.y].s+b->b.x) == '\0') b->b.x--;
-     }
-     if (f->flg & 1) e_del_a_ind(b,  s);
-     else e_del_nchar(b, s, b->b.x, b->b.y, 1);
-    }
-    e_schirm(f, 1);
-   }
-  }
-  else if (c == ENTF || c == 4)
-  {
-   if (f->ins == 8)
-   {
+	}
+      if ((c > 31 || (c == WPE_TAB && !(f->flg & 1)) ||
+	   (f->ins > 1 && f->ins != 8)) && c < 255)
+	{
+	  if (f->ins == 8)
+	    continue;
+	  if (f->ins == 0 || f->ins == 2)
+	    e_put_char (c, b, s);
+	  else
+	    e_ins_nchar (b, s, &cc, b->b.x, b->b.y, 1);
+	  e_schirm (f, 1);
+	}
+      else if (c == WPE_DC)
+	{
+	  if (f->ins == 8)
+	    {
+	      if (f->dtmd == DTMD_HELP)
+		e_help_last (f);
+	      continue;
+	    }
+	  if (b->b.y > 0 || b->b.x > 0)
+	    {
+	      if (b->bf[b->b.y].len == 0)
+		{
+		  e_del_line (b->b.y, b, s);
+		  b->b.y--;
+		  b->b.x = b->bf[b->b.y].len;
+		  if (*(b->bf[b->b.y].s + b->b.x) == '\0')
+		    b->b.x--;
+		}
+	      else
+		{
+		  if (b->b.x > 0)
+		    b->b.x--;
+		  else
+		    {
+		      b->b.y--;
+		      b->b.x = b->bf[b->b.y].len;
+		      if (*(b->bf[b->b.y].s + b->b.x) == '\0')
+			b->b.x--;
+		    }
+		  if (f->flg & 1)
+		    e_del_a_ind (b, s);
+		  else
+		    e_del_nchar (b, s, b->b.x, b->b.y, 1);
+		}
+	      e_schirm (f, 1);
+	    }
+	}
+      else if (c == ENTF || c == 4)
+	{
+	  if (f->ins == 8)
+	    {
 #ifdef DEBUGGER
-    if (WpeIsProg()) e_d_is_watch(c, f);
+	      if (WpeIsProg ())
+		e_d_is_watch (c, f);
 #endif
-    continue;
-   }
-   if (*(b->bf[b->b.y].s + b->b.x) != '\0' &&
-     (b->b.y < b->mxlines-1 || *(b->bf[b->b.y].s + b->b.x) != WPE_WR))
-   {
-    e_del_nchar(b, s, b->b.x, b->b.y, 1);
-    e_schirm(f, 1);
-   }
-  }
-  else if (c == WPE_CR)
-  {
+	      continue;
+	    }
+	  if (*(b->bf[b->b.y].s + b->b.x) != '\0' &&
+	      (b->b.y < b->mxlines - 1
+	       || *(b->bf[b->b.y].s + b->b.x) != WPE_WR))
+	    {
+	      e_del_nchar (b, s, b->b.x, b->b.y, 1);
+	      e_schirm (f, 1);
+	    }
+	}
+      else if (c == WPE_CR)
+	{
 #ifdef PROG
-   if (f->ins == 8)
-   {
-    if (f->dtmd == DTMD_HELP) {  e_help_ret(f);  goto weiter;  }
-    if (WpeIsProg())  {  e_d_car_ret(f);  goto weiter;  }
-    else continue;
-   }
+	  if (f->ins == 8)
+	    {
+	      if (f->dtmd == DTMD_HELP)
+		{
+		  e_help_ret (f);
+		  goto weiter;
+		}
+	      if (WpeIsProg ())
+		{
+		  e_d_car_ret (f);
+		  goto weiter;
+		}
+	      else
+		continue;
+	    }
 #else
-   if (f->ins == 8) continue;
+	  if (f->ins == 8)
+	    continue;
 #endif
-   e_car_ret(b, s);
-   e_schirm(f, 1);
-  }
-  else if (c == WPE_TAB)
-  {
-   e_tab_a_ind(b, s);
-   e_schirm(f, 1);
-  }
+	  e_car_ret (b, s);
+	  e_schirm (f, 1);
+	}
+      else if (c == WPE_TAB)
+	{
+	  e_tab_a_ind (b, s);
+	  e_schirm (f, 1);
+	}
 /*
           else if(c == WPE_TAB)
           {    if(f->ins == 8) continue;
@@ -510,1607 +546,1772 @@ int e_eingabe(ECNT *e)
                e_schirm(b, s, f, 1);
           }
 */
-  else
-  {
-   ret = e_tst_cur(c, e); /*up/down arrows go this way*/
-   if (ret != 0) ret = e_tst_fkt(c, e);
-  }
-weiter:
-  f = e->f[e->mxedt];
-  if (e->mxedt > 0 && DTMD_ISTEXT(f->dtmd))
-  {
-   b = f->b;
-   s = f->s;
-   s->ks.x = b->b.x;  s->ks.y = b->b.y;
-   e_cursor(f, 1);
-   if ((c & 511) != CUP && (c & 511) != CDO) b->clsv = b->cl;
-   e_zlsplt(f);
-  }
- }
- return(c);
+      else
+	{
+	  ret = e_tst_cur (c, e);	/*up/down arrows go this way */
+	  if (ret != 0)
+	    ret = e_tst_fkt (c, e);
+	}
+    weiter:
+      f = e->f[e->mxedt];
+      if (e->mxedt > 0 && DTMD_ISTEXT (f->dtmd))
+	{
+	  b = f->b;
+	  s = f->s;
+	  s->ks.x = b->b.x;
+	  s->ks.y = b->b.y;
+	  e_cursor (f, 1);
+	  if ((c & 511) != CUP && (c & 511) != CDO)
+	    b->clsv = b->cl;
+	  e_zlsplt (f);
+	}
+    }
+  return (c);
 }
 
 /*              Interpretation of cursor keys
                      ( Primitive editor )                    */
-int e_tst_cur(int c, ECNT *e)
+int
+e_tst_cur (int c, ECNT * e)
 {
-   FENSTER *f = e->f[e->mxedt];
-   BUFFER *b = f->b;
-   SCHIRM *s = f->s;
-   
-   switch (c)
-   {  case CtrlP:
-      case CUP:
-      case CUP+512:
-	 if(b->b.y > 0) (b->b.y)--;
-	 b->b.x = e_chr_sp(b->clsv, b, f);
-	 break;
-      case CtrlN:
-      case CDO:
-      case CDO+512:
-	 if(b->b.y < b->mxlines - 1) (b->b.y)++;
-	 b->b.x = e_chr_sp(b->clsv, b, f);
-	 break;
-      case CtrlB:
-      case CLE:
-      case CLE+512:
-	 (b->b.x)--;
-	 if(b->b.x < 0)
-	 {  if(b->b.y > 0)
-	    {  (b->b.y)--; b->b.x = b->bf[b->b.y].len;  }
-	    else {  b->b.x = 0;  }
-	 }
-	 break;
-      case CtrlF:
-      case CRI:
-      case CRI+512:
-	 (b->b.x)++;
-	 if(b->b.x > b->bf[b->b.y].len)
-	 {  if(b->b.y < b->mxlines - 1)  {  (b->b.y)++; b->b.x = 0;  }
-	    else {  b->b.x = b->bf[b->b.y].len;  }
-	 }
-	 break;
-	 
-      case CCLE:
-      case CCLE+512:
-	 if(b->b.x <= 0 && b->b.y > 0)
-	 {  b->b.y--;
-	    b->b.x = b->bf[b->b.y].len;
-	 }
-	 else if( b->b.x > 0 )
-	 b->b.x = e_su_rblk(b->b.x - 1, b->bf[b->b.y].s);
-	 break;
-      case CCRI:
-      case CCRI+512:
-	 if(b->b.x >= b->bf[b->b.y].len && b->b.y < b->mxlines)
-	 {  b->b.x = 0; b->b.y++;  }
-	 else if( b->b.x < b->bf[b->b.y].len )
-	 b->b.x = e_su_lblk(b->b.x, b->bf[b->b.y].s);
-	 break;
-      case BDO:
-      case BDO+512:
-	 b->b.y = b->b.y + NUM_LINES_ON_SCREEN - 2;
-	 if(b->b.y > b->mxlines - 1) b->b.y = b->mxlines - 1;
-	 e_schirm(f, 1);
-	 e_cursor(f, 1);
-	 break;
-      case BUP:
-      case BUP+512:
-	 b->b.y = b->b.y - f->e.y + f->a.y + 2;
-	 if(b->b.y < 0) b->b.y = 0;
-	 e_schirm(f, 1);
-	 e_cursor(f, 1);
-	 break;
-      case CBDO:
-      case CBDO+512:
-	 b->b.y = b->mxlines - 1;
-	 b->b.x = b->bf[b->mxlines - 1].len;
-	 e_schirm(f, 1);
-	 break;
-      case CBUP:
-      case CBUP+512:
-	 if(b->b.y != 0)
-	 {  b->b.x = 0;
-	    b->b.y = 0;
-	    e_schirm(f, 1);  }
-	 break;
-      case CEND:
-      case CEND+512:
-	 if(LINE_NUM_ON_SCREEN_BOTTOM < b->mxlines)
-	 b->b.y = LINE_NUM_ON_SCREEN_BOTTOM - 1;
-	 else
-	 b->b.y = b->mxlines - 1;
-	 b->b.x = b->bf[b->b.y].len;
-	 break;
-      case CPS1:
-      case CPS1+512:
-	 b->b.x = 0;
-	 b->b.y = s->c.y;
-	 break;
-      case AltI:
-      case EINFG:
-	 if (f->ins == 8) {
-#ifdef DEBUGGER
-	    if (WpeIsProg()) e_d_is_watch(c, f);
-#endif
-	    break;  }
-	 if(f->ins & 1) f->ins &= ~1;
-	 else f->ins |= 1;
-#ifdef NEWSTYLE
-	 e_ed_rahmen(f, 1);
-#else
-	 e_pr_filetype(f);
-#endif
-	 break;
-      case AltJ:
-	 if (f->ins == 8) break;
-	 if(f->ins & 2) f->ins &= ~2;
-	 else f->ins |= 2;
-#ifdef NEWSTYLE
-	 e_ed_rahmen(f, 1);
-#else
-	 e_pr_filetype(f);
-#endif
-	 break;
-      case CtrlA:
-      case POS1:
-      case POS1+512:
-	 b->b.x = 0;
-	 break;
-      case CtrlE:
-      case ENDE:
-      case ENDE+512:
-	 b->b.x = b->bf[b->b.y].len;
-	 break;
-      case CtrlT:
-	 if(f->ins == 8) break;
-	 if( b->b.x < b->bf[b->b.y].len )
-	 {  c = e_su_lblk(b->b.x, b->bf[b->b.y].s);
-	    e_del_nchar(b, s, b->b.x, b->b.y, c-b->b.x);
-	 }
-	 else if(*(b->bf[b->b.y].s+b->b.x) == WPE_WR)
-	 e_del_nchar(b, s, b->b.x, b->b.y, 1);
-	 else if(b->b.x >= b->bf[b->b.y].len && b->b.y < b->mxlines)
-	 {  b->b.x = 0; (b->b.y)++;  }
-	 e_schirm(f, 1);
-	 break;
-      case CtrlZ:
-	 if(f->ins == 8) break;
-	 e_del_nchar(b, s, b->b.x, b->b.y, b->bf[b->b.y].len-b->b.x);
-	 e_schirm(f, 1);
-	 break;
-      case DGZ:
-	 if(f->ins == 8) break;
-	 e_del_line(b->b.y, b, s);
-	 if(b->b.y > b->mxlines - 1) (b->b.y)--;
-	 e_schirm(f, 1);
-	 break;
-      case AF7:
-      case AltV:
-	 if(f->dtmd != DTMD_HELP || f->ins != 8) return(c);
-         e_help_next(f, 0);
-	 break;
-      case AF8:
-      case AltT:
-	 if(f->dtmd != DTMD_HELP || f->ins != 8) return(c);
-         e_help_next(f, 1);
-	 break;
-      default:
-	 return(c);
-   }
-   if(c >= 512 )
-   {  if(s->ks.y == s->mark_begin.y && s->ks.x == s->mark_begin.x &&
-		(s->mark_begin.y != s->mark_end.y || s->mark_begin.x != s->mark_end.x))
-      {  s->mark_begin.x = b->b.x;  s->mark_begin.y = b->b.y;  }
-      else if(s->ks.y == s->mark_end.y && s->ks.x == s->mark_end.x &&
-		(s->mark_begin.y != s->mark_end.y || s->mark_begin.x != s->mark_end.x))
-      {  s->mark_end.x = b->b.x;  s->mark_end.y = b->b.y;  }
-      else if(s->ks.y < b->b.y || ( s->ks.y == b->b.y && s->ks.x < b->b.x))
-      {  s->mark_begin.x = s->ks.x;  s->mark_begin.y = s->ks.y;
-	 s->mark_end.x = b->b.x;  s->mark_end.y = b->b.y;
-      }
+  FENSTER *f = e->f[e->mxedt];
+  BUFFER *b = f->b;
+  SCHIRM *s = f->s;
+
+  switch (c)
+    {
+    case CtrlP:
+    case CUP:
+    case CUP + 512:
+      if (b->b.y > 0)
+	(b->b.y)--;
+      b->b.x = e_chr_sp (b->clsv, b, f);
+      break;
+    case CtrlN:
+    case CDO:
+    case CDO + 512:
+      if (b->b.y < b->mxlines - 1)
+	(b->b.y)++;
+      b->b.x = e_chr_sp (b->clsv, b, f);
+      break;
+    case CtrlB:
+    case CLE:
+    case CLE + 512:
+      (b->b.x)--;
+      if (b->b.x < 0)
+	{
+	  if (b->b.y > 0)
+	    {
+	      (b->b.y)--;
+	      b->b.x = b->bf[b->b.y].len;
+	    }
+	  else
+	    {
+	      b->b.x = 0;
+	    }
+	}
+      break;
+    case CtrlF:
+    case CRI:
+    case CRI + 512:
+      (b->b.x)++;
+      if (b->b.x > b->bf[b->b.y].len)
+	{
+	  if (b->b.y < b->mxlines - 1)
+	    {
+	      (b->b.y)++;
+	      b->b.x = 0;
+	    }
+	  else
+	    {
+	      b->b.x = b->bf[b->b.y].len;
+	    }
+	}
+      break;
+
+    case CCLE:
+    case CCLE + 512:
+      if (b->b.x <= 0 && b->b.y > 0)
+	{
+	  b->b.y--;
+	  b->b.x = b->bf[b->b.y].len;
+	}
+      else if (b->b.x > 0)
+	b->b.x = e_su_rblk (b->b.x - 1, b->bf[b->b.y].s);
+      break;
+    case CCRI:
+    case CCRI + 512:
+      if (b->b.x >= b->bf[b->b.y].len && b->b.y < b->mxlines)
+	{
+	  b->b.x = 0;
+	  b->b.y++;
+	}
+      else if (b->b.x < b->bf[b->b.y].len)
+	b->b.x = e_su_lblk (b->b.x, b->bf[b->b.y].s);
+      break;
+    case BDO:
+    case BDO + 512:
+      b->b.y = b->b.y + NUM_LINES_ON_SCREEN - 2;
+      if (b->b.y > b->mxlines - 1)
+	b->b.y = b->mxlines - 1;
+      e_schirm (f, 1);
+      e_cursor (f, 1);
+      break;
+    case BUP:
+    case BUP + 512:
+      b->b.y = b->b.y - f->e.y + f->a.y + 2;
+      if (b->b.y < 0)
+	b->b.y = 0;
+      e_schirm (f, 1);
+      e_cursor (f, 1);
+      break;
+    case CBDO:
+    case CBDO + 512:
+      b->b.y = b->mxlines - 1;
+      b->b.x = b->bf[b->mxlines - 1].len;
+      e_schirm (f, 1);
+      break;
+    case CBUP:
+    case CBUP + 512:
+      if (b->b.y != 0)
+	{
+	  b->b.x = 0;
+	  b->b.y = 0;
+	  e_schirm (f, 1);
+	}
+      break;
+    case CEND:
+    case CEND + 512:
+      if (LINE_NUM_ON_SCREEN_BOTTOM < b->mxlines)
+	b->b.y = LINE_NUM_ON_SCREEN_BOTTOM - 1;
       else
-      {  s->mark_end.x = s->ks.x;  s->mark_end.y = s->ks.y;
-	 s->mark_begin.x = b->b.x;  s->mark_begin.y = b->b.y;
-      }
-      e_schirm(f, 1);
-   }
-   return(0);
+	b->b.y = b->mxlines - 1;
+      b->b.x = b->bf[b->b.y].len;
+      break;
+    case CPS1:
+    case CPS1 + 512:
+      b->b.x = 0;
+      b->b.y = s->c.y;
+      break;
+    case AltI:
+    case EINFG:
+      if (f->ins == 8)
+	{
+#ifdef DEBUGGER
+	  if (WpeIsProg ())
+	    e_d_is_watch (c, f);
+#endif
+	  break;
+	}
+      if (f->ins & 1)
+	f->ins &= ~1;
+      else
+	f->ins |= 1;
+#ifdef NEWSTYLE
+      e_ed_rahmen (f, 1);
+#else
+      e_pr_filetype (f);
+#endif
+      break;
+    case AltJ:
+      if (f->ins == 8)
+	break;
+      if (f->ins & 2)
+	f->ins &= ~2;
+      else
+	f->ins |= 2;
+#ifdef NEWSTYLE
+      e_ed_rahmen (f, 1);
+#else
+      e_pr_filetype (f);
+#endif
+      break;
+    case CtrlA:
+    case POS1:
+    case POS1 + 512:
+      b->b.x = 0;
+      break;
+    case CtrlE:
+    case ENDE:
+    case ENDE + 512:
+      b->b.x = b->bf[b->b.y].len;
+      break;
+    case CtrlT:
+      if (f->ins == 8)
+	break;
+      if (b->b.x < b->bf[b->b.y].len)
+	{
+	  c = e_su_lblk (b->b.x, b->bf[b->b.y].s);
+	  e_del_nchar (b, s, b->b.x, b->b.y, c - b->b.x);
+	}
+      else if (*(b->bf[b->b.y].s + b->b.x) == WPE_WR)
+	e_del_nchar (b, s, b->b.x, b->b.y, 1);
+      else if (b->b.x >= b->bf[b->b.y].len && b->b.y < b->mxlines)
+	{
+	  b->b.x = 0;
+	  (b->b.y)++;
+	}
+      e_schirm (f, 1);
+      break;
+    case CtrlZ:
+      if (f->ins == 8)
+	break;
+      e_del_nchar (b, s, b->b.x, b->b.y, b->bf[b->b.y].len - b->b.x);
+      e_schirm (f, 1);
+      break;
+    case DGZ:
+      if (f->ins == 8)
+	break;
+      e_del_line (b->b.y, b, s);
+      if (b->b.y > b->mxlines - 1)
+	(b->b.y)--;
+      e_schirm (f, 1);
+      break;
+    case AF7:
+    case AltV:
+      if (f->dtmd != DTMD_HELP || f->ins != 8)
+	return (c);
+      e_help_next (f, 0);
+      break;
+    case AF8:
+    case AltT:
+      if (f->dtmd != DTMD_HELP || f->ins != 8)
+	return (c);
+      e_help_next (f, 1);
+      break;
+    default:
+      return (c);
+    }
+  if (c >= 512)
+    {
+      if (s->ks.y == s->mark_begin.y && s->ks.x == s->mark_begin.x &&
+	  (s->mark_begin.y != s->mark_end.y
+	   || s->mark_begin.x != s->mark_end.x))
+	{
+	  s->mark_begin.x = b->b.x;
+	  s->mark_begin.y = b->b.y;
+	}
+      else if (s->ks.y == s->mark_end.y && s->ks.x == s->mark_end.x &&
+	       (s->mark_begin.y != s->mark_end.y
+		|| s->mark_begin.x != s->mark_end.x))
+	{
+	  s->mark_end.x = b->b.x;
+	  s->mark_end.y = b->b.y;
+	}
+      else if (s->ks.y < b->b.y || (s->ks.y == b->b.y && s->ks.x < b->b.x))
+	{
+	  s->mark_begin.x = s->ks.x;
+	  s->mark_begin.y = s->ks.y;
+	  s->mark_end.x = b->b.x;
+	  s->mark_end.y = b->b.y;
+	}
+      else
+	{
+	  s->mark_end.x = s->ks.x;
+	  s->mark_end.y = s->ks.y;
+	  s->mark_begin.x = b->b.x;
+	  s->mark_begin.y = b->b.y;
+	}
+      e_schirm (f, 1);
+    }
+  return (0);
 }
 
 /*   function key (F1-F12) evaluation, editor only */
-int e_tst_fkt(int c, ECNT *e)
+int
+e_tst_fkt (int c, ECNT * e)
 {
- extern OPT opt[];
- int i;
- FENSTER *f = e->f[e->mxedt];
+  extern OPT opt[];
+  int i;
+  FENSTER *f = e->f[e->mxedt];
 
 #ifdef PROG
- if (e_tst_dfkt(f, c) == 0 || ((WpeIsProg()) && e_prog_switch(f, c) == 0))
+  if (e_tst_dfkt (f, c) == 0 || ((WpeIsProg ()) && e_prog_switch (f, c) == 0))
 #else
- if (e_tst_dfkt(f, c) == 0)
+  if (e_tst_dfkt (f, c) == 0)
 #endif
- {
-  f = e->f[e->mxedt];
-  fk_cursor(1);
-  if (e->mxedt > 0)
-   e_cursor(f, 1);
-  return(0);
- }
+    {
+      f = e->f[e->mxedt];
+      fk_cursor (1);
+      if (e->mxedt > 0)
+	e_cursor (f, 1);
+      return (0);
+    }
 
- for (i = 0; i < MENOPT; i++)
-  if (c == opt[i].as)
-   WpeHandleMainmenu(i, f);
+  for (i = 0; i < MENOPT; i++)
+    if (c == opt[i].as)
+      WpeHandleMainmenu (i, f);
 
- switch (c)
- {
-  case CtrlK:
-   e_ctrl_k(f);    /*  ctrl k  */
-   break;
-  case CtrlO:      /*  ctrl o  */
-   e_ctrl_o(f);
-   break;
-  case AltG:
-   e_goto_line(f);
-   break;
-  case CF10:
-  case CtrlW:
-   e_show_clipboard(f);
-   break;
-  case CtrlDel:
-   e_blck_del(f);
-   break;
-  case UNDO:
-  case AltBS:
-  case CtrlU:
-   e_make_undo(f);
-   break;
-  case AGAIN:
-  case SABS:
-  case CtrlR:
-   e_make_redo(f);
-   break;
-  case CUT:
-  case ShiftDel:    /*  shift Del  :  Delete to Clipboard  */
+  switch (c)
+    {
+    case CtrlK:
+      e_ctrl_k (f);		/*  ctrl k  */
+      break;
+    case CtrlO:		/*  ctrl o  */
+      e_ctrl_o (f);
+      break;
+    case AltG:
+      e_goto_line (f);
+      break;
+    case CF10:
+    case CtrlW:
+      e_show_clipboard (f);
+      break;
+    case CtrlDel:
+      e_blck_del (f);
+      break;
+    case UNDO:
+    case AltBS:
+    case CtrlU:
+      e_make_undo (f);
+      break;
+    case AGAIN:
+    case SABS:
+    case CtrlR:
+      e_make_redo (f);
+      break;
+    case CUT:
+    case ShiftDel:		/*  shift Del  :  Delete to Clipboard  */
 /*               case 402:     */
-  case CtrlX:
-   e_edt_del(f);
-   break;
-  case PASTE:
-  case ShiftEin:    /*  shift Einf  */
-  case CtrlV:
-   e_edt_einf(f);
-   break;
+    case CtrlX:
+      e_edt_del (f);
+      break;
+    case PASTE:
+    case ShiftEin:		/*  shift Einf  */
+    case CtrlV:
+      e_edt_einf (f);
+      break;
 #if !defined(NO_XWINDOWS)
-  case AltEin:
-   e_copy_X_buffer(f);
-   break;
-  case AltDel:
-   e_paste_X_buffer(f);
-   break;
+    case AltEin:
+      e_copy_X_buffer (f);
+      break;
+    case AltDel:
+      e_paste_X_buffer (f);
+      break;
 #endif
-  case COPY:
-  case CtrlEin:    /*  ctrl Einf  */
+    case COPY:
+    case CtrlEin:		/*  ctrl Einf  */
 /*               case 401:    */
-  case CtrlC:
-   e_edt_copy(f);
-   break;
-  default:
-   if (f->ed->edopt & ED_CUA_STYLE)
-   {
-    switch (c)
-    {
-     case AF2:
-      e_m_save(f);
+    case CtrlC:
+      e_edt_copy (f);
       break;
-     case FID:
-     case AF3:
-      e_find(f);
+    default:
+      if (f->ed->edopt & ED_CUA_STYLE)
+	{
+	  switch (c)
+	    {
+	    case AF2:
+	      e_m_save (f);
+	      break;
+	    case FID:
+	    case AF3:
+	      e_find (f);
+	      break;
+	    case SF3:
+	      e_replace (f);
+	      break;
+	    case F3:
+	      e_rep_search (f);
+	      break;
+	    default:
+	      return (c);
+	    }
+	}
+      else
+	{
+	  switch (c)
+	    {
+	    case F2:
+	      e_m_save (f);
+	      break;
+	    case FID:
+	    case F4:
+	      e_find (f);
+	      break;
+	    case AF4:
+	      e_replace (f);
+	      break;
+	    case CtrlL:
+	    case CF4:
+	      e_rep_search (f);
+	      break;
+	    default:
+	      return (c);
+	    }
+	}
       break;
-     case SF3:
-      e_replace(f);
-      break;
-     case F3:
-      e_rep_search(f);
-      break;
-     default:
-      return(c);
     }
-   }
-   else
-   {
-    switch(c)
-    {
-     case F2:
-      e_m_save(f);
-      break;
-     case FID:
-     case F4:
-      e_find(f);
-      break;
-     case AF4:
-      e_replace(f);
-      break;
-     case CtrlL:
-     case CF4:
-      e_rep_search(f);
-      break;
-     default:
-      return(c);
-    }
-   }
-   break;
- }
- fk_cursor(1);
- return(0);
+  fk_cursor (1);
+  return (0);
 }
 
-int e_ctrl_k(FENSTER *f)
+int
+e_ctrl_k (FENSTER * f)
 {
- BUFFER *b = f->ed->f[f->ed->mxedt]->b;
- SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
- int c;
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
+  int c;
 
- c = toupper(e_getch());
- if (c < 32)
-  c = c + 'A' - 1;
- switch (c)
- {
-  case 'A':
-   b->b = s->mark_begin;
-   e_schirm(f, 1);
-   break;
-  case 'B':
-   s->mark_begin = e_set_pnt(b->b.x, b->b.y);
-   e_schirm(f, 1);
-   break;
-  case 'C':
-   e_blck_copy(f);
-   break;
-  case 'D':
-   e_changecase_dialog(f);
-   break;
-  case 'F':
-   e_mk_beauty(1, 3, f);
-   break;
-  case 'H':
-   e_blck_hide(f);
-   break;
-  case 'I':
-   e_blck_to_right(f);
-   break;
-  case 'K':
-   s->mark_end = e_set_pnt(b->b.x, b->b.y);
-   e_schirm(f, 1);
-   break;
-  case 'L':
-   f->s->mark_begin.x = 0;
-   f->s->mark_begin.y = f->b->b.y;
-   if (f->b->b.y < f->b->mxlines-1)
-   {
-    f->s->mark_end.x = 0;
-    f->s->mark_end.y = f->b->b.y+1;
-   }
-   else
-   {
-    f->s->mark_end.x = f->b->bf[f->b->b.y].len;
-    f->s->mark_end.y = f->b->b.y;
-   }
-   e_schirm(f, 1);
-   break;
-  case 'R':
-   e_blck_read(f);
-   break;
-  case 'U':
-   e_blck_to_left(f);
-   break;
-  case 'V':
-   e_blck_move(f);
-   break;
-  case 'W':
-   e_blck_write(f);
-   break;
-  case 'X':
-   s->mark_begin.x = 0;
-   s->mark_begin.y = 0;
-   s->mark_end.y = b->mxlines-1;
-   s->mark_end.x = b->bf[b->mxlines-1].len;
-   e_schirm(f, 1);
-   break;
-  case 'Y':
-   e_blck_del(f);
-   break;
-  case 'Z':
-   b->b = s->mark_end;
-   e_schirm(f, 1);
-   break;
-  case '0':
-  case '1':
-  case '2':
-  case '3':
-  case '4':
-  case '5':
-  case '6':
-  case '7':
-  case '8':
-  case '9':
-   s->pt[c-'0'] = e_set_pnt(b->b.x, b->b.y);
-   s->fa.y = b->b.y;  s->fa.x = b->b.x;  s->fe.x = b->b.x+1;
-   e_schirm(f, 1);
-   break;
- }
- return 0;
+  c = toupper (e_getch ());
+  if (c < 32)
+    c = c + 'A' - 1;
+  switch (c)
+    {
+    case 'A':
+      b->b = s->mark_begin;
+      e_schirm (f, 1);
+      break;
+    case 'B':
+      s->mark_begin = e_set_pnt (b->b.x, b->b.y);
+      e_schirm (f, 1);
+      break;
+    case 'C':
+      e_blck_copy (f);
+      break;
+    case 'D':
+      e_changecase_dialog (f);
+      break;
+    case 'F':
+      e_mk_beauty (1, 3, f);
+      break;
+    case 'H':
+      e_blck_hide (f);
+      break;
+    case 'I':
+      e_blck_to_right (f);
+      break;
+    case 'K':
+      s->mark_end = e_set_pnt (b->b.x, b->b.y);
+      e_schirm (f, 1);
+      break;
+    case 'L':
+      f->s->mark_begin.x = 0;
+      f->s->mark_begin.y = f->b->b.y;
+      if (f->b->b.y < f->b->mxlines - 1)
+	{
+	  f->s->mark_end.x = 0;
+	  f->s->mark_end.y = f->b->b.y + 1;
+	}
+      else
+	{
+	  f->s->mark_end.x = f->b->bf[f->b->b.y].len;
+	  f->s->mark_end.y = f->b->b.y;
+	}
+      e_schirm (f, 1);
+      break;
+    case 'R':
+      e_blck_read (f);
+      break;
+    case 'U':
+      e_blck_to_left (f);
+      break;
+    case 'V':
+      e_blck_move (f);
+      break;
+    case 'W':
+      e_blck_write (f);
+      break;
+    case 'X':
+      s->mark_begin.x = 0;
+      s->mark_begin.y = 0;
+      s->mark_end.y = b->mxlines - 1;
+      s->mark_end.x = b->bf[b->mxlines - 1].len;
+      e_schirm (f, 1);
+      break;
+    case 'Y':
+      e_blck_del (f);
+      break;
+    case 'Z':
+      b->b = s->mark_end;
+      e_schirm (f, 1);
+      break;
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      s->pt[c - '0'] = e_set_pnt (b->b.x, b->b.y);
+      s->fa.y = b->b.y;
+      s->fa.x = b->b.x;
+      s->fe.x = b->b.x + 1;
+      e_schirm (f, 1);
+      break;
+    }
+  return 0;
 }
 
 /*   Ctrl - O - Dispatcher     */
-int e_ctrl_o(FENSTER *f)
+int
+e_ctrl_o (FENSTER * f)
 {
- BUFFER *b = f->ed->f[f->ed->mxedt]->b;
- SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
- int i, c;
- unsigned char cc;
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
+  int i, c;
+  unsigned char cc;
 
- c = toupper(e_getch());
- if (c < 32) c = c + 'A' - 1;
- switch(c)
- {
-  case 'Y':     /*  delete end of line    */
-   if (f->ins == 8) break;
-   e_del_nchar(b, s, b->b.x, b->b.y, b->bf[b->b.y].len-b->b.x);
-   e_schirm(f, 1);
-   e_cursor(f, 1);
-   break;
-  case 'T':     /*  delete up to beginning of next word    */
-   if (f->ins == 8) break;
-   if (b->b.x <= 0 && b->b.y > 0)
-   {
-    b->b.y--;
-    b->b.x = b->bf[b->b.y].len;
-   }
-   else if (b->b.x > 0)
-   {
-    c = b->b.x;
-    b->b.x = e_su_rblk(b->b.x - 1, b->bf[b->b.y].s);
-    e_del_nchar(b, s, b->b.x, b->b.y, c-b->b.x);
-   }
-   e_schirm(f, 1);
-   break;
-  case 'F':     /*  find string    */
-   e_find(f);
-   break;
-  case 'A':     /*  replace string    */
-   e_replace(f);
-   break;
-#ifdef PROG
-  case 'S':     /*  find declaration    */
-   e_sh_def(f);
-   break;
-  case 'N':     /*  ...next...  */
-   e_sh_nxt_def(f);
-   break;
-  case 'K':     /*  next bracket  */
-   e_nxt_brk(f);
-   break;
-  case 'B':     /*  beautify text  */
-   e_p_beautify(f);
-   break;
-#endif
-  case 'U':     /*   for help file: create button */
-   if (s->mark_begin.y == s->mark_end.y && s->mark_begin.y >= 0 && s->mark_begin.x < s->mark_end.x)
-   {
-    cc = HED;
-    e_ins_nchar(b, s, &cc, s->mark_end.x, s->mark_end.y, 1);
-    cc = HBG;
-    e_ins_nchar(b, s, &cc, s->mark_begin.x, s->mark_end.y, 1);
-    e_schirm(f, 1);
-   }
-   break;
-  case 'M':     /*   for help file: Mark-Line  */
-   if (s->mark_begin.y == s->mark_end.y && s->mark_begin.y >= 0 && s->mark_begin.x < s->mark_end.x)
-   {
-    cc = HED;
-    e_ins_nchar(b, s, &cc, s->mark_end.x, s->mark_end.y, 1);
-    cc = HBB;
-    e_ins_nchar(b, s, &cc, s->mark_begin.x, s->mark_end.y, 1);
-    e_schirm(f, 1);
-   }
-   break;
-  case 'H':     /*   for help file: create Header  */
-   if (s->mark_begin.y == s->mark_end.y && s->mark_begin.y >= 0 && s->mark_begin.x < s->mark_end.x)
-   {
-    cc = HED;
-    e_ins_nchar(b, s, &cc, s->mark_end.x, s->mark_end.y, 1);
-    cc = HHD;
-    e_ins_nchar(b, s, &cc, s->mark_begin.x, s->mark_end.y, 1);
-    e_schirm(f, 1);
-   }
-   break;
-  case 'E':     /*   for help file: create end mark  */
-   e_new_line(b->b.y, b);
-   cc = HFE;
-   e_ins_nchar(b, s, &cc, 0, b->b.y, 1);
-   e_schirm(f, 1);
-   break;
-  case 'L':     /*   for help file: delete "help" special chars  */
-   for (i = 0; i < b->bf[b->b.y].len; i++)
-    if (b->bf[b->b.y].s[i] == HBG || b->bf[b->b.y].s[i] == HED ||
-      b->bf[b->b.y].s[i] == HHD || b->bf[b->b.y].s[i] == HBB ||
-      b->bf[b->b.y].s[i] == HFE || b->bf[b->b.y].s[i] == HFB ||
-      b->bf[b->b.y].s[i] == HFE)
+  c = toupper (e_getch ());
+  if (c < 32)
+    c = c + 'A' - 1;
+  switch (c)
     {
-     e_del_nchar(b, s, i, b->b.y, 1);
-     i--;
+    case 'Y':			/*  delete end of line    */
+      if (f->ins == 8)
+	break;
+      e_del_nchar (b, s, b->b.x, b->b.y, b->bf[b->b.y].len - b->b.x);
+      e_schirm (f, 1);
+      e_cursor (f, 1);
+      break;
+    case 'T':			/*  delete up to beginning of next word    */
+      if (f->ins == 8)
+	break;
+      if (b->b.x <= 0 && b->b.y > 0)
+	{
+	  b->b.y--;
+	  b->b.x = b->bf[b->b.y].len;
+	}
+      else if (b->b.x > 0)
+	{
+	  c = b->b.x;
+	  b->b.x = e_su_rblk (b->b.x - 1, b->bf[b->b.y].s);
+	  e_del_nchar (b, s, b->b.x, b->b.y, c - b->b.x);
+	}
+      e_schirm (f, 1);
+      break;
+    case 'F':			/*  find string    */
+      e_find (f);
+      break;
+    case 'A':			/*  replace string    */
+      e_replace (f);
+      break;
+#ifdef PROG
+    case 'S':			/*  find declaration    */
+      e_sh_def (f);
+      break;
+    case 'N':			/*  ...next...  */
+      e_sh_nxt_def (f);
+      break;
+    case 'K':			/*  next bracket  */
+      e_nxt_brk (f);
+      break;
+    case 'B':			/*  beautify text  */
+      e_p_beautify (f);
+      break;
+#endif
+    case 'U':			/*   for help file: create button */
+      if (s->mark_begin.y == s->mark_end.y && s->mark_begin.y >= 0
+	  && s->mark_begin.x < s->mark_end.x)
+	{
+	  cc = HED;
+	  e_ins_nchar (b, s, &cc, s->mark_end.x, s->mark_end.y, 1);
+	  cc = HBG;
+	  e_ins_nchar (b, s, &cc, s->mark_begin.x, s->mark_end.y, 1);
+	  e_schirm (f, 1);
+	}
+      break;
+    case 'M':			/*   for help file: Mark-Line  */
+      if (s->mark_begin.y == s->mark_end.y && s->mark_begin.y >= 0
+	  && s->mark_begin.x < s->mark_end.x)
+	{
+	  cc = HED;
+	  e_ins_nchar (b, s, &cc, s->mark_end.x, s->mark_end.y, 1);
+	  cc = HBB;
+	  e_ins_nchar (b, s, &cc, s->mark_begin.x, s->mark_end.y, 1);
+	  e_schirm (f, 1);
+	}
+      break;
+    case 'H':			/*   for help file: create Header  */
+      if (s->mark_begin.y == s->mark_end.y && s->mark_begin.y >= 0
+	  && s->mark_begin.x < s->mark_end.x)
+	{
+	  cc = HED;
+	  e_ins_nchar (b, s, &cc, s->mark_end.x, s->mark_end.y, 1);
+	  cc = HHD;
+	  e_ins_nchar (b, s, &cc, s->mark_begin.x, s->mark_end.y, 1);
+	  e_schirm (f, 1);
+	}
+      break;
+    case 'E':			/*   for help file: create end mark  */
+      e_new_line (b->b.y, b);
+      cc = HFE;
+      e_ins_nchar (b, s, &cc, 0, b->b.y, 1);
+      e_schirm (f, 1);
+      break;
+    case 'L':			/*   for help file: delete "help" special chars  */
+      for (i = 0; i < b->bf[b->b.y].len; i++)
+	if (b->bf[b->b.y].s[i] == HBG || b->bf[b->b.y].s[i] == HED ||
+	    b->bf[b->b.y].s[i] == HHD || b->bf[b->b.y].s[i] == HBB ||
+	    b->bf[b->b.y].s[i] == HFE || b->bf[b->b.y].s[i] == HFB ||
+	    b->bf[b->b.y].s[i] == HFE)
+	  {
+	    e_del_nchar (b, s, i, b->b.y, 1);
+	    i--;
+	  }
+      e_schirm (f, 1);
+      break;
+    case 'C':			/*   for help file: check help file   */
+      e_help_comp (f);
+      break;
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      b->b.x = s->pt[c - '0'].x;
+      b->b.y = s->pt[c - '0'].y;
+      s->fa.y = b->b.y;
+      s->fa.x = b->b.x;
+      s->fe.x = b->b.x + 1;
+      e_cursor (f, 1);
+      break;
     }
-   e_schirm(f, 1);
-   break;
-  case 'C':     /*   for help file: check help file   */
-   e_help_comp(f);
-   break;
-  case '0':
-  case '1':
-  case '2':
-  case '3':
-  case '4':
-  case '5':
-  case '6':
-  case '7':
-  case '8':
-  case '9':
-   b->b.x = s->pt[c-'0'].x;  b->b.y = s->pt[c-'0'].y;
-   s->fa.y = b->b.y;  s->fa.x = b->b.x;  s->fe.x = b->b.x+1;
-   e_cursor(f, 1);
-   break;
- }
- return(0);
+  return (0);
 }
 
 /* general function key dispatcher 
    basically, every time when it returns with zero
    something has happened */
-int e_tst_dfkt(FENSTER *f, int c)
+int
+e_tst_dfkt (FENSTER * f, int c)
 {
- if (c >= Alt1 && c <= Alt9)
- {
-  e_switch_window(c - Alt1 + 1, f);
-  return(0);
- }
- if (c >= 1024 && c <= 1049)
- {
-  e_switch_window(c - 1014, f);
-  return(0);
- }
- switch (c)
- {
-  case F1:
-  case HELP:
-   e_help_loc(f, 0);
-   break;
+  if (c >= Alt1 && c <= Alt9)
+    {
+      e_switch_window (c - Alt1 + 1, f);
+      return (0);
+    }
+  if (c >= 1024 && c <= 1049)
+    {
+      e_switch_window (c - 1014, f);
+      return (0);
+    }
+  switch (c)
+    {
+    case F1:
+    case HELP:
+      e_help_loc (f, 0);
+      break;
 #if defined(PROG)
-  case CF1:
-   if (WpeIsProg())
-    e_topic_search(f);
-   break;
-  case AF1:
-   if (WpeIsProg())
-    e_funct_in(f);
-   break;
+    case CF1:
+      if (WpeIsProg ())
+	e_topic_search (f);
+      break;
+    case AF1:
+      if (WpeIsProg ())
+	e_funct_in (f);
+      break;
 #endif
-  case WPE_ESC:
-  case F10:
-  case AltBl:
-   WpeHandleMainmenu(-1, f);
-   break;
-  case Alt0:
-   e_list_all_win(f);
-   break;
-  case AF5:
-   e_deb_out(f);
-   break;
-  default:
-   if (f->ed->edopt & ED_CUA_STYLE)
-   {
-    switch (c)
-    {
-     case CtrlL:
-      e_size_move(f);
+    case WPE_ESC:
+    case F10:
+    case AltBl:
+      WpeHandleMainmenu (-1, f);
       break;
-     case OPEN:
-     case F2:
-      WpeManager(f);
+    case Alt0:
+      e_list_all_win (f);
       break;
-     case SF2:
-      WpeManagerFirst(f);
+    case AF5:
+      e_deb_out (f);
       break;
-     case CF4:
-     case AltX:
-      e_close_window(f);
-      break;
-     case FRONT:
-     case AltZ:
-     case SF4:
-      e_ed_cascade(f);
-      break;
-     case SF5:
-      e_ed_tile(f);
-      break;
-     case SF6:
-      e_ed_zoom(f);
-      break;
-     case CF6:
-     case AltN:
-      e_ed_next(f);
-      break;
-     case STOP:
-     case AF4:
-      e_quit(f);
-      break;
-     default:
-      return(c);
+    default:
+      if (f->ed->edopt & ED_CUA_STYLE)
+	{
+	  switch (c)
+	    {
+	    case CtrlL:
+	      e_size_move (f);
+	      break;
+	    case OPEN:
+	    case F2:
+	      WpeManager (f);
+	      break;
+	    case SF2:
+	      WpeManagerFirst (f);
+	      break;
+	    case CF4:
+	    case AltX:
+	      e_close_window (f);
+	      break;
+	    case FRONT:
+	    case AltZ:
+	    case SF4:
+	      e_ed_cascade (f);
+	      break;
+	    case SF5:
+	      e_ed_tile (f);
+	      break;
+	    case SF6:
+	      e_ed_zoom (f);
+	      break;
+	    case CF6:
+	    case AltN:
+	      e_ed_next (f);
+	      break;
+	    case STOP:
+	    case AF4:
+	      e_quit (f);
+	      break;
+	    default:
+	      return (c);
+	    }
+	}
+      else
+	{
+	  switch (c)
+	    {
+	    case CF5:
+	    case AF2:
+	      e_size_move (f);
+	      break;
+	    case OPEN:
+	    case F3:
+	      WpeManager (f);
+	      break;
+	    case CF3:
+	      WpeManagerFirst (f);
+	      break;
+	    case AF3:
+	      e_close_window (f);
+	      break;
+	    case FRONT:
+	    case AltZ:
+	    case F5:
+	      e_ed_zoom (f);
+	      break;
+	    case F6:
+	    case AltN:
+	      e_ed_next (f);
+	      break;
+	    case STOP:
+	    case AltX:
+	      e_quit (f);
+	      break;
+	    default:
+	      return (c);
+	    }
+	}
     }
-   }
-   else
-   {
-    switch(c)
-    {
-     case CF5:
-     case AF2:
-      e_size_move(f);
-      break;
-     case OPEN:
-     case F3:
-      WpeManager(f);
-      break;
-     case CF3:
-      WpeManagerFirst(f);
-      break;
-     case AF3:
-      e_close_window(f);
-      break;
-     case FRONT:
-     case AltZ:
-     case F5:
-      e_ed_zoom(f);
-      break;
-     case F6:
-     case AltN:
-      e_ed_next(f);
-      break;
-     case STOP:
-     case AltX:
-      e_quit(f);
-      break;
-     default:
-      return(c);
-    }
-   } 
- }
- return(0);
+  return (0);
 }
 
-int e_chr_sp(int x, BUFFER *b, FENSTER *f)
+int
+e_chr_sp (int x, BUFFER * b, FENSTER * f)
 {
- int i, j;
+  int i, j;
 
- for (i = j = 0; i + j < x && i < b->bf[b->b.y].len; i++)
- {
-  if (*(b->bf[b->b.y].s + i) == WPE_TAB)
-   j += (f->ed->tabn - ((j + i) % f->ed->tabn) - 1);
+  for (i = j = 0; i + j < x && i < b->bf[b->b.y].len; i++)
+    {
+      if (*(b->bf[b->b.y].s + i) == WPE_TAB)
+	j += (f->ed->tabn - ((j + i) % f->ed->tabn) - 1);
 #ifdef UNIX
-  else if (!WpeIsXwin() && ((unsigned char) *(b->bf[b->b.y].s + i)) > 126)
-  {
-   j++;
-   if (((unsigned char) *(b->bf[b->b.y].s + i)) < 128 + ' ')
-    j++;
-  }
-  else if (*(b->bf[b->b.y].s + i) < ' ')
-   j++;
-  if (f->dtmd == DTMD_HELP)
-  {
-   if (b->bf[b->b.y].s[i] == HBG || b->bf[b->b.y].s[i] == HFB ||
-     b->bf[b->b.y].s[i] == HED || b->bf[b->b.y].s[i] == HHD ||
-     b->bf[b->b.y].s[i] == HFE || b->bf[b->b.y].s[i] == HBB ||
-     b->bf[b->b.y].s[i] == HNF)
-    j -= 2;
-  }
+      else if (!WpeIsXwin ()
+	       && ((unsigned char) *(b->bf[b->b.y].s + i)) > 126)
+	{
+	  j++;
+	  if (((unsigned char) *(b->bf[b->b.y].s + i)) < 128 + ' ')
+	    j++;
+	}
+      else if (*(b->bf[b->b.y].s + i) < ' ')
+	j++;
+      if (f->dtmd == DTMD_HELP)
+	{
+	  if (b->bf[b->b.y].s[i] == HBG || b->bf[b->b.y].s[i] == HFB ||
+	      b->bf[b->b.y].s[i] == HED || b->bf[b->b.y].s[i] == HHD ||
+	      b->bf[b->b.y].s[i] == HFE || b->bf[b->b.y].s[i] == HBB ||
+	      b->bf[b->b.y].s[i] == HNF)
+	    j -= 2;
+	}
 #endif
- }
- return(i);
+    }
+  return (i);
 }
 
 /****************************************/
-int FindFirstNospaceChar(BUFFER *b, int line)
+int
+FindFirstNospaceChar (BUFFER * b, int line)
 /* returns char number in the line, -1 otherwise */
 {
   int k;
   /* advance x while char[k] == space() */
-  for(k = 0; k < b->bf[line].len; k++) {
-    if(!isspace(b->bf[line].s[k])) {
-      return k;
+  for (k = 0; k < b->bf[line].len; k++)
+    {
+      if (!isspace (b->bf[line].s[k]))
+	{
+	  return k;
+	}
     }
-  }
   return -1;
 }
 
 /****************************************/
-int GetXOfCharNum(BUFFER *b, int line, int char_num)
+int
+GetXOfCharNum (BUFFER * b, int line, int char_num)
 {
-   int x, k;
-   
-   for(x = 0, k = 0; k < b->bf[line].len; k++) {
-     if(k == char_num) {
-       return x;
-     }
-     x = ((b->bf[line].s[k] == '\t') ?
-          (x / b->cn->tabn + 1) * b->cn->tabn : x + 1);
-   }
-   /* return 0 to secure result interpretation */
-   return 0;
+  int x, k;
+
+  for (x = 0, k = 0; k < b->bf[line].len; k++)
+    {
+      if (k == char_num)
+	{
+	  return x;
+	}
+      x = ((b->bf[line].s[k] == '\t') ?
+	   (x / b->cn->tabn + 1) * b->cn->tabn : x + 1);
+    }
+  /* return 0 to secure result interpretation */
+  return 0;
 }
 
 /****************************************/
-int GetCharNumOfX(BUFFER *b, int line, int char_x)
+int
+GetCharNumOfX (BUFFER * b, int line, int char_x)
 {
-   int x, k, next_x;
-   
-   for(x = 0, k = 0; k < b->bf[line].len; k++) {
-     next_x = ((b->bf[line].s[k] == '\t') ?
-          (x / b->cn->tabn + 1) * b->cn->tabn : x + 1);
-     if(next_x > char_x) {
-       return x;
-     }
-     x = next_x;
-   }
-   /* return 0 to secure result interpretation */
-   return 0;
+  int x, k, next_x;
+
+  for (x = 0, k = 0; k < b->bf[line].len; k++)
+    {
+      next_x = ((b->bf[line].s[k] == '\t') ?
+		(x / b->cn->tabn + 1) * b->cn->tabn : x + 1);
+      if (next_x > char_x)
+	{
+	  return x;
+	}
+      x = next_x;
+    }
+  /* return 0 to secure result interpretation */
+  return 0;
 }
+
 /****************************************/
 
 /* New version of auto-indent */
-int e_tab_a_ind(BUFFER *b, SCHIRM *s)
+int
+e_tab_a_ind (BUFFER * b, SCHIRM * s)
 {
- int a_indent = b->cn->autoindent;
- int line, x, k, char_to_ins;
- unsigned char *str;
- int do_auto_indent = 0;
- int first_nospace_k;
+  int a_indent = b->cn->autoindent;
+  int line, x, k, char_to_ins;
+  unsigned char *str;
+  int do_auto_indent = 0;
+  int first_nospace_k;
 
- /* If at the right of current pos there are only space chars, tab up to
-    first nospace position (auto-indent pos) of previous lines. 
-    Tail spaces of current line are erased.
-    If left current pos there are only spaces and even if there
-    are nospaces at the right, tab up to auto-indent pos.
-    Otherwise, insert TAB char.
- */
+  /* If at the right of current pos there are only space chars, tab up to
+     first nospace position (auto-indent pos) of previous lines. 
+     Tail spaces of current line are erased.
+     If left current pos there are only spaces and even if there
+     are nospaces at the right, tab up to auto-indent pos.
+     Otherwise, insert TAB char.
+   */
 
- line = b->b.y; /* current line */
+  line = b->b.y;		/* current line */
 
- first_nospace_k = FindFirstNospaceChar(b, line);
- if (first_nospace_k > -1)
- {
-  /* there is a nospace char in the line */
-  /* get its x */
-  if(b->b.x > GetXOfCharNum(b, line, first_nospace_k))
-  {
-   /* nospace char before curr pos */
-
-   /* are there nospace chars under and after cursor pos */
-   do_auto_indent = 1;
-   for (k = GetCharNumOfX(b, line, b->b.x); k < b->bf[line].len; k++)
-   {
-    if (!isspace(b->bf[line].s[k]))
+  first_nospace_k = FindFirstNospaceChar (b, line);
+  if (first_nospace_k > -1)
     {
-     /* yes, there are */
-     do_auto_indent = 0;
-     break;
+      /* there is a nospace char in the line */
+      /* get its x */
+      if (b->b.x > GetXOfCharNum (b, line, first_nospace_k))
+	{
+	  /* nospace char before curr pos */
+
+	  /* are there nospace chars under and after cursor pos */
+	  do_auto_indent = 1;
+	  for (k = GetCharNumOfX (b, line, b->b.x); k < b->bf[line].len; k++)
+	    {
+	      if (!isspace (b->bf[line].s[k]))
+		{
+		  /* yes, there are */
+		  do_auto_indent = 0;
+		  break;
+		}
+	    }
+	  if (do_auto_indent)
+	    {
+	      /* erase all tail spaces */
+	      e_del_nchar (b, s, b->b.x, line, b->bf[line].len - b->b.x);
+	    }
+	}
+      else
+	{
+	  /* nospace char only at or after curr pos */
+	  do_auto_indent = 1;
+	}
     }
-   }
-   if (do_auto_indent)
-   {
-    /* erase all tail spaces */
-    e_del_nchar(b, s, b->b.x, line, b->bf[line].len - b->b.x);
-   }
-  }
   else
-  {
-   /* nospace char only at or after curr pos */
-   do_auto_indent = 1;
-  }
- }
- else
- {
-  /* there are only space chars in the line */
-  do_auto_indent = 1;
-  if (b->bf[line].len > 0)
-  {
-   /* erase all tail spaces */
-   e_del_nchar(b, s, b->b.x, line, b->bf[line].len - b->b.x);
-  }
- }
+    {
+      /* there are only space chars in the line */
+      do_auto_indent = 1;
+      if (b->bf[line].len > 0)
+	{
+	  /* erase all tail spaces */
+	  e_del_nchar (b, s, b->b.x, line, b->bf[line].len - b->b.x);
+	}
+    }
 
- if (!do_auto_indent)
- {
-  /* insert TAB char */
-  str = malloc(sizeof(unsigned char));
-  str[0] = '\t';
-  char_to_ins = 1;
- }
- else
- {
-  /* auto-indent */ 
-
-  /* find x of the first nospace char of lines from above */
-  x = 0;
-  for (line = b->b.y - 1; (line > 0); line--)
-  {
-   k = FindFirstNospaceChar(b, line);
-   if (k > -1)
-   {
-    x = GetXOfCharNum(b, line, k);
-    break;
-   }
-  }
-
-  if (b->b.x < x)
-  {
-   /* indent to x with spaces */
-   /* insert chars */
-   k = x - b->b.x;
-   str = malloc(k * sizeof(unsigned char));
-   for (x = 0; x < k; x++)
-    str[x] = ' ';
-   char_to_ins = k;
-  }
-  else if (b->b.x < (x + a_indent))
-  {
-   /* indent to x + a_indent with spaces */
-   /* insert chars */
-   k = x + a_indent - b->b.x;
-   str = malloc(k * sizeof(unsigned char));
-   for (x = 0; x < k; x++)
-    str[x] = ' ';
-   char_to_ins = k;
-  }
+  if (!do_auto_indent)
+    {
+      /* insert TAB char */
+      str = malloc (sizeof (unsigned char));
+      str[0] = '\t';
+      char_to_ins = 1;
+    }
   else
-  {
-   /* insert TAB char */
-   str = malloc(sizeof(unsigned char));
-   str[0] = '\t';
-   char_to_ins = 1;
-  }
- }
+    {
+      /* auto-indent */
 
- e_ins_nchar(b, s, str, b->b.x, b->b.y, char_to_ins);
- free(str);
- return(b->b.x);
+      /* find x of the first nospace char of lines from above */
+      x = 0;
+      for (line = b->b.y - 1; (line > 0); line--)
+	{
+	  k = FindFirstNospaceChar (b, line);
+	  if (k > -1)
+	    {
+	      x = GetXOfCharNum (b, line, k);
+	      break;
+	    }
+	}
+
+      if (b->b.x < x)
+	{
+	  /* indent to x with spaces */
+	  /* insert chars */
+	  k = x - b->b.x;
+	  str = malloc (k * sizeof (unsigned char));
+	  for (x = 0; x < k; x++)
+	    str[x] = ' ';
+	  char_to_ins = k;
+	}
+      else if (b->b.x < (x + a_indent))
+	{
+	  /* indent to x + a_indent with spaces */
+	  /* insert chars */
+	  k = x + a_indent - b->b.x;
+	  str = malloc (k * sizeof (unsigned char));
+	  for (x = 0; x < k; x++)
+	    str[x] = ' ';
+	  char_to_ins = k;
+	}
+      else
+	{
+	  /* insert TAB char */
+	  str = malloc (sizeof (unsigned char));
+	  str[0] = '\t';
+	  char_to_ins = 1;
+	}
+    }
+
+  e_ins_nchar (b, s, str, b->b.x, b->b.y, char_to_ins);
+  free (str);
+  return (b->b.x);
 }
 
-int e_del_a_ind(BUFFER *b, SCHIRM *s)
+int
+e_del_a_ind (BUFFER * b, SCHIRM * s)
 {
- int i = 1, j = -1, k;
+  int i = 1, j = -1, k;
 
- if (b->b.y > 0)
- {
-  for (i = 0;
-    i < b->bf[b->b.y].len && i < b->b.x && isspace(b->bf[b->b.y].s[i]); i++)
-   ;
-  if (i == b->b.x)
-  {
-   for (j = 0, i = 0; j <= b->b.x; j++)
-   {
-    i = b->bf[b->b.y].s[j] == '\t' ? (i / b->cn->tabn + 1) * b->cn->tabn :
-      i + 1;
-   }
-   if (i != j)
-   {
-    unsigned char *str = malloc(i * sizeof(unsigned char));
-    e_del_nchar(b, s, 0, b->b.y, j);
-    for (j = 0; j < i; j++)
-     str[j] = ' ';
-    e_ins_nchar(b, s, str, 0, b->b.y, i);
-    b->b.x = i - 1;
-    free(str);
-   }
-   for (j = b->b.y-1; j >= 0; j--)
-   {
-    for (i = 0, k = 0; k < b->bf[j].len && isspace(b->bf[j].s[k]); k++)
-     i = b->bf[j].s[k] == '\t' ? (i / b->cn->tabn + 1) * b->cn->tabn : i + 1;
-    if (k < b->bf[j].len && b->bf[j].s[k] != '#' && i <= b->b.x)
+  if (b->b.y > 0)
     {
-     i = b->b.x - i + 1;
-     b->b.x -= i - 1;
-     break;
+      for (i = 0;
+	   i < b->bf[b->b.y].len && i < b->b.x
+	   && isspace (b->bf[b->b.y].s[i]); i++)
+	;
+      if (i == b->b.x)
+	{
+	  for (j = 0, i = 0; j <= b->b.x; j++)
+	    {
+	      i =
+		b->bf[b->b.y].s[j] ==
+		'\t' ? (i / b->cn->tabn + 1) * b->cn->tabn : i + 1;
+	    }
+	  if (i != j)
+	    {
+	      unsigned char *str = malloc (i * sizeof (unsigned char));
+	      e_del_nchar (b, s, 0, b->b.y, j);
+	      for (j = 0; j < i; j++)
+		str[j] = ' ';
+	      e_ins_nchar (b, s, str, 0, b->b.y, i);
+	      b->b.x = i - 1;
+	      free (str);
+	    }
+	  for (j = b->b.y - 1; j >= 0; j--)
+	    {
+	      for (i = 0, k = 0; k < b->bf[j].len && isspace (b->bf[j].s[k]);
+		   k++)
+		i =
+		  b->bf[j].s[k] ==
+		  '\t' ? (i / b->cn->tabn + 1) * b->cn->tabn : i + 1;
+	      if (k < b->bf[j].len && b->bf[j].s[k] != '#' && i <= b->b.x)
+		{
+		  i = b->b.x - i + 1;
+		  b->b.x -= i - 1;
+		  break;
+		}
+	    }
+	  if (j < 0)
+	    {
+	      i = b->b.x;
+	      b->b.x = 0;
+	    }
+	}
     }
-   }
-   if (j < 0)
-   {
-    i = b->b.x;
-    b->b.x = 0;
-   }
-  }
- }
- if (j < 0)
-  i = 1;
- e_del_nchar(b, s, b->b.x, b->b.y, i);
- return(i);
+  if (j < 0)
+    i = 1;
+  e_del_nchar (b, s, b->b.x, b->b.y, i);
+  return (i);
 }
 
-int e_car_a_ind(BUFFER *b, SCHIRM *s)
+int
+e_car_a_ind (BUFFER * b, SCHIRM * s)
 {
- int i, j, k;
- unsigned char *str;
+  int i, j, k;
+  unsigned char *str;
 
- if (b->b.y == 0)
-  return(0);
- j = b->b.y;
- do
- {
-  j--;
-  for (i = 0, k = 0;
-    k < b->bf[j].len && (isspace(b->bf[j].s[k]) || b->bf[j].s[i] == '{'); k++)
-   i = b->bf[j].s[k] == '\t' ? (i / b->cn->tabn + 1) * b->cn->tabn : i + 1;
- } while (j > 0 && b->bf[j].s[k] == '#');
- if (k == b->bf[j].len && k > 0 && b->bf[j].s[k-1] == '{')
-  i--;
- if (i > 0)
- {
-  str = malloc(i * sizeof(char));
-  for (j = 0; j < i; j++)
-   str[j] = ' ';
-  e_ins_nchar(b, s, str, 0, b->b.y, i);
-  b->b.x = i;
-  free(str);
- }
- return(i);
+  if (b->b.y == 0)
+    return (0);
+  j = b->b.y;
+  do
+    {
+      j--;
+      for (i = 0, k = 0;
+	   k < b->bf[j].len && (isspace (b->bf[j].s[k])
+				|| b->bf[j].s[i] == '{'); k++)
+	i =
+	  b->bf[j].s[k] == '\t' ? (i / b->cn->tabn + 1) * b->cn->tabn : i + 1;
+    }
+  while (j > 0 && b->bf[j].s[k] == '#');
+  if (k == b->bf[j].len && k > 0 && b->bf[j].s[k - 1] == '{')
+    i--;
+  if (i > 0)
+    {
+      str = malloc (i * sizeof (char));
+      for (j = 0; j < i; j++)
+	str[j] = ' ';
+      e_ins_nchar (b, s, str, 0, b->b.y, i);
+      b->b.x = i;
+      free (str);
+    }
+  return (i);
 }
 
 /*   write n blanks */
-int e_blk(int anz, int xa, int ya, int col)
+int
+e_blk (int anz, int xa, int ya, int col)
 {
- for (anz--; anz >= 0 ; anz--)
-  e_pr_char(xa+anz, ya, ' ', col);
- return(anz);
+  for (anz--; anz >= 0; anz--)
+    e_pr_char (xa + anz, ya, ' ', col);
+  return (anz);
 }
 
 /*       insert Carriage Return     */
-int e_car_ret(BUFFER *b, SCHIRM *s)
+int
+e_car_ret (BUFFER * b, SCHIRM * s)
 {
-   int len, i;
-   len = b->bf[b->b.y].len;
-   e_add_undo('a', b, b->b.x, b->b.y, 1);
-   (b->f->save)++;
-   if(b->b.x != len || *(b->bf[b->b.y].s+len) != '\0')
-   {  e_new_line(b->b.y+1, b);
-      for(i=0; i <= len - b->b.x; i++)
-              *(b->bf[b->b.y+1].s + i) = *(b->bf[b->b.y].s+b->b.x+i);
-      *(b->bf[b->b.y+1].s+i)='\0';
-      b->bf[b->b.y+1].len = e_str_len(b->bf[b->b.y+1].s);
-      b->bf[b->b.y+1].nrc = strlen((const char *)b->bf[b->b.y+1].s);
-      if(s->mark_begin.y > b->b.y) (s->mark_begin.y)++;
-      else if(s->mark_begin.y == b->b.y && s->mark_begin.x > b->b.x)
-      {  (s->mark_begin.y)++;  (s->mark_begin.x) -= (b->b.x);  }
-      if(s->mark_end.y > b->b.y) (s->mark_end.y)++;
-      else if(s->mark_end.y == b->b.y && s->mark_end.x > b->b.x)
-      {  (s->mark_end.y)++;  (s->mark_end.x) -= (b->b.x);  }
-   }
-   *(b->bf[b->b.y].s+b->b.x) = WPE_WR;
-   *(b->bf[b->b.y].s+b->b.x+1) = '\0';
-   b->bf[b->b.y].len = e_str_len(b->bf[b->b.y].s);
-   b->bf[b->b.y].nrc = strlen((const char *)b->bf[b->b.y].s);
-   sc_txt_3(b->b.y, b, 1);
-/***************************/   
-   if(b->b.x>0) e_brk_recalc(b->f,b->b.y+1,1);
-   else e_brk_recalc(b->f,b->b.y,1);
-/***************************/   
-   if (b->b.y < b->mxlines - 1)
-   {  (b->b.y)++;
+  int len, i;
+  len = b->bf[b->b.y].len;
+  e_add_undo ('a', b, b->b.x, b->b.y, 1);
+  (b->f->save)++;
+  if (b->b.x != len || *(b->bf[b->b.y].s + len) != '\0')
+    {
+      e_new_line (b->b.y + 1, b);
+      for (i = 0; i <= len - b->b.x; i++)
+	*(b->bf[b->b.y + 1].s + i) = *(b->bf[b->b.y].s + b->b.x + i);
+      *(b->bf[b->b.y + 1].s + i) = '\0';
+      b->bf[b->b.y + 1].len = e_str_len (b->bf[b->b.y + 1].s);
+      b->bf[b->b.y + 1].nrc = strlen ((const char *) b->bf[b->b.y + 1].s);
+      if (s->mark_begin.y > b->b.y)
+	(s->mark_begin.y)++;
+      else if (s->mark_begin.y == b->b.y && s->mark_begin.x > b->b.x)
+	{
+	  (s->mark_begin.y)++;
+	  (s->mark_begin.x) -= (b->b.x);
+	}
+      if (s->mark_end.y > b->b.y)
+	(s->mark_end.y)++;
+      else if (s->mark_end.y == b->b.y && s->mark_end.x > b->b.x)
+	{
+	  (s->mark_end.y)++;
+	  (s->mark_end.x) -= (b->b.x);
+	}
+    }
+  *(b->bf[b->b.y].s + b->b.x) = WPE_WR;
+  *(b->bf[b->b.y].s + b->b.x + 1) = '\0';
+  b->bf[b->b.y].len = e_str_len (b->bf[b->b.y].s);
+  b->bf[b->b.y].nrc = strlen ((const char *) b->bf[b->b.y].s);
+  sc_txt_3 (b->b.y, b, 1);
+/***************************/
+  if (b->b.x > 0)
+    e_brk_recalc (b->f, b->b.y + 1, 1);
+  else
+    e_brk_recalc (b->f, b->b.y, 1);
+/***************************/
+  if (b->b.y < b->mxlines - 1)
+    {
+      (b->b.y)++;
       b->b.x = 0;
-   }
-   if(b->f->flg & 1) e_car_a_ind(b, s);
-   return(b->b.y);
+    }
+  if (b->f->flg & 1)
+    e_car_a_ind (b, s);
+  return (b->b.y);
 }
 
 /*   cursor placement */
-void e_cursor(FENSTER *f, int sw)
+void
+e_cursor (FENSTER * f, int sw)
 {
- BUFFER *b = f->b;
- SCHIRM *s = f->s;
- static int iold = 0, jold = 0;
- int i, j;
+  BUFFER *b = f->b;
+  SCHIRM *s = f->s;
+  static int iold = 0, jold = 0;
+  int i, j;
 
- if (!DTMD_ISTEXT(f->dtmd)) return;
- if (b->b.y > b->mxlines-1) b->b.y = b->mxlines-1;
- if (b->b.y < 0) b->b.y = 0;
- if (b->b.x < 0) b->b.x = 0;
- if (b->mxlines==0) b->b.x=0; /* the else branch needs b->b.y < b->mxlines, which is not true for b->mxlines==0 */
- else if (b->b.x > b->bf[b->b.y].len) b->b.x = b->bf[b->b.y].len;
- for (i = j = 0; i < b->b.x; i++)
- {
-  if (*(b->bf[b->b.y].s + i) == WPE_TAB)
-   j += (f->ed->tabn - ((j + i) % f->ed->tabn) - 1);
-  else if (!WpeIsXwin() && ((unsigned char) *(b->bf[b->b.y].s + i)) > 126)
-  {
-   j++;
-   if (((unsigned char) *(b->bf[b->b.y].s + i)) < 128 + ' ') j++;
-  }
-  else if (*(b->bf[b->b.y].s + i) < ' ') j++;
-  if (f->dtmd == DTMD_HELP)
-  {
-   if (b->bf[b->b.y].s[i] == HBG || b->bf[b->b.y].s[i] == HED ||
-     b->bf[b->b.y].s[i] == HHD || b->bf[b->b.y].s[i] == HFE ||
-     b->bf[b->b.y].s[i] == HFB || b->bf[b->b.y].s[i] == HBB ||
-     b->bf[b->b.y].s[i] == HNF)
-    j -= 2;
-  }
- }
- if (b->b.y - s->c.y < 0 || b->b.y - s->c.y >= NUM_LINES_ON_SCREEN - 1 ||
-   s->c.y < 0 || s->c.y >= b->mxlines ||
-   b->b.x + j - s->c.x < 0 ||
-   b->b.x + j- s->c.x >= NUM_COLS_ON_SCREEN - 1 )
- {
+  if (!DTMD_ISTEXT (f->dtmd))
+    return;
+  if (b->b.y > b->mxlines - 1)
+    b->b.y = b->mxlines - 1;
+  if (b->b.y < 0)
+    b->b.y = 0;
+  if (b->b.x < 0)
+    b->b.x = 0;
+  if (b->mxlines == 0)
+    b->b.x = 0;			/* the else branch needs b->b.y < b->mxlines, which is not true for b->mxlines==0 */
+  else if (b->b.x > b->bf[b->b.y].len)
+    b->b.x = b->bf[b->b.y].len;
+  for (i = j = 0; i < b->b.x; i++)
+    {
+      if (*(b->bf[b->b.y].s + i) == WPE_TAB)
+	j += (f->ed->tabn - ((j + i) % f->ed->tabn) - 1);
+      else if (!WpeIsXwin ()
+	       && ((unsigned char) *(b->bf[b->b.y].s + i)) > 126)
+	{
+	  j++;
+	  if (((unsigned char) *(b->bf[b->b.y].s + i)) < 128 + ' ')
+	    j++;
+	}
+      else if (*(b->bf[b->b.y].s + i) < ' ')
+	j++;
+      if (f->dtmd == DTMD_HELP)
+	{
+	  if (b->bf[b->b.y].s[i] == HBG || b->bf[b->b.y].s[i] == HED ||
+	      b->bf[b->b.y].s[i] == HHD || b->bf[b->b.y].s[i] == HFE ||
+	      b->bf[b->b.y].s[i] == HFB || b->bf[b->b.y].s[i] == HBB ||
+	      b->bf[b->b.y].s[i] == HNF)
+	    j -= 2;
+	}
+    }
+  if (b->b.y - s->c.y < 0 || b->b.y - s->c.y >= NUM_LINES_ON_SCREEN - 1 ||
+      s->c.y < 0 || s->c.y >= b->mxlines ||
+      b->b.x + j - s->c.x < 0 ||
+      b->b.x + j - s->c.x >= NUM_COLS_ON_SCREEN - 1)
+    {
 #if defined(UNIX)
       /*if(b->b.y - s->c.y < 0) s->c.y = b->b.y - (f->e.y - f->a.y)/2;
-      else if(b->b.y - s->c.y >= f->e.y - f->a.y -1)
-      s->c.y = b->b.y - (f->e.y - f->a.y)/2;*/
-  if (b->b.y - s->c.y < -1)
-  {
-   s->c.y = b->b.y - (NUM_LINES_ON_SCREEN)/2;
-  }
-  else if (b->b.y - s->c.y == -1)
-  {
-   s->c.y -= 1;
-  }
-  else if (b->b.y - s->c.y > NUM_LINES_ON_SCREEN -1)
-  {
-   s->c.y = b->b.y - (NUM_LINES_ON_SCREEN)/2;
-  }
-  else if (b->b.y - s->c.y == NUM_LINES_ON_SCREEN -1)
-  {
-   s->c.y += 1;
-  }
+         else if(b->b.y - s->c.y >= f->e.y - f->a.y -1)
+         s->c.y = b->b.y - (f->e.y - f->a.y)/2; */
+      if (b->b.y - s->c.y < -1)
+	{
+	  s->c.y = b->b.y - (NUM_LINES_ON_SCREEN) / 2;
+	}
+      else if (b->b.y - s->c.y == -1)
+	{
+	  s->c.y -= 1;
+	}
+      else if (b->b.y - s->c.y > NUM_LINES_ON_SCREEN - 1)
+	{
+	  s->c.y = b->b.y - (NUM_LINES_ON_SCREEN) / 2;
+	}
+      else if (b->b.y - s->c.y == NUM_LINES_ON_SCREEN - 1)
+	{
+	  s->c.y += 1;
+	}
 #else
-  if (b->b.y - s->c.y < 0) s->c.y = b->b.y;
-  else if (b->b.y - s->c.y >= NUM_LINES_ON_SCREEN -1)
-   (s->c.y) = b->b.y - f->e.y + f->a.y + 2;
+      if (b->b.y - s->c.y < 0)
+	s->c.y = b->b.y;
+      else if (b->b.y - s->c.y >= NUM_LINES_ON_SCREEN - 1)
+	(s->c.y) = b->b.y - f->e.y + f->a.y + 2;
 #endif
-  if (s->c.y >= b->mxlines - 1) s->c.y = b->mxlines - 2 ;
-  if (s->c.y < 0) s->c.y = 0 ;
+      if (s->c.y >= b->mxlines - 1)
+	s->c.y = b->mxlines - 2;
+      if (s->c.y < 0)
+	s->c.y = 0;
 
-  if (b->b.x + j - s->c.x < 0)
-   (s->c.x) = b->b.x + j - (NUM_COLS_ON_SCREEN)/2 ;
-  else if (b->b.x + j - s->c.x >= NUM_COLS_ON_SCREEN - 1)
-   (s->c.x) = b->b.x + j - (NUM_COLS_ON_SCREEN)/2 ;
-  if (s->c.x < 0) s->c.x = 0 ;
-  else if (s->c.x >= b->bf[b->b.y].len + j) s->c.x = b->bf[b->b.y].len + j;
-  e_schirm(f, sw);
- }
- if (s->fa.y == -1) {  e_schirm(f, sw);  s->fa.y--;  }
- else if (s->fa.y > -1) s->fa.y = -1;
- if (sw != 0)
- {
-  iold = e_lst_zeichen(f->e.x, f->a.y+1, f->e.y-f->a.y-1, 0,
-    f->fb->em.fb, b->mxlines, iold, b->b.y);
-  jold = e_lst_zeichen(f->a.x+19, f->e.y, f->e.x-f->a.x-20, 1,
-    f->fb->em.fb, b->mx.x, jold, b->b.x);
- }
- b->cl = b->b.x+j;
- fk_locate(f->a.x+b->b.x-s->c.x+j+1, f->a.y+b->b.y-s->c.y+1);
+      if (b->b.x + j - s->c.x < 0)
+	(s->c.x) = b->b.x + j - (NUM_COLS_ON_SCREEN) / 2;
+      else if (b->b.x + j - s->c.x >= NUM_COLS_ON_SCREEN - 1)
+	(s->c.x) = b->b.x + j - (NUM_COLS_ON_SCREEN) / 2;
+      if (s->c.x < 0)
+	s->c.x = 0;
+      else if (s->c.x >= b->bf[b->b.y].len + j)
+	s->c.x = b->bf[b->b.y].len + j;
+      e_schirm (f, sw);
+    }
+  if (s->fa.y == -1)
+    {
+      e_schirm (f, sw);
+      s->fa.y--;
+    }
+  else if (s->fa.y > -1)
+    s->fa.y = -1;
+  if (sw != 0)
+    {
+      iold = e_lst_zeichen (f->e.x, f->a.y + 1, f->e.y - f->a.y - 1, 0,
+			    f->fb->em.fb, b->mxlines, iold, b->b.y);
+      jold = e_lst_zeichen (f->a.x + 19, f->e.y, f->e.x - f->a.x - 20, 1,
+			    f->fb->em.fb, b->mx.x, jold, b->b.x);
+    }
+  b->cl = b->b.x + j;
+  fk_locate (f->a.x + b->b.x - s->c.x + j + 1, f->a.y + b->b.y - s->c.y + 1);
 }
 
 /*   delete one line */
-int e_del_line(int yd, BUFFER *b, SCHIRM *s)
+int
+e_del_line (int yd, BUFFER * b, SCHIRM * s)
 {
- int i;
+  int i;
 
- if (b->mxlines == 1)
- {
-  *(b->bf[0].s) = '\0';
-  b->bf[0].nrc = b->bf[0].len = 0;
- }
- else
- {
-  e_add_undo('l', b, 0, yd, 1);
-  (b->mxlines)--;
-  for (i = yd; i < b->mxlines; i++)
-   b->bf[i] = b->bf[i+1];
-  if (s->mark_begin.y > yd)
-   (s->mark_begin.y)--;
-  else if (s->mark_begin.y == yd)
-   (s->mark_begin.x) = 0;
-  if (s->mark_end.y > yd)
-   (s->mark_end.y)--;
-  else if (s->mark_end.y == yd)
-  {
-   (s->mark_end.y)--;
-   s->mark_end.x = b->bf[yd-1].len;
-  }
- }
- sc_txt_3(yd, b, -1);
- if (b->f)
-  (b->f->save) += 10;
-/*******************************/   
- e_brk_recalc(b->f,yd,-1);
-/*******************************/   
- return(b->mxlines);
+  if (b->mxlines == 1)
+    {
+      *(b->bf[0].s) = '\0';
+      b->bf[0].nrc = b->bf[0].len = 0;
+    }
+  else
+    {
+      e_add_undo ('l', b, 0, yd, 1);
+      (b->mxlines)--;
+      for (i = yd; i < b->mxlines; i++)
+	b->bf[i] = b->bf[i + 1];
+      if (s->mark_begin.y > yd)
+	(s->mark_begin.y)--;
+      else if (s->mark_begin.y == yd)
+	(s->mark_begin.x) = 0;
+      if (s->mark_end.y > yd)
+	(s->mark_end.y)--;
+      else if (s->mark_end.y == yd)
+	{
+	  (s->mark_end.y)--;
+	  s->mark_end.x = b->bf[yd - 1].len;
+	}
+    }
+  sc_txt_3 (yd, b, -1);
+  if (b->f)
+    (b->f->save) += 10;
+/*******************************/
+  e_brk_recalc (b->f, yd, -1);
+/*******************************/
+  return (b->mxlines);
 }
 
 /*   delete N chars from buffer */
-int e_del_nchar(BUFFER *b, SCHIRM *s, int x, int y, int n)
+int
+e_del_nchar (BUFFER * b, SCHIRM * s, int x, int y, int n)
 {
- FENSTER *f = WpeEditor->f[WpeEditor->mxedt];
- int len, i, j;
+  FENSTER *f = WpeEditor->f[WpeEditor->mxedt];
+  int len, i, j;
 
- (f->save) += n;
- e_add_undo('r', b, x, y, n);
- e_undo_sw++;
- len = b->bf[y].len;
- if (*(b->bf[y].s+len) == WPE_WR) len++;
- for (j = x; j <= len - n; ++j) *(b->bf[y].s+j) = *(b->bf[y].s+j+n)
-  ;
- if (s->mark_begin.y == y && s->mark_begin.x > x)
-  s->mark_begin.x = (s->mark_begin.x-n > x) ? s->mark_begin.x-n : x;
- if (s->mark_end.y == y && s->mark_end.x > x)
-  s->mark_end.x = (s->mark_end.x-n > x) ? s->mark_end.x-n : x;
+  (f->save) += n;
+  e_add_undo ('r', b, x, y, n);
+  e_undo_sw++;
+  len = b->bf[y].len;
+  if (*(b->bf[y].s + len) == WPE_WR)
+    len++;
+  for (j = x; j <= len - n; ++j)
+    *(b->bf[y].s + j) = *(b->bf[y].s + j + n);
+  if (s->mark_begin.y == y && s->mark_begin.x > x)
+    s->mark_begin.x = (s->mark_begin.x - n > x) ? s->mark_begin.x - n : x;
+  if (s->mark_end.y == y && s->mark_end.x > x)
+    s->mark_end.x = (s->mark_end.x - n > x) ? s->mark_end.x - n : x;
 
- if (len <= n) e_del_line(y, b, s);
- else if (y < b->mxlines - 1 && *(b->bf[y].s+len-n-1) != WPE_WR )
- {
-  if (b->mx.x+n-len > b->bf[y+1].len)
-   i = b->bf[y+1].len;
-  else
-   i = e_su_rblk(b->mx.x+n-len, b->bf[y+1].s);
-  if (b->bf[y+1].s[i] == WPE_WR) i++;
-  if (i > 0)
-  {
-   for (j = 0; j < i; ++j)
-    *(b->bf[y].s+len-n+j) = *(b->bf[y+1].s+j);
-   *(b->bf[y].s+len-n+i) = '\0';
-   if (s->mark_begin.y == y+1 && s->mark_begin.x <= i)
-   {  s->mark_begin.y--;  s->mark_begin.x += (len-n);  }
-   if (s->mark_end.y == y+1 && s->mark_end.x <= i)
-   {  s->mark_end.y--;  s->mark_end.x += (len-n);  }
-   e_del_nchar(b, s, 0, y+1, i);
-  }
- }
- if (y < b->mxlines)
- {
-  b->bf[y].len = e_str_len(b->bf[y].s);
-  b->bf[y].nrc = strlen((const char *)b->bf[y].s);
- }
- e_undo_sw--;
- sc_txt_4(y, b, 0);
- return(x+n);
+  if (len <= n)
+    e_del_line (y, b, s);
+  else if (y < b->mxlines - 1 && *(b->bf[y].s + len - n - 1) != WPE_WR)
+    {
+      if (b->mx.x + n - len > b->bf[y + 1].len)
+	i = b->bf[y + 1].len;
+      else
+	i = e_su_rblk (b->mx.x + n - len, b->bf[y + 1].s);
+      if (b->bf[y + 1].s[i] == WPE_WR)
+	i++;
+      if (i > 0)
+	{
+	  for (j = 0; j < i; ++j)
+	    *(b->bf[y].s + len - n + j) = *(b->bf[y + 1].s + j);
+	  *(b->bf[y].s + len - n + i) = '\0';
+	  if (s->mark_begin.y == y + 1 && s->mark_begin.x <= i)
+	    {
+	      s->mark_begin.y--;
+	      s->mark_begin.x += (len - n);
+	    }
+	  if (s->mark_end.y == y + 1 && s->mark_end.x <= i)
+	    {
+	      s->mark_end.y--;
+	      s->mark_end.x += (len - n);
+	    }
+	  e_del_nchar (b, s, 0, y + 1, i);
+	}
+    }
+  if (y < b->mxlines)
+    {
+      b->bf[y].len = e_str_len (b->bf[y].s);
+      b->bf[y].nrc = strlen ((const char *) b->bf[y].s);
+    }
+  e_undo_sw--;
+  sc_txt_4 (y, b, 0);
+  return (x + n);
 }
 
 /*   insert N chars in buffer */
-int e_ins_nchar(BUFFER *b, SCHIRM *sch, unsigned char *s, int xa, int ya,
-  int n)
+int
+e_ins_nchar (BUFFER * b, SCHIRM * sch, unsigned char *s, int xa, int ya,
+	     int n)
 {
- FENSTER *f = WpeEditor->f[WpeEditor->mxedt];
- int i, j;
+  FENSTER *f = WpeEditor->f[WpeEditor->mxedt];
+  int i, j;
 
- (f->save) += n;
- e_add_undo('a', b, xa, ya, n);
- e_undo_sw++;
- if (b->bf[ya].len+n >= b->mx.x-1)
- {
-  if (xa < b->bf[ya].len)
-  {
-   i = b->mx.x-n-1;
-   if (i >= b->bf[ya].len-1)
-    i = b->bf[ya].len-1;
-  }
-  else
-  {
-   for (; xa < b->mx.x-1; xa++, s++, n--)
-   {
-    *(b->bf[ya].s + xa + 1) = *(b->bf[ya].s + xa);
-    *(b->bf[ya].s + xa) = *s;
-   }
-   *(b->bf[ya].s + xa + 1) = '\0';
-   i = b->mx.x;
-   b->bf[ya].len = e_str_len(b->bf[ya].s);
-   b->bf[ya].nrc = strlen((const char *)b->bf[ya].s);
-  }
-  for (; i > 0 && *(b->bf[ya].s+i) != ' ' && *(b->bf[ya].s+i) != '-'; i--);
-  if (i == 0)
-  {
-   if (s[n-1] != ' ' && s[n-1] != '-')
-    i = b->bf[ya].len - 2;
-   else
-    i--;
-  }
-  if (*(b->bf[ya].s+b->bf[ya].len) == WPE_WR || ya == b->mxlines)
-  {
-   e_new_line(ya+1, b);
-   if (sch->mark_begin.y > ya)
-    (sch->mark_begin.y)++;
-   else if(sch->mark_begin.y == ya)
-   {
-    if (sch->mark_begin.x > i)
+  (f->save) += n;
+  e_add_undo ('a', b, xa, ya, n);
+  e_undo_sw++;
+  if (b->bf[ya].len + n >= b->mx.x - 1)
     {
-     (sch->mark_begin.y)++;
-     (sch->mark_begin.x) -= (i+1);
-    }
-    else if (sch->mark_begin.x >= xa)
-     sch->mark_begin.x += n;
-   }
-   if (sch->mark_end.y > ya)
-    (sch->mark_end.y)++;
-   else if(sch->mark_end.y == ya)
-   {
-    if(sch->mark_end.x > i)
-    {
-     (sch->mark_end.y)++;
-     (sch->mark_end.x) -= (i+1);
-    }
-    else if(sch->mark_end.x >= xa)
-     sch->mark_end.x += n;
-   }
-   for (j = i+1; *(b->bf[ya].s+j) != WPE_WR && *(b->bf[ya].s+j) != '\0'; j++)
-    *(b->bf[ya+1].s+j-i-1) = *(b->bf[ya].s+j);
-   *(b->bf[ya+1].s+j-i-1) = WPE_WR;
-   b->bf[ya+1].len = e_str_len(b->bf[ya+1].s);
-   b->bf[ya+1].nrc = strlen((const char *)b->bf[ya+1].s);
-   sc_txt_4(ya, b, 1);
-  }
-  else
-  {
-   e_ins_nchar(b, sch, b->bf[ya].s+i+1, 0, ya+1, b->bf[ya].len-i-1);
-   if (sch->mark_begin.y == ya)
-   {
-    if (sch->mark_begin.x > i)
-    {
-     (sch->mark_begin.y)++;
-     (sch->mark_begin.x) -= (i+1);
-    }
-    else if (sch->mark_begin.x >= xa)
-     sch->mark_begin.x += n;
-   }
-   if (sch->mark_end.y == ya)
-   {
-    if (sch->mark_end.x > i)
-    {
-     (sch->mark_end.y)++;
-     (sch->mark_end.x) -= (i+1);
-    }
-    else if (sch->mark_end.x >= xa)
-     sch->mark_end.x += n;
-   }
-  }
+      if (xa < b->bf[ya].len)
+	{
+	  i = b->mx.x - n - 1;
+	  if (i >= b->bf[ya].len - 1)
+	    i = b->bf[ya].len - 1;
+	}
+      else
+	{
+	  for (; xa < b->mx.x - 1; xa++, s++, n--)
+	    {
+	      *(b->bf[ya].s + xa + 1) = *(b->bf[ya].s + xa);
+	      *(b->bf[ya].s + xa) = *s;
+	    }
+	  *(b->bf[ya].s + xa + 1) = '\0';
+	  i = b->mx.x;
+	  b->bf[ya].len = e_str_len (b->bf[ya].s);
+	  b->bf[ya].nrc = strlen ((const char *) b->bf[ya].s);
+	}
+      for (; i > 0 && *(b->bf[ya].s + i) != ' ' && *(b->bf[ya].s + i) != '-';
+	   i--);
+      if (i == 0)
+	{
+	  if (s[n - 1] != ' ' && s[n - 1] != '-')
+	    i = b->bf[ya].len - 2;
+	  else
+	    i--;
+	}
+      if (*(b->bf[ya].s + b->bf[ya].len) == WPE_WR || ya == b->mxlines)
+	{
+	  e_new_line (ya + 1, b);
+	  if (sch->mark_begin.y > ya)
+	    (sch->mark_begin.y)++;
+	  else if (sch->mark_begin.y == ya)
+	    {
+	      if (sch->mark_begin.x > i)
+		{
+		  (sch->mark_begin.y)++;
+		  (sch->mark_begin.x) -= (i + 1);
+		}
+	      else if (sch->mark_begin.x >= xa)
+		sch->mark_begin.x += n;
+	    }
+	  if (sch->mark_end.y > ya)
+	    (sch->mark_end.y)++;
+	  else if (sch->mark_end.y == ya)
+	    {
+	      if (sch->mark_end.x > i)
+		{
+		  (sch->mark_end.y)++;
+		  (sch->mark_end.x) -= (i + 1);
+		}
+	      else if (sch->mark_end.x >= xa)
+		sch->mark_end.x += n;
+	    }
+	  for (j = i + 1;
+	       *(b->bf[ya].s + j) != WPE_WR && *(b->bf[ya].s + j) != '\0';
+	       j++)
+	    *(b->bf[ya + 1].s + j - i - 1) = *(b->bf[ya].s + j);
+	  *(b->bf[ya + 1].s + j - i - 1) = WPE_WR;
+	  b->bf[ya + 1].len = e_str_len (b->bf[ya + 1].s);
+	  b->bf[ya + 1].nrc = strlen ((const char *) b->bf[ya + 1].s);
+	  sc_txt_4 (ya, b, 1);
+	}
+      else
+	{
+	  e_ins_nchar (b, sch, b->bf[ya].s + i + 1, 0, ya + 1,
+		       b->bf[ya].len - i - 1);
+	  if (sch->mark_begin.y == ya)
+	    {
+	      if (sch->mark_begin.x > i)
+		{
+		  (sch->mark_begin.y)++;
+		  (sch->mark_begin.x) -= (i + 1);
+		}
+	      else if (sch->mark_begin.x >= xa)
+		sch->mark_begin.x += n;
+	    }
+	  if (sch->mark_end.y == ya)
+	    {
+	      if (sch->mark_end.x > i)
+		{
+		  (sch->mark_end.y)++;
+		  (sch->mark_end.x) -= (i + 1);
+		}
+	      else if (sch->mark_end.x >= xa)
+		sch->mark_end.x += n;
+	    }
+	}
 /*	 if(*(b->bf[ya].s+i) == ' ') *(b->bf[ya].s+i) = '\0';
          else
 */
-  *(b->bf[ya].s+i+1) = '\0';
-  b->bf[ya].len = e_str_len(b->bf[ya].s);
-  b->bf[ya].nrc = strlen((const char *)b->bf[ya].s);
-  if (xa > b->bf[ya].len)
-  {
-   xa -= (b->bf[ya].len);
-   ya++;
-   b->bf[ya].len = e_str_len(b->bf[ya].s);
-   b->bf[ya].nrc = strlen((const char *)b->bf[ya].s);
-   if (sch->mark_begin.y == ya && sch->mark_begin.x >= xa)
-    sch->mark_begin.x += n;
-   if (sch->mark_end.y == ya && sch->mark_end.x >= xa)
-    sch->mark_end.x += n;
-  }
- }
- else
- {
-  if (sch->mark_begin.y == ya && sch->mark_begin.x >= xa)
-   sch->mark_begin.x += n;
-  if(sch->mark_end.y == ya && sch->mark_end.x >= xa)
-   sch->mark_end.x += n;
- }
- for (j = b->bf[ya].len; j >= xa; --j)
-  *(b->bf[ya].s+j+n) = *(b->bf[ya].s+j);
- for (j = 0; j < n; ++j)
-  *(b->bf[ya].s+xa+j) = *(s+j);
- if (b->bf[ya].s[b->bf[ya].len] == WPE_WR)
-  b->bf[ya].s[b->bf[ya].len+1] = '\0';
- b->b.x = xa + n;
- b->b.y = ya;
- b->bf[ya].len = e_str_len(b->bf[ya].s);
- b->bf[ya].nrc = strlen((const char *)b->bf[ya].s);
- e_undo_sw--;
- sc_txt_4(ya, b, 0);
- return(xa+n);
+      *(b->bf[ya].s + i + 1) = '\0';
+      b->bf[ya].len = e_str_len (b->bf[ya].s);
+      b->bf[ya].nrc = strlen ((const char *) b->bf[ya].s);
+      if (xa > b->bf[ya].len)
+	{
+	  xa -= (b->bf[ya].len);
+	  ya++;
+	  b->bf[ya].len = e_str_len (b->bf[ya].s);
+	  b->bf[ya].nrc = strlen ((const char *) b->bf[ya].s);
+	  if (sch->mark_begin.y == ya && sch->mark_begin.x >= xa)
+	    sch->mark_begin.x += n;
+	  if (sch->mark_end.y == ya && sch->mark_end.x >= xa)
+	    sch->mark_end.x += n;
+	}
+    }
+  else
+    {
+      if (sch->mark_begin.y == ya && sch->mark_begin.x >= xa)
+	sch->mark_begin.x += n;
+      if (sch->mark_end.y == ya && sch->mark_end.x >= xa)
+	sch->mark_end.x += n;
+    }
+  for (j = b->bf[ya].len; j >= xa; --j)
+    *(b->bf[ya].s + j + n) = *(b->bf[ya].s + j);
+  for (j = 0; j < n; ++j)
+    *(b->bf[ya].s + xa + j) = *(s + j);
+  if (b->bf[ya].s[b->bf[ya].len] == WPE_WR)
+    b->bf[ya].s[b->bf[ya].len + 1] = '\0';
+  b->b.x = xa + n;
+  b->b.y = ya;
+  b->bf[ya].len = e_str_len (b->bf[ya].s);
+  b->bf[ya].nrc = strlen ((const char *) b->bf[ya].s);
+  e_undo_sw--;
+  sc_txt_4 (ya, b, 0);
+  return (xa + n);
 }
 
 /*   insert new line */
-int e_new_line(int yd, BUFFER *b)
+int
+e_new_line (int yd, BUFFER * b)
 {
- int i;
+  int i;
 
- if (b->mxlines > b->mx.y-2)
- {
-  b->mx.y += MAXLINES;
-  if ((b->bf = realloc(b->bf, b->mx.y * sizeof(STRING))) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, b->fb);
-  if (b->f->c_sw)
-   b->f->c_sw = realloc(b->f->c_sw , b->mx.y * sizeof(int));
- }
- for (i = b->mxlines-1; i >= yd; i--)
- {
-  b->bf[i+1] = b->bf[i];
- }
- (b->mxlines)++;
- b->bf[yd].s = malloc(b->mx.x+1);
- if (b->bf[yd].s == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, b->fb);
- *(b->bf[yd].s) = '\0';
- b->bf[yd].len = 0;
- b->bf[yd].nrc = 0;
- return(b->mxlines);
+  if (b->mxlines > b->mx.y - 2)
+    {
+      b->mx.y += MAXLINES;
+      if ((b->bf = realloc (b->bf, b->mx.y * sizeof (STRING))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, b->fb);
+      if (b->f->c_sw)
+	b->f->c_sw = realloc (b->f->c_sw, b->mx.y * sizeof (int));
+    }
+  for (i = b->mxlines - 1; i >= yd; i--)
+    {
+      b->bf[i + 1] = b->bf[i];
+    }
+  (b->mxlines)++;
+  b->bf[yd].s = malloc (b->mx.x + 1);
+  if (b->bf[yd].s == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, b->fb);
+  *(b->bf[yd].s) = '\0';
+  b->bf[yd].len = 0;
+  b->bf[yd].nrc = 0;
+  return (b->mxlines);
 }
 
 /*     Overwriting of a character       */
-int e_put_char(int c, BUFFER *b, SCHIRM *s)
+int
+e_put_char (int c, BUFFER * b, SCHIRM * s)
 {
- unsigned char cc = c;
+  unsigned char cc = c;
 
- if (b->b.x == b->bf[b->b.y].len)
-  e_ins_nchar(b, s, &cc, b->b.x, b->b.y, 1);
- else
- {
-  e_add_undo('p', b, b->b.x, b->b.y, 1);
-  (b->f->save)++;
-  *(b->bf[b->b.y].s+b->b.x) = c;
- }
- (b->b.x)++;
- return(b->b.x);
+  if (b->b.x == b->bf[b->b.y].len)
+    e_ins_nchar (b, s, &cc, b->b.x, b->b.y, 1);
+  else
+    {
+      e_add_undo ('p', b, b->b.x, b->b.y, 1);
+      (b->f->save)++;
+      *(b->bf[b->b.y].s + b->b.x) = c;
+    }
+  (b->b.x)++;
+  return (b->b.x);
 }
 
 /*   search right (left end of word) */
 /** FIXME: is unsigned char * really necessary? Do we expect value > 127? */
-int e_su_lblk(int xa, unsigned char *s)
+int
+e_su_lblk (int xa, unsigned char *s)
 {
- int len = strlen((const char *)s);
+  int len = strlen ((const char *) s);
 
- if (xa >= len)
-  xa = len - 1;
- for (; xa < len  && isalnum1(s[xa]); xa++)
-  ;
- for (; xa < len && !isalnum1(s[xa]); xa++)
-  ;
- return(xa);
+  if (xa >= len)
+    xa = len - 1;
+  for (; xa < len && isalnum1 (s[xa]); xa++)
+    ;
+  for (; xa < len && !isalnum1 (s[xa]); xa++)
+    ;
+  return (xa);
 }
 
 /*     Search left (left end of word)     */
 /** FIXME: is unsigned char * really necessary? Do we expect value > 127? */
-int e_su_rblk(int xa, unsigned char *s)
+int
+e_su_rblk (int xa, unsigned char *s)
 {
- int len = strlen((const char *)s);
+  int len = strlen ((const char *) s);
 
- if (xa <= 0)
-  return(xa);
- if (xa > len)
-  xa = len;
- for (xa--; xa > 0 && !isalnum1(s[xa]); xa--)
-  ;
- if (!xa)
-  return(xa);
- for (; xa > 0 && isalnum1(s[xa]); xa--)
-  ;
- return(!xa ? xa : xa + 1);
+  if (xa <= 0)
+    return (xa);
+  if (xa > len)
+    xa = len;
+  for (xa--; xa > 0 && !isalnum1 (s[xa]); xa--)
+    ;
+  if (!xa)
+    return (xa);
+  for (; xa > 0 && isalnum1 (s[xa]); xa--)
+    ;
+  return (!xa ? xa : xa + 1);
 }
 
 /* Prints out the line number and column of cursor */
-void e_zlsplt(FENSTER *f)
+void
+e_zlsplt (FENSTER * f)
 {
- char str[20];
+  char str[20];
 
- if (!DTMD_ISTEXT(f->dtmd))
-  return;
- sprintf(str,"%5d:%-4d", f->b->b.y + 1, f->b->cl + 1);
- e_puts(str,f->a.x+5,f->e.y,f->fb->er.fb);
- if (f->save)
-  e_pr_char(f->a.x+3, f->e.y, '*', f->fb->er.fb);
- else
-  e_pr_char(f->a.x+3, f->e.y, ' ', f->fb->er.fb);
+  if (!DTMD_ISTEXT (f->dtmd))
+    return;
+  sprintf (str, "%5d:%-4d", f->b->b.y + 1, f->b->cl + 1);
+  e_puts (str, f->a.x + 5, f->e.y, f->fb->er.fb);
+  if (f->save)
+    e_pr_char (f->a.x + 3, f->e.y, '*', f->fb->er.fb);
+  else
+    e_pr_char (f->a.x + 3, f->e.y, ' ', f->fb->er.fb);
 #ifdef NEWSTYLE
- if (WpeIsXwin())
- {
-  e_make_xrect(f->a.x + 1, f->e.y, f->e.x - 1, f->e.y, 0);
-  e_make_xrect(f->a.x + 5, f->e.y, f->a.x + 14, f->e.y, 0);
- }
+  if (WpeIsXwin ())
+    {
+      e_make_xrect (f->a.x + 1, f->e.y, f->e.x - 1, f->e.y, 0);
+      e_make_xrect (f->a.x + 5, f->e.y, f->a.x + 14, f->e.y, 0);
+    }
 #endif
 }
 
-void WpeFilenameToPathFile(char *filename, char **path, char **file)
+void
+WpeFilenameToPathFile (char *filename, char **path, char **file)
 {
- char *tmp;
- char *cur_dir;
- int len;
+  char *tmp;
+  char *cur_dir;
+  int len;
 
- *path = NULL;
- tmp = strrchr(filename, DIRC);
- if (tmp)
- {
-  *file = WpeStrdup(tmp + 1);
- }
- else
- {
-  *file = WpeStrdup(filename);
- }
- if ((!tmp) || ((filename + 1 == tmp) && (*filename == '.')))
- {
-  *path = WpeGetCurrentDir(WpeEditor);
- }
- else
- {
-  if (*filename != DIRC)
-  {
-   if ((cur_dir = WpeGetCurrentDir(WpeEditor)) == NULL)
-   {
-    free(*file);
-    *file = NULL;
-    return ;
-   }
-   /* Delete the slash at the end. */
-   len = strlen(cur_dir);
-   cur_dir[len - 1] = 0;
-   len = tmp - filename + 1;
-   while (strncmp(filename, "../", 3) == 0)
-   {
-    tmp = strrchr(cur_dir, DIRC);
-    if (tmp == cur_dir)
+  *path = NULL;
+  tmp = strrchr (filename, DIRC);
+  if (tmp)
     {
-     cur_dir[1] = 0;
+      *file = WpeStrdup (tmp + 1);
     }
-    else
-    {
-     *tmp = 0;
-    }
-    len -= 3;
-    filename += 3;
-   }
-   *path = malloc((strlen(cur_dir) + len + 2) * sizeof(char));
-   strcpy(*path, cur_dir);
-   strcat(*path, DIRS);
-   strncat(*path, filename, len);
-   if ((*path)[strlen(cur_dir) + len] != DIRC)
-   {
-    (*path)[strlen(cur_dir) + len + 1] = 0;
-   }
-   else
-   {
-    (*path)[strlen(cur_dir) + len] = DIRC;
-    (*path)[strlen(cur_dir) + len + 1] = 0;
-   }
-   free(cur_dir);
-  }
   else
-  {
-   len = tmp - filename + 1;
-   *path = malloc(len + 1 * sizeof(char));
-   strncpy(*path, filename, len);
-   (*path)[len] = 0;
-  }
- }
+    {
+      *file = WpeStrdup (filename);
+    }
+  if ((!tmp) || ((filename + 1 == tmp) && (*filename == '.')))
+    {
+      *path = WpeGetCurrentDir (WpeEditor);
+    }
+  else
+    {
+      if (*filename != DIRC)
+	{
+	  if ((cur_dir = WpeGetCurrentDir (WpeEditor)) == NULL)
+	    {
+	      free (*file);
+	      *file = NULL;
+	      return;
+	    }
+	  /* Delete the slash at the end. */
+	  len = strlen (cur_dir);
+	  cur_dir[len - 1] = 0;
+	  len = tmp - filename + 1;
+	  while (strncmp (filename, "../", 3) == 0)
+	    {
+	      tmp = strrchr (cur_dir, DIRC);
+	      if (tmp == cur_dir)
+		{
+		  cur_dir[1] = 0;
+		}
+	      else
+		{
+		  *tmp = 0;
+		}
+	      len -= 3;
+	      filename += 3;
+	    }
+	  *path = malloc ((strlen (cur_dir) + len + 2) * sizeof (char));
+	  strcpy (*path, cur_dir);
+	  strcat (*path, DIRS);
+	  strncat (*path, filename, len);
+	  if ((*path)[strlen (cur_dir) + len] != DIRC)
+	    {
+	      (*path)[strlen (cur_dir) + len + 1] = 0;
+	    }
+	  else
+	    {
+	      (*path)[strlen (cur_dir) + len] = DIRC;
+	      (*path)[strlen (cur_dir) + len + 1] = 0;
+	    }
+	  free (cur_dir);
+	}
+      else
+	{
+	  len = tmp - filename + 1;
+	  *path = malloc (len + 1 * sizeof (char));
+	  strncpy (*path, filename, len);
+	  (*path)[len] = 0;
+	}
+    }
 }
 
 /*   draw mouse slider cursor */
-int e_lst_zeichen(int x, int y, int n, int sw, int frb, int max, int iold,
-  int new)
+int
+e_lst_zeichen (int x, int y, int n, int sw, int frb, int max, int iold,
+	       int new)
 {
- int inew;
- double d = max ? 1./(float)max : 0;
+  int inew;
+  double d = max ? 1. / (float) max : 0;
 
- if (n < 3)
-  return(1);
+  if (n < 3)
+    return (1);
 
- if ((inew = (int) (new*(n-2)*d + 1.5)) > n-2)
-  inew = n-2;
- if (iold < 1)
-  iold = 1;
- if (inew < 1)
-  inew = 1;
+  if ((inew = (int) (new * (n - 2) * d + 1.5)) > n - 2)
+    inew = n - 2;
+  if (iold < 1)
+    iold = 1;
+  if (inew < 1)
+    inew = 1;
 
- if (sw == 0)
- {
-  if (iold < n-1)
-   e_pr_char(x, y+iold, MCI, frb);
-  e_pr_char(x, y+inew, MCA, frb);
-  e_make_xrect(x, y+1, x, y+n-2, 0);
-  e_make_xrect(x, y+inew, x, y+inew, 0);
- }
- else
- {
-  if (iold < n-1) e_pr_char(x+iold, y, MCI, frb);
-   e_pr_char(x+inew, y, MCA, frb);
-  e_make_xrect(x+1, y, x+n-2, y, 0);
-  e_make_xrect(x+inew, y, x+inew, y, 0);
- }
- return(inew);
+  if (sw == 0)
+    {
+      if (iold < n - 1)
+	e_pr_char (x, y + iold, MCI, frb);
+      e_pr_char (x, y + inew, MCA, frb);
+      e_make_xrect (x, y + 1, x, y + n - 2, 0);
+      e_make_xrect (x, y + inew, x, y + inew, 0);
+    }
+  else
+    {
+      if (iold < n - 1)
+	e_pr_char (x + iold, y, MCI, frb);
+      e_pr_char (x + inew, y, MCA, frb);
+      e_make_xrect (x + 1, y, x + n - 2, y, 0);
+      e_make_xrect (x + inew, y, x + inew, y, 0);
+    }
+  return (inew);
 }
 
 /*   draw mouse slider bar */
-void e_mouse_bar(int x, int y, int n, int sw, int frb)
+void
+e_mouse_bar (int x, int y, int n, int sw, int frb)
 {
- int sv = n;
+  int sv = n;
 
- if (sw == 0)
- {
-  e_pr_char(x, y, MCU, frb);
-  e_pr_char(x, y+n-1, MCD, frb);
-  for (; n > 2; n--)
-   e_pr_char(x, y+n-2, MCI, frb);
-  e_make_xrect(x, y+1, x, y+sv-2, 0);
-  e_make_xrect(x, y, x, y, 0);
-  e_make_xrect(x, y+sv-1, x, y+sv-1, 0);
- }
- else
- {
-  e_pr_char(x, y, MCL, frb);
-  e_pr_char(x+n-1, y, MCR, frb);
-  for (; n > 2; n--)
-   e_pr_char(x+n-2, y, MCI, frb);
-  e_make_xrect(x+1, y, x+sv-2, y, 0);
-  e_make_xrect(x, y, x, y, 0);
-  e_make_xrect(x+sv-1, y, x+sv-1, y, 0);
- }
-}
-
-int e_autosave(FENSTER *f)
-{
- char *tmp, *str;
- unsigned long maxname;
-
- f->save = 1;
- if (!(f->ed->autosv & 2)) return(0);
- /* Check if file system could have an autosave or emergency save file
-    >12 check is to eliminate dos file systems */
- if (((maxname = pathconf(f->dirct, _PC_NAME_MAX)) >= strlen(f->datnam) + 4) &&
-   (maxname > 12))
- {
-  str = malloc(strlen(f->datnam) + 5);
-  str = e_make_postf(str, f->datnam, ".ASV");
-  tmp = f->datnam;
-  f->datnam = str;
-  /*e_save(f);*/
-  WpeMouseChangeShape(WpeWorkingShape);
-  e_write(0, 0, f->b->mx.x, f->b->mxlines-1, f, WPE_NOBACKUP);
-  WpeMouseRestoreShape();
-  f->datnam = tmp;
-  f->save = 1;
-  free(str);
- }
- return(0);
-}
-
-Undo *e_remove_undo(Undo *ud, int sw)
-{
- if (ud == NULL)
-  return(ud);
- ud->next = e_remove_undo(ud->next, sw + 1);
- if (sw > WpeEditor->numundo)
- {
-  if(ud->type == 'l')
-   free(ud->u.pt);
-  else if (ud->type == 'd')
-  {
-   BUFFER *b = (BUFFER*) ud->u.pt;
-   int i;
-
-   free(b->f->s);
-   free(b->f);
-   if (b->bf != NULL)
-   {
-    for (i = 0; i < b->mxlines; i++)
+  if (sw == 0)
     {
-     if (b->bf[i].s != NULL)
-      free( b->bf[i].s );
-     b->bf[i].s = NULL;
+      e_pr_char (x, y, MCU, frb);
+      e_pr_char (x, y + n - 1, MCD, frb);
+      for (; n > 2; n--)
+	e_pr_char (x, y + n - 2, MCI, frb);
+      e_make_xrect (x, y + 1, x, y + sv - 2, 0);
+      e_make_xrect (x, y, x, y, 0);
+      e_make_xrect (x, y + sv - 1, x, y + sv - 1, 0);
     }
-    free(b->bf);
-   }
-   free(b);
-  }
-  free(ud);
-  ud = NULL;
- }
- return(ud);
+  else
+    {
+      e_pr_char (x, y, MCL, frb);
+      e_pr_char (x + n - 1, y, MCR, frb);
+      for (; n > 2; n--)
+	e_pr_char (x + n - 2, y, MCI, frb);
+      e_make_xrect (x + 1, y, x + sv - 2, y, 0);
+      e_make_xrect (x, y, x, y, 0);
+      e_make_xrect (x + sv - 1, y, x + sv - 1, y, 0);
+    }
+}
+
+int
+e_autosave (FENSTER * f)
+{
+  char *tmp, *str;
+  unsigned long maxname;
+
+  f->save = 1;
+  if (!(f->ed->autosv & 2))
+    return (0);
+  /* Check if file system could have an autosave or emergency save file
+     >12 check is to eliminate dos file systems */
+  if (((maxname =
+	pathconf (f->dirct, _PC_NAME_MAX)) >= strlen (f->datnam) + 4)
+      && (maxname > 12))
+    {
+      str = malloc (strlen (f->datnam) + 5);
+      str = e_make_postf (str, f->datnam, ".ASV");
+      tmp = f->datnam;
+      f->datnam = str;
+      /*e_save(f); */
+      WpeMouseChangeShape (WpeWorkingShape);
+      e_write (0, 0, f->b->mx.x, f->b->mxlines - 1, f, WPE_NOBACKUP);
+      WpeMouseRestoreShape ();
+      f->datnam = tmp;
+      f->save = 1;
+      free (str);
+    }
+  return (0);
+}
+
+Undo *
+e_remove_undo (Undo * ud, int sw)
+{
+  if (ud == NULL)
+    return (ud);
+  ud->next = e_remove_undo (ud->next, sw + 1);
+  if (sw > WpeEditor->numundo)
+    {
+      if (ud->type == 'l')
+	free (ud->u.pt);
+      else if (ud->type == 'd')
+	{
+	  BUFFER *b = (BUFFER *) ud->u.pt;
+	  int i;
+
+	  free (b->f->s);
+	  free (b->f);
+	  if (b->bf != NULL)
+	    {
+	      for (i = 0; i < b->mxlines; i++)
+		{
+		  if (b->bf[i].s != NULL)
+		    free (b->bf[i].s);
+		  b->bf[i].s = NULL;
+		}
+	      free (b->bf);
+	    }
+	  free (b);
+	}
+      free (ud);
+      ud = NULL;
+    }
+  return (ud);
 }
 
 /**
@@ -2132,213 +2333,237 @@ Undo *e_remove_undo(Undo *ud, int sw)
  *  Remark: the **global** e_undo_sw is a disabler for this function.
  *  if e_undo_sw is true, this function does nothing.
  */
-int e_add_undo(int sw, BUFFER *b, int x, int y, int n)
+int
+e_add_undo (int sw, BUFFER * b, int x, int y, int n)
 {
- Undo *next;
+  Undo *next;
 
- if (e_undo_sw) return(0);
- if (!e_redo_sw && b->rd)
-  b->rd = e_remove_undo(b->rd, WpeEditor->numundo+1);
- if ((next = malloc(sizeof(Undo))) == NULL)
- {
-  e_error(e_msg[ERR_LOWMEM], 0, b->fb);
-  return(-1);
- }
- next->type = sw;
- next->b.x = x;
- next->b.y = y;
- next->a.x = n;
- if (e_redo_sw == 1) next->next = b->rd;
- else next->next = b->ud;
- if (sw == 'a') ;
- else if (sw == 'p') next->u.c = b->bf[y].s[x];
- else if (sw == 'r' || sw == 's')
- {
-  char *str = malloc(n);
-  int i;
+  if (e_undo_sw)
+    return (0);
+  if (!e_redo_sw && b->rd)
+    b->rd = e_remove_undo (b->rd, WpeEditor->numundo + 1);
+  if ((next = malloc (sizeof (Undo))) == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, b->fb);
+      return (-1);
+    }
+  next->type = sw;
+  next->b.x = x;
+  next->b.y = y;
+  next->a.x = n;
+  if (e_redo_sw == 1)
+    next->next = b->rd;
+  else
+    next->next = b->ud;
+  if (sw == 'a');
+  else if (sw == 'p')
+    next->u.c = b->bf[y].s[x];
+  else if (sw == 'r' || sw == 's')
+    {
+      char *str = malloc (n);
+      int i;
 
-  if (str == NULL)
-  {
-   e_error(e_msg[ERR_LOWMEM], 0, b->fb);
-   free(next);
-   return(-1);
-  }
-  for (i = 0; i < n; i++)
-   str[i] = b->bf[y].s[x+i];
-  next->u.pt = str;
+      if (str == NULL)
+	{
+	  e_error (e_msg[ERR_LOWMEM], 0, b->fb);
+	  free (next);
+	  return (-1);
+	}
+      for (i = 0; i < n; i++)
+	str[i] = b->bf[y].s[x + i];
+      next->u.pt = str;
 
 /* !!! obsolete !!!
   next->a.y = b->cn->fd.rn;
 */
-  next->a.y = b->f->fd.rn;
+      next->a.y = b->f->fd.rn;
 
- }
- else if (sw == 'l') next->u.pt = b->bf[y].s;
- else if (sw == 'c' || sw == 'v')
- {
-  SCHIRM *s = b->cn->f[b->cn->mxedt]->s;
+    }
+  else if (sw == 'l')
+    next->u.pt = b->bf[y].s;
+  else if (sw == 'c' || sw == 'v')
+    {
+      SCHIRM *s = b->cn->f[b->cn->mxedt]->s;
 
-  next->a = s->mark_begin;
-  next->e = s->mark_end;
- }
- else if (sw == 'd')
- {
-  BUFFER *bn = malloc(sizeof(BUFFER));
-  SCHIRM *sn = malloc(sizeof(SCHIRM));
-  FENSTER *fn = malloc(sizeof(FENSTER));
-  FENSTER *f = b->cn->f[b->cn->mxedt];
+      next->a = s->mark_begin;
+      next->e = s->mark_end;
+    }
+  else if (sw == 'd')
+    {
+      BUFFER *bn = malloc (sizeof (BUFFER));
+      SCHIRM *sn = malloc (sizeof (SCHIRM));
+      FENSTER *fn = malloc (sizeof (FENSTER));
+      FENSTER *f = b->cn->f[b->cn->mxedt];
 
-  bn->bf = (STRING *) malloc(MAXLINES*sizeof(STRING));
-  if (bn == NULL || sn == 0 || bn->bf == NULL)
-   return(e_error(e_msg[ERR_LOWMEM], 0, b->fb));
-  fn->b = bn;
-  fn->c_sw = NULL;
-  fn->c_st = NULL;
-  fn->ed = NULL; /* Quick fix so that breakpoints aren't recalculated */
-  fn->fd.dirct = NULL;
-  bn->f = fn;
-  bn->f->s = sn;
-  bn->b = e_set_pnt(0, 0);
-  bn->mx = e_set_pnt(b->cn->maxcol, MAXLINES);
-  bn->mxlines = 0;
-  sn->fb = bn->fb = b->fb;
-  bn->cn = b->cn;
-  bn->ud = NULL;
-  bn->rd = NULL;
-  sn->c = sn->ks = sn->mark_begin = sn->mark_end = sn->fa = sn->fe = e_set_pnt(0, 0);
-  e_new_line(0 ,bn);
-  *(bn->bf[0].s) = WPE_WR;
-  *(bn->bf[0].s+1) = '\0';
-  bn->bf[0].len = 0;
-  bn->bf[0].nrc = 1;
-  next->u.pt = bn;
-  e_undo_sw = 1;
-  e_move_block(0, 0, b, bn, f);
-  e_undo_sw = 0;
- }
- if (e_redo_sw == 1) b->rd = next;
- else
- {
-  next->next = e_remove_undo(b->ud, 1);
-  b->ud = next;
- }
- return(0);
+      bn->bf = (STRING *) malloc (MAXLINES * sizeof (STRING));
+      if (bn == NULL || sn == 0 || bn->bf == NULL)
+	return (e_error (e_msg[ERR_LOWMEM], 0, b->fb));
+      fn->b = bn;
+      fn->c_sw = NULL;
+      fn->c_st = NULL;
+      fn->ed = NULL;		/* Quick fix so that breakpoints aren't recalculated */
+      fn->fd.dirct = NULL;
+      bn->f = fn;
+      bn->f->s = sn;
+      bn->b = e_set_pnt (0, 0);
+      bn->mx = e_set_pnt (b->cn->maxcol, MAXLINES);
+      bn->mxlines = 0;
+      sn->fb = bn->fb = b->fb;
+      bn->cn = b->cn;
+      bn->ud = NULL;
+      bn->rd = NULL;
+      sn->c = sn->ks = sn->mark_begin = sn->mark_end = sn->fa = sn->fe =
+	e_set_pnt (0, 0);
+      e_new_line (0, bn);
+      *(bn->bf[0].s) = WPE_WR;
+      *(bn->bf[0].s + 1) = '\0';
+      bn->bf[0].len = 0;
+      bn->bf[0].nrc = 1;
+      next->u.pt = bn;
+      e_undo_sw = 1;
+      e_move_block (0, 0, b, bn, f);
+      e_undo_sw = 0;
+    }
+  if (e_redo_sw == 1)
+    b->rd = next;
+  else
+    {
+      next->next = e_remove_undo (b->ud, 1);
+      b->ud = next;
+    }
+  return (0);
 }
 
-int e_make_undo(FENSTER *f)
+int
+e_make_undo (FENSTER * f)
 {
- return(e_make_rudo(f, 0));
+  return (e_make_rudo (f, 0));
 }
 
-int e_make_redo(FENSTER *f)
+int
+e_make_redo (FENSTER * f)
 {
- return(e_make_rudo(f, 1));
+  return (e_make_rudo (f, 1));
 }
 
-int e_make_rudo(FENSTER *f, int sw)
+int
+e_make_rudo (FENSTER * f, int sw)
 {
- BUFFER *b;
- SCHIRM *s;
- Undo *ud;
- int i;
+  BUFFER *b;
+  SCHIRM *s;
+  Undo *ud;
+  int i;
 
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--);
- if (i <= 0) return(0);
- e_switch_window(f->ed->edt[i], f);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;  s = f->s;
- if (!sw) ud = b->ud;
- else ud = b->rd;
- if (ud == NULL)
- {
-  e_error((!sw ? e_msg[ERR_UNDO] : e_msg[ERR_REDO]), 0, b->fb);
-  return(-1);
- }
- f = f->ed->f[f->ed->mxedt];
- if (!sw) e_redo_sw = 1;
- else e_redo_sw = 2;
- b->b = ud->b;
- if (ud->type == 'r' || ud->type == 's')
- {
-  if (ud->type == 's')
-  {
-   e_add_undo('s', b, ud->b.x, ud->b.y, ud->a.y);
-   e_undo_sw = 1;
-   e_del_nchar(b, s, ud->b.x, ud->b.y, ud->a.y);
-  }
-  if (*((char*)ud->u.pt) == '\n' && ud->a.x == 1) e_car_ret(b, s);
-  else if (*((char*)ud->u.pt + ud->a.x - 1) == '\n')
-  {
-   e_ins_nchar(b, s, ((unsigned char *)ud->u.pt), ud->b.x, ud->b.y, ud->a.x-1);
-   e_car_ret(b, s);
-  }
-  else e_ins_nchar(b, s, ((unsigned char *)ud->u.pt), ud->b.x, ud->b.y, ud->a.x);
-  e_undo_sw = 0;
-  s->mark_begin = ud->b;
-  s->mark_end.y = ud->b.y;
-  s->mark_end.x = ud->b.x + ud->a.x;
-  free(ud->u.pt);
- }
- else if (ud->type == 'l')
- {
-  for(i = b->mxlines; i > ud->b.y; i--) b->bf[i] = b->bf[i-1];
-  (b->mxlines)++;
-  b->bf[b->b.y].s = ud->u.pt;
-  b->bf[b->b.y].len = e_str_len(b->bf[b->b.y].s);
-  b->bf[b->b.y].nrc = strlen((const char *)b->bf[b->b.y].s);
-  s->mark_begin = ud->b;
-  s->mark_end.y = ud->b.y + 1;
-  s->mark_end.x = 0;
-  e_add_undo('y', b, 0, b->b.y, 0);
- }
- else if (ud->type == 'y')
-  e_del_line(b->b.y, b, s);
- else if (ud->type == 'a')
-  e_del_nchar(b, s, ud->b.x, ud->b.y, ud->a.x);
- else if (ud->type == 'p')
-  b->bf[ud->b.y].s[ud->b.x] = ud->u.c;
- else if (ud->type == 'c')
- {
-  b->b = s->mark_begin = ud->a;
-  s->mark_end = ud->e;
-/*	e_blck_clear(b, s);   */
-  e_blck_del(f);
- }
- else if (ud->type == 'v')
- {
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--);
+  if (i <= 0)
+    return (0);
+  e_switch_window (f->ed->edt[i], f);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  if (!sw)
+    ud = b->ud;
+  else
+    ud = b->rd;
+  if (ud == NULL)
+    {
+      e_error ((!sw ? e_msg[ERR_UNDO] : e_msg[ERR_REDO]), 0, b->fb);
+      return (-1);
+    }
+  f = f->ed->f[f->ed->mxedt];
+  if (!sw)
+    e_redo_sw = 1;
+  else
+    e_redo_sw = 2;
   b->b = ud->b;
-  s->mark_begin = ud->a;
-  s->mark_end = ud->e;
-  e_blck_move(f);
- }
- else if (ud->type == 'd')
- {
-  BUFFER *bn = (BUFFER*)ud->u.pt;
-  e_undo_sw = 1;
-  s->mark_begin = bn->f->s->mark_begin;
-  s->mark_end = bn->f->s->mark_end;
-  e_move_block(ud->b.x, ud->b.y, bn, b, f);
-  e_undo_sw = 0;
-  free(bn->f->s);
-  free(bn->f);
-  free(bn->bf[0].s);
-  free(bn->bf);
-  free(ud->u.pt);
-  e_add_undo('c', b, ud->b.x, ud->b.y, 0);
- }
- if (!sw) b->ud = ud->next;
- else b->rd = ud->next;
- e_redo_sw = 0;
- free(ud);
- e_schirm(f, 1);
- e_cursor(f, 1);
- return(0);
+  if (ud->type == 'r' || ud->type == 's')
+    {
+      if (ud->type == 's')
+	{
+	  e_add_undo ('s', b, ud->b.x, ud->b.y, ud->a.y);
+	  e_undo_sw = 1;
+	  e_del_nchar (b, s, ud->b.x, ud->b.y, ud->a.y);
+	}
+      if (*((char *) ud->u.pt) == '\n' && ud->a.x == 1)
+	e_car_ret (b, s);
+      else if (*((char *) ud->u.pt + ud->a.x - 1) == '\n')
+	{
+	  e_ins_nchar (b, s, ((unsigned char *) ud->u.pt), ud->b.x, ud->b.y,
+		       ud->a.x - 1);
+	  e_car_ret (b, s);
+	}
+      else
+	e_ins_nchar (b, s, ((unsigned char *) ud->u.pt), ud->b.x, ud->b.y,
+		     ud->a.x);
+      e_undo_sw = 0;
+      s->mark_begin = ud->b;
+      s->mark_end.y = ud->b.y;
+      s->mark_end.x = ud->b.x + ud->a.x;
+      free (ud->u.pt);
+    }
+  else if (ud->type == 'l')
+    {
+      for (i = b->mxlines; i > ud->b.y; i--)
+	b->bf[i] = b->bf[i - 1];
+      (b->mxlines)++;
+      b->bf[b->b.y].s = ud->u.pt;
+      b->bf[b->b.y].len = e_str_len (b->bf[b->b.y].s);
+      b->bf[b->b.y].nrc = strlen ((const char *) b->bf[b->b.y].s);
+      s->mark_begin = ud->b;
+      s->mark_end.y = ud->b.y + 1;
+      s->mark_end.x = 0;
+      e_add_undo ('y', b, 0, b->b.y, 0);
+    }
+  else if (ud->type == 'y')
+    e_del_line (b->b.y, b, s);
+  else if (ud->type == 'a')
+    e_del_nchar (b, s, ud->b.x, ud->b.y, ud->a.x);
+  else if (ud->type == 'p')
+    b->bf[ud->b.y].s[ud->b.x] = ud->u.c;
+  else if (ud->type == 'c')
+    {
+      b->b = s->mark_begin = ud->a;
+      s->mark_end = ud->e;
+/*	e_blck_clear(b, s);   */
+      e_blck_del (f);
+    }
+  else if (ud->type == 'v')
+    {
+      b->b = ud->b;
+      s->mark_begin = ud->a;
+      s->mark_end = ud->e;
+      e_blck_move (f);
+    }
+  else if (ud->type == 'd')
+    {
+      BUFFER *bn = (BUFFER *) ud->u.pt;
+      e_undo_sw = 1;
+      s->mark_begin = bn->f->s->mark_begin;
+      s->mark_end = bn->f->s->mark_end;
+      e_move_block (ud->b.x, ud->b.y, bn, b, f);
+      e_undo_sw = 0;
+      free (bn->f->s);
+      free (bn->f);
+      free (bn->bf[0].s);
+      free (bn->bf);
+      free (ud->u.pt);
+      e_add_undo ('c', b, ud->b.x, ud->b.y, 0);
+    }
+  if (!sw)
+    b->ud = ud->next;
+  else
+    b->rd = ud->next;
+  e_redo_sw = 0;
+  free (ud);
+  e_schirm (f, 1);
+  e_cursor (f, 1);
+  return (0);
 }
 
-char *e_make_postf(char *out, char *name, char *pf)
+char *
+e_make_postf (char *out, char *name, char *pf)
 {
- strcpy(out, name);
- strcat(out, pf);
- return(out);
+  strcpy (out, name);
+  strcat (out, pf);
+  return (out);
 }
-

--- a/src/we_edit.h
+++ b/src/we_edit.h
@@ -12,36 +12,36 @@
 #include "we_debug.h"
 
 /*   we_edit.c   */
-int e_edit(ECNT *cn, char *filename);
-int e_eingabe(ECNT *e);
-int e_tst_cur(int c, ECNT *e);
-int e_tst_fkt(int c, ECNT *e);
-int e_ctrl_k(FENSTER *f);
-int e_ctrl_o(FENSTER *f);
-int e_tst_dfkt(FENSTER *f, int c);
-int e_blk(int anz, int xa, int ya, int col);
-int e_car_ret(BUFFER *b, SCHIRM *s);
-void e_cursor(FENSTER *f, int sw);
-int e_del_line(int yd, BUFFER *b, SCHIRM *s);
-int e_del_nchar(BUFFER *b, SCHIRM *s, int x, int y, int n);
-int e_ins_nchar(BUFFER *b, SCHIRM *sch, unsigned char *s, int xa, int ya,
-  int n);
-int e_new_line(int yd, BUFFER *b);
-int e_put_char(int c, BUFFER *b, SCHIRM *s);
-int e_su_lblk(int xa, unsigned char *s);
-int e_su_rblk(int xa, unsigned char *s);
-void e_zlsplt(FENSTER *f);
-void WpeFilenameToPathFile(char *filename, char **path, char **file);
-int e_lst_zeichen(int x, int y, int n, int sw, int frb, int max, int iold,
-  int new);
-void e_mouse_bar(int x, int y, int n, int sw, int frb);
-int e_chr_sp(int x, BUFFER *b, FENSTER *f);
-Undo *e_remove_undo(Undo *ud, int sw);
-int e_add_undo(int sw, BUFFER *b, int x, int y, int n);
-int e_make_undo(FENSTER *f);
-int e_make_redo(FENSTER *f);
-int e_make_rudo(FENSTER *f, int sw);
-int e_autosave(FENSTER *f);
-char *e_make_postf(char *out, char *name, char *pf);
+int e_edit (ECNT * cn, char *filename);
+int e_eingabe (ECNT * e);
+int e_tst_cur (int c, ECNT * e);
+int e_tst_fkt (int c, ECNT * e);
+int e_ctrl_k (FENSTER * f);
+int e_ctrl_o (FENSTER * f);
+int e_tst_dfkt (FENSTER * f, int c);
+int e_blk (int anz, int xa, int ya, int col);
+int e_car_ret (BUFFER * b, SCHIRM * s);
+void e_cursor (FENSTER * f, int sw);
+int e_del_line (int yd, BUFFER * b, SCHIRM * s);
+int e_del_nchar (BUFFER * b, SCHIRM * s, int x, int y, int n);
+int e_ins_nchar (BUFFER * b, SCHIRM * sch, unsigned char *s, int xa, int ya,
+		 int n);
+int e_new_line (int yd, BUFFER * b);
+int e_put_char (int c, BUFFER * b, SCHIRM * s);
+int e_su_lblk (int xa, unsigned char *s);
+int e_su_rblk (int xa, unsigned char *s);
+void e_zlsplt (FENSTER * f);
+void WpeFilenameToPathFile (char *filename, char **path, char **file);
+int e_lst_zeichen (int x, int y, int n, int sw, int frb, int max, int iold,
+		   int new);
+void e_mouse_bar (int x, int y, int n, int sw, int frb);
+int e_chr_sp (int x, BUFFER * b, FENSTER * f);
+Undo *e_remove_undo (Undo * ud, int sw);
+int e_add_undo (int sw, BUFFER * b, int x, int y, int n);
+int e_make_undo (FENSTER * f);
+int e_make_redo (FENSTER * f);
+int e_make_rudo (FENSTER * f, int sw);
+int e_autosave (FENSTER * f);
+char *e_make_postf (char *out, char *name, char *pf);
 
 #endif

--- a/src/we_fl_fkt.c
+++ b/src/we_fl_fkt.c
@@ -28,522 +28,610 @@
 #define putc(c, fp) fputc(c, fp)
 #endif
 
-int e_read_help();
-int e_read_info();
+int e_read_help ();
+int e_read_info ();
 
 char *info_file = NULL;
 char *e_tmp_dir = NULL;
 
 /* create complete file name */
-char *e_mkfilename(char *dr, char *fn)
+char *
+e_mkfilename (char *dr, char *fn)
 {
- char *fl;
+  char *fl;
 
- if (!fn)
-  return(NULL);
- if(!dr)
- {
-  fl = malloc(strlen(fn) + 1);
-  strcpy(fl, fn);
-  return(fl);
- }
- fl = malloc(strlen(dr) + strlen(fn) + 2);
- strcpy(fl, dr);
- if (dr[0] != '\0' && dr[strlen(dr)-1] != DIRC)
-  strcat(fl, DIRS);
- strcat(fl, fn);
- return(fl);
+  if (!fn)
+    return (NULL);
+  if (!dr)
+    {
+      fl = malloc (strlen (fn) + 1);
+      strcpy (fl, fn);
+      return (fl);
+    }
+  fl = malloc (strlen (dr) + strlen (fn) + 2);
+  strcpy (fl, dr);
+  if (dr[0] != '\0' && dr[strlen (dr) - 1] != DIRC)
+    strcat (fl, DIRS);
+  strcat (fl, fn);
+  return (fl);
 }
 
 /*   read file routine     */
-POINT e_readin(int i, int j, FILE *fp, BUFFER *b, char *type)
+POINT
+e_readin (int i, int j, FILE * fp, BUFFER * b, char *type)
 {
- POINT pkt;
- int ii, k, n = 1, hb = 0;
- signed char cc, c = 0;
+  POINT pkt;
+  int ii, k, n = 1, hb = 0;
+  signed char cc, c = 0;
 
- WpeMouseChangeShape(WpeWorkingShape);
- if (i == 0) e_new_line(j, b);
- while (n == 1)
- {
-  for (; i < b->mx.x; i++)
-  {
-   if (hb != 2)
-    n = fread(&c, sizeof(char), 1, fp);
-   else
-   {
-    c = cc;
-    hb = 0;
-   }
-   if (n == 1 && c == WPE_CR)
-   {
-    if (DTMD_NORMAL == *type)
+  WpeMouseChangeShape (WpeWorkingShape);
+  if (i == 0)
+    e_new_line (j, b);
+  while (n == 1)
     {
-     *type = DTMD_MSDOS;
+      for (; i < b->mx.x; i++)
+	{
+	  if (hb != 2)
+	    n = fread (&c, sizeof (char), 1, fp);
+	  else
+	    {
+	      c = cc;
+	      hb = 0;
+	    }
+	  if (n == 1 && c == WPE_CR)
+	    {
+	      if (DTMD_NORMAL == *type)
+		{
+		  *type = DTMD_MSDOS;
+		}
+	      i--;
+	      continue;
+	    }
+	  if ((DTMD_HELP == *type) && (c == CtrlH))
+	    {
+	      if (!hb)
+		{
+		  *(b->bf[j].s + i - 1) = HBB;
+		  hb = 1;
+		}
+	      else
+		i--;
+	      n = fread (&c, sizeof (char), 1, fp);
+	    }
+	  else if ((DTMD_HELP == *type) && (hb == 1))
+	    {
+	      n = fread (&cc, sizeof (char), 1, fp);
+	      if (cc != HBS)
+		{
+		  *(b->bf[j].s + i) = HED;
+		  i++;
+		  hb = 2;
+		}
+	      else
+		n = fread (&c, sizeof (char), 1, fp);
+	    }
+	  if (n != 1)
+	    {
+	      *(b->bf[j].s + i) = '\0';
+	      break;
+	    }
+	  *(b->bf[j].s + i) = c;
+	  if (c == WPE_WR)
+	    break;
+	}
+      if (n != 1)
+	{
+	  if (i == 0 && j > 0)
+	    {
+	      free (b->bf[j].s);
+	      for (k = j; k < b->mxlines; k++)
+		b->bf[k] = b->bf[k + 1];
+	      (b->mxlines)--;
+	    }
+	  else
+	    {
+	      *(b->bf[j].s + i) = WPE_WR;
+	      *(b->bf[j].s + i + 1) = '\0';
+	      j++;
+	    }
+	}
+      else if (i >= b->mx.x)
+	{
+	  for (ii = i - 1;
+	       *(b->bf[j].s + ii) != ' ' && *(b->bf[j].s + ii) != '-'
+	       && ii > 0; ii--);
+	  if (ii <= 1)
+	    ii = i - 1;
+	  e_new_line (j + 1, b);
+	  for (k = ii + 1; k <= i; k++)
+	    {
+	      if (*(b->bf[j].s + k) != '\0')
+		*(b->bf[j + 1].s + k - ii - 1) = *(b->bf[j].s + k);
+	      else
+		*(b->bf[j + 1].s + k - ii - 1) = ' ';
+	    }
+	  i = i - ii - 1;
+	  *(b->bf[j].s + ii + 1) = '\0';
+	  j++;
+	  if (i < 0)
+	    i = 0;
+	}
+      else if (c == WPE_WR)
+	{
+	  *(b->bf[j].s + i) = WPE_WR;
+	  *(b->bf[j].s + i + 1) = '\0';
+	  e_new_line (++j, b);
+	  i = 0;
+	}
+      else
+	{
+	  *(b->bf[j].s + i) = ' ';
+	  i++;
+	  *(b->bf[j].s + i) = '\0';
+	}
+      b->bf[j - 1].len = e_str_len (b->bf[j - 1].s);
+      b->bf[j - 1].nrc = strlen ((const char *) b->bf[j - 1].s);
     }
-    i--;
-    continue;
-   }
-   if ((DTMD_HELP == *type) && (c == CtrlH))
-   {
-    if (!hb)
-    {
-     *(b->bf[j].s+i-1) = HBB;
-     hb = 1;
-    }
-    else i--;
-    n = fread(&c, sizeof(char), 1, fp);
-   }
-   else if ((DTMD_HELP == *type) && (hb == 1))
-   {
-    n = fread(&cc, sizeof(char), 1, fp);
-    if (cc != HBS)
-    {
-     *(b->bf[j].s+i) = HED;
-     i++;
-     hb = 2;
-    }
-    else n = fread(&c, sizeof(char), 1, fp);
-   }
-   if (n != 1)
-   {
-    *(b->bf[j].s+i) = '\0';
-    break;
-   }
-   *(b->bf[j].s+i) = c;
-   if (c == WPE_WR) break;
-  }
-  if (n != 1)
-  {
-   if (i == 0 && j > 0)
-   {
-    free(b->bf[j].s);
-    for (k = j; k < b->mxlines; k++) b->bf[k] = b->bf[k+1];
-    (b->mxlines)--;
-   }
-   else
-   {
-    *(b->bf[j].s+i) = WPE_WR;
-    *(b->bf[j].s+i+1) = '\0';
-    j++;
-   }
-  }
-  else if (i >= b->mx.x)
-  {
-   for (ii = i-1; *(b->bf[j].s+ii) != ' ' && *(b->bf[j].s+ii) != '-' && ii > 0; ii--);
-   if (ii <= 1) ii = i - 1;
-   e_new_line(j+1, b);
-   for (k = ii+1; k <= i; k++)
-   {
-    if (*(b->bf[j].s+k) != '\0') *(b->bf[j+1].s+k-ii-1) = *(b->bf[j].s+k);
-    else *(b->bf[j+1].s+k-ii-1) = ' ';
-   }
-   i = i - ii - 1;
-   *(b->bf[j].s+ii+1) = '\0';
-   j++;
-   if (i < 0) i = 0;
-  }
-  else if (c == WPE_WR)
-  {
-   *(b->bf[j].s+i) = WPE_WR;
-   *(b->bf[j].s+i+1) = '\0';
-   e_new_line(++j, b);
-   i = 0;
-  }
-  else
-  {
-   *(b->bf[j].s+i) = ' ';
-   i++;
-   *(b->bf[j].s+i) = '\0';
-  }
-  b->bf[j-1].len = e_str_len(b->bf[j-1].s);
-  b->bf[j-1].nrc = strlen((const char *)b->bf[j-1].s);
- }
- pkt.x = i;  pkt.y = j;
- WpeMouseRestoreShape();
- return(pkt);
+  pkt.x = i;
+  pkt.y = j;
+  WpeMouseRestoreShape ();
+  return (pkt);
 }
 
 /*   Open new edit window   */
-int e_new(FENSTER *f)
+int
+e_new (FENSTER * f)
 {
- e_edit(f->ed, "");
- return(0);
+  e_edit (f->ed, "");
+  return (0);
 }
 
-int e_m_save(FENSTER *f)
+int
+e_m_save (FENSTER * f)
 {
- int ret = e_save(f);
+  int ret = e_save (f);
 
- if (ret == WPE_ESC)
-  e_message(0, e_msg[ERR_MSG_SAVE], f);
- return(ret);
+  if (ret == WPE_ESC)
+    e_message (0, e_msg[ERR_MSG_SAVE], f);
+  return (ret);
 }
 
-int e_save(FENSTER *f)
+int
+e_save (FENSTER * f)
 {
- BUFFER *b;
- int ret;
+  BUFFER *b;
+  int ret;
 
- if (!DTMD_ISTEXT(f->dtmd))
-  return(0);
- for (ret = f->ed->mxedt; ret > 0 && f->ed->f[ret] != f; ret--)
-  ;
- if (!ret)
-  return(0);
- WpeMouseChangeShape(WpeWorkingShape);
- b = f->ed->f[ret]->b;
- ret = e_write(0, 0, b->mx.x, b->mxlines-1, f, WPE_BACKUP);
- if (ret != WPE_ESC)
-  f->save = 0;
- WpeMouseRestoreShape();
- return(ret);
+  if (!DTMD_ISTEXT (f->dtmd))
+    return (0);
+  for (ret = f->ed->mxedt; ret > 0 && f->ed->f[ret] != f; ret--)
+    ;
+  if (!ret)
+    return (0);
+  WpeMouseChangeShape (WpeWorkingShape);
+  b = f->ed->f[ret]->b;
+  ret = e_write (0, 0, b->mx.x, b->mxlines - 1, f, WPE_BACKUP);
+  if (ret != WPE_ESC)
+    f->save = 0;
+  WpeMouseRestoreShape ();
+  return (ret);
 }
 
 /*	save all windows */
-int e_saveall(FENSTER *f)
+int
+e_saveall (FENSTER * f)
 {
- int i, ret = 0;
- ECNT *cn = f->ed;
+  int i, ret = 0;
+  ECNT *cn = f->ed;
 
- for (i = cn->mxedt; i > 0; i--)
- {
-  if (cn->f[i]->save != 0 && cn->f[i]->ins != 8)
-   if (e_save(cn->f[i]) == WPE_ESC)
-    ret = WPE_ESC;
- }
- if (ret == WPE_ESC)
-  e_message(0, e_msg[ERR_MSG_SAVEALL], f);
- return(ret);
+  for (i = cn->mxedt; i > 0; i--)
+    {
+      if (cn->f[i]->save != 0 && cn->f[i]->ins != 8)
+	if (e_save (cn->f[i]) == WPE_ESC)
+	  ret = WPE_ESC;
+    }
+  if (ret == WPE_ESC)
+    e_message (0, e_msg[ERR_MSG_SAVEALL], f);
+  return (ret);
 }
 
 /*	terminate edit session */
-int e_quit(FENSTER *f)
+int
+e_quit (FENSTER * f)
 {
- int i;
- char tmp[128];
+  int i;
+  char tmp[128];
 #if  MOUSE
- int g[4];
+  int g[4];
 #endif
- ECNT *cn = f->ed;
+  ECNT *cn = f->ed;
 #ifdef DEBUGGER
- e_d_quit_basic(f);
+  e_d_quit_basic (f);
 #endif
- for (i = cn->mxedt; i > 0; i--)
- {
-  if (e_close_window(cn->f[cn->mxedt]) == WPE_ESC)
-   return(WPE_ESC);
- }
- if (cn->autosv & 1)
-  e_save_opt(cn->f[0]);
+  for (i = cn->mxedt; i > 0; i--)
+    {
+      if (e_close_window (cn->f[cn->mxedt]) == WPE_ESC)
+	return (WPE_ESC);
+    }
+  if (cn->autosv & 1)
+    e_save_opt (cn->f[0]);
 #ifdef UNIX
- if (WpeQuitWastebasket(cn->f[0]))
-  return(0);
- sprintf(tmp, "rm -rf %s&", e_tmp_dir);
- int ret = system(tmp);
-	if (WIFSIGNALED(ret) && (WTERMSIG(ret) == SIGINT || WTERMSIG(ret) == SIGQUIT)) {
-		printf("System call command %s resulted in an interrupt.\n", 
-			tmp);
-	} else if (ret == 127) {
-		printf("System call command %s failed with code 127\n%s\n%s\n%s\n", 
-			tmp, 
-			"This could mean one of two things:",
-			"1. No shell was available (should never happen unless using chroot)",
-			"2. The command returned 127.\n");
-	} else if (ret != 0) {
-		printf("System call command %s failed. Return code = %i.\n", tmp, ret);
-	}
- 
+  if (WpeQuitWastebasket (cn->f[0]))
+    return (0);
+  sprintf (tmp, "rm -rf %s&", e_tmp_dir);
+  int ret = system (tmp);
+  if (WIFSIGNALED (ret)
+      && (WTERMSIG (ret) == SIGINT || WTERMSIG (ret) == SIGQUIT))
+    {
+      printf ("System call command %s resulted in an interrupt.\n", tmp);
+    }
+  else if (ret == 127)
+    {
+      printf ("System call command %s failed with code 127\n%s\n%s\n%s\n",
+	      tmp,
+	      "This could mean one of two things:",
+	      "1. No shell was available (should never happen unless using chroot)",
+	      "2. The command returned 127.\n");
+    }
+  else if (ret != 0)
+    {
+      printf ("System call command %s failed. Return code = %i.\n", tmp, ret);
+    }
+
 #endif
 #if  MOUSE
- g[0] = 2;
- fk_mouse(g);
+  g[0] = 2;
+  fk_mouse (g);
 #endif
- e_cls(cn->fb->ws, ' ');
- fk_locate(0, 0);
- fk_cursor(1);
- e_refresh();
- WpeExit(0);
- return(0);
+  e_cls (cn->fb->ws, ' ');
+  fk_locate (0, 0);
+  fk_cursor (1);
+  e_refresh ();
+  WpeExit (0);
+  return (0);
 }
 
 /*	write file to disk */
-int e_write(int xa, int ya, int xe, int ye, FENSTER *f, int backup)
+int
+e_write (int xa, int ya, int xe, int ye, FENSTER * f, int backup)
 {
- BUFFER *b;
- int i = xa, j;
- char *tmp, *ptmp;
- FILE *fp;
+  BUFFER *b;
+  int i = xa, j;
+  char *tmp, *ptmp;
+  FILE *fp;
 
- for (j = f->ed->mxedt; j > 0 && f->ed->f[j] != f; j--)
-  ;
- b = f->ed->f[j]->b;
- if (f->ins == 8)
-  return(WPE_ESC);
- ptmp = e_mkfilename(f->dirct, f->datnam);
+  for (j = f->ed->mxedt; j > 0 && f->ed->f[j] != f; j--)
+    ;
+  b = f->ed->f[j]->b;
+  if (f->ins == 8)
+    return (WPE_ESC);
+  ptmp = e_mkfilename (f->dirct, f->datnam);
 // F_OK means: test for existance and has the value zero.
 // Use R_OK, W_OK and X_OK for Read, Write or execute permissions
 // FIXME: man page discourage use of access: switch to real user and test open, then switch back.
- if ((backup == WPE_BACKUP) && (access(ptmp, F_OK) == 0))
- {
-  tmp = e_bakfilename(ptmp);
-  if (access(tmp, F_OK) == 0)
-   remove(tmp);
-  WpeRenameCopy(ptmp, tmp, f, 1);
-  free(tmp);
- }
- if ((fp = fopen(ptmp, "wb")) == NULL)
- {
-  e_error(e_msg[ERR_FOPEN], 0, f->fb);
-  free(ptmp);
-  return(WPE_ESC);
- }
- if (f->filemode >= 0)
-  chmod(ptmp, f->filemode);
- for (j = ya; j < ye && j < b->mxlines; j++)
- {
+  if ((backup == WPE_BACKUP) && (access (ptmp, F_OK) == 0))
+    {
+      tmp = e_bakfilename (ptmp);
+      if (access (tmp, F_OK) == 0)
+	remove (tmp);
+      WpeRenameCopy (ptmp, tmp, f, 1);
+      free (tmp);
+    }
+  if ((fp = fopen (ptmp, "wb")) == NULL)
+    {
+      e_error (e_msg[ERR_FOPEN], 0, f->fb);
+      free (ptmp);
+      return (WPE_ESC);
+    }
+  if (f->filemode >= 0)
+    chmod (ptmp, f->filemode);
+  for (j = ya; j < ye && j < b->mxlines; j++)
+    {
+      if (b->bf[j].s != NULL)
+	for (; i <= b->bf[j].len && i < b->mx.x && *(b->bf[j].s + i) != '\0';
+	     i++)
+	  {
+	    if (*(b->bf[j].s + i) == WPE_WR)
+	      {
+		if (DTMD_MSDOS == f->dtmd)
+		  {
+		    putc (WPE_CR, fp);
+		  }
+		putc (WPE_WR, fp);
+		break;
+	      }
+	    else
+	      putc (*(b->bf[j].s + i), fp);
+	  }
+      i = 0;
+    }
   if (b->bf[j].s != NULL)
-   for (; i <= b->bf[j].len && i < b->mx.x && *(b->bf[j].s+i)!= '\0' ; i++)
-   {
-    if (*(b->bf[j].s+i) == WPE_WR)
-    {
-     if (DTMD_MSDOS == f->dtmd)
-     {
-      putc(WPE_CR, fp);
-     }
-     putc(WPE_WR, fp);
-     break;
-    }
-    else
-     putc(*(b->bf[j].s+i), fp);
-   }
-  i = 0;
- }
- if (b->bf[j].s != NULL)
-  for (i = 0; i < xe && *(b->bf[j].s+i)!= '\0' && i <= b->bf[j].len && i < b->mx.x ; i++)
-  {
-   if (*(b->bf[j].s+i) == WPE_WR)
-   {
-    if (DTMD_MSDOS == f->dtmd)
-    {
-     putc(WPE_CR, fp);
-    }
-    putc(WPE_WR, fp);
-    break;
-   }
-   else
-    putc(*(b->bf[j].s+i), fp);
-  }
- free(ptmp);
- fclose(fp);
- return(0);
+    for (i = 0;
+	 i < xe && *(b->bf[j].s + i) != '\0' && i <= b->bf[j].len
+	 && i < b->mx.x; i++)
+      {
+	if (*(b->bf[j].s + i) == WPE_WR)
+	  {
+	    if (DTMD_MSDOS == f->dtmd)
+	      {
+		putc (WPE_CR, fp);
+	      }
+	    putc (WPE_WR, fp);
+	    break;
+	  }
+	else
+	  putc (*(b->bf[j].s + i), fp);
+      }
+  free (ptmp);
+  fclose (fp);
+  return (0);
 }
 
 /*	append new qualifier (suffix) to file name */
-char *e_new_qual(char *s, char *ns, char *sb)
+char *
+e_new_qual (char *s, char *ns, char *sb)
 {
- int i, j;
+  int i, j;
 
- for (i = strlen(s); i >= 0 && s[i] != '.' && s[i] != DIRC; i--)
-  ;
- if (i < 0 || s[i] == DIRC)
-  strcpy(sb, s);
- else if (i == 0 || s[i-1] == DIRC)
-  strcpy(sb, s);
- else
- {
-  for (j = 0; j < i; j++)
-   sb[j] = s[j];
-  sb[j] = '\0';
- }
- strcat(sb, ".");
- strcat(sb, ns);
- return(sb);
+  for (i = strlen (s); i >= 0 && s[i] != '.' && s[i] != DIRC; i--)
+    ;
+  if (i < 0 || s[i] == DIRC)
+    strcpy (sb, s);
+  else if (i == 0 || s[i - 1] == DIRC)
+    strcpy (sb, s);
+  else
+    {
+      for (j = 0; j < i; j++)
+	sb[j] = s[j];
+      sb[j] = '\0';
+    }
+  strcat (sb, ".");
+  strcat (sb, ns);
+  return (sb);
 }
 
 /*     make up the bak-file name */
-char *e_bakfilename(char* s)
+char *
+e_bakfilename (char *s)
 {
- /* "" is the special code for TurboC replace-extension style */
+  /* "" is the special code for TurboC replace-extension style */
 #ifndef SIMPLE_BACKUP_SUFFIX
 #define SIMPLE_BACKUP_SUFFIX ""
 #endif
 
- static char* bak = NULL;
- char *result;
- if (!bak)
- {
-  bak = getenv("SIMPLE_BACKUP_SUFFIX");
-  if (!bak) bak = SIMPLE_BACKUP_SUFFIX;
- }
+  static char *bak = NULL;
+  char *result;
+  if (!bak)
+    {
+      bak = getenv ("SIMPLE_BACKUP_SUFFIX");
+      if (!bak)
+	bak = SIMPLE_BACKUP_SUFFIX;
+    }
 
- result = malloc(strlen(s) + strlen(bak) + 5);
- if (!*bak)
-  return e_new_qual(s, "bak", result); /* TurboC style */
- else
- {
-  strcpy(result, s);
-  strcat(result, bak);
-  return result;
- }
+  result = malloc (strlen (s) + strlen (bak) + 5);
+  if (!*bak)
+    return e_new_qual (s, "bak", result);	/* TurboC style */
+  else
+    {
+      strcpy (result, s);
+      strcat (result, bak);
+      return result;
+    }
 }
 
 /*    Clear file-/directory-structure   */
-int freedf(struct dirfile *df)
+int
+freedf (struct dirfile *df)
 {
- if (df == NULL) return(-1);
- if(df->name)
- {
-  for (; df->anz > 0; (df->anz)--) {
-   if (*(df->name+df->anz-1))
-    free(*(df->name+df->anz-1));
-   }
-   free(df->name);
- }
- free(df);
- df = NULL;
- return(0);
+  if (df == NULL)
+    return (-1);
+  if (df->name)
+    {
+      for (; df->anz > 0; (df->anz)--)
+	{
+	  if (*(df->name + df->anz - 1))
+	    free (*(df->name + df->anz - 1));
+	}
+      free (df->name);
+    }
+  free (df);
+  df = NULL;
+  return (0);
 }
 
 
 
-int e_file_window(int sw, FLWND *fw, int ft, int fz)
+int
+e_file_window (int sw, FLWND * fw, int ft, int fz)
 {
-   int i, c, nsu = 0;
-   int len = 0;
-   char sustr[18];
-   if(fw->df->anz > 0)
-   {  if(fw->nf >= fw->df->anz) fw->nf = fw->df->anz-1;
-      len = strlen(*(fw->df->name+fw->nf));
-   }
-   e_mouse_bar(fw->xe, fw->ya, fw->ye-fw->ya, 0, fw->f->fb->em.fb);
-   e_mouse_bar(fw->xa, fw->ye, fw->xe-fw->xa, 1, fw->f->fb->em.fb);
-   while (1)
-   {  e_pr_file_window(fw, 1, 1, ft, fz, 0);
+  int i, c, nsu = 0;
+  int len = 0;
+  char sustr[18];
+  if (fw->df->anz > 0)
+    {
+      if (fw->nf >= fw->df->anz)
+	fw->nf = fw->df->anz - 1;
+      len = strlen (*(fw->df->name + fw->nf));
+    }
+  e_mouse_bar (fw->xe, fw->ya, fw->ye - fw->ya, 0, fw->f->fb->em.fb);
+  e_mouse_bar (fw->xa, fw->ye, fw->xe - fw->xa, 1, fw->f->fb->em.fb);
+  while (1)
+    {
+      e_pr_file_window (fw, 1, 1, ft, fz, 0);
 #if  MOUSE
-      if((c = e_getch()) < 0) c = fl_wnd_mouse(sw, c, fw);
+      if ((c = e_getch ()) < 0)
+	c = fl_wnd_mouse (sw, c, fw);
 #else
-      c = e_getch();
+      c = e_getch ();
 #endif
-      if(fw->df->anz <= 0) return(WPE_ESC);
+      if (fw->df->anz <= 0)
+	return (WPE_ESC);
       if (c == CUP || c == CtrlP)
-      {  if(fw->nf <= 0)  return(c);
-	 else  fw->nf--;
-	 if(fw->srcha < 0) nsu = 0;
-      }
-      else if ((c == CDO || c == CtrlN) && fw->nf < fw->df->anz-1)
-      {  fw->nf++;
-	 if(fw->srcha < 0) nsu = 0;
-      }
+	{
+	  if (fw->nf <= 0)
+	    return (c);
+	  else
+	    fw->nf--;
+	  if (fw->srcha < 0)
+	    nsu = 0;
+	}
+      else if ((c == CDO || c == CtrlN) && fw->nf < fw->df->anz - 1)
+	{
+	  fw->nf++;
+	  if (fw->srcha < 0)
+	    nsu = 0;
+	}
       else if (c == CLE || c == CtrlB)
-      {  if(fw->ja <= 0)  return(c);
-	 else  fw->ja--;
-      }
+	{
+	  if (fw->ja <= 0)
+	    return (c);
+	  else
+	    fw->ja--;
+	}
       else if (c == CRI || c == CtrlF)
-      {  if(fw->ja > len-2)  return(c);
-	 else  fw->ja++;
-      }
+	{
+	  if (fw->ja > len - 2)
+	    return (c);
+	  else
+	    fw->ja++;
+	}
       else if (c == BUP)
-      {  if(fw->nf <= 0)  return(c);
-	 if((fw->nf -= (fw->ye-fw->ya-1)) < 0) fw->nf = 0;
-	 if(fw->srcha < 0) nsu = 0;
-      }
+	{
+	  if (fw->nf <= 0)
+	    return (c);
+	  if ((fw->nf -= (fw->ye - fw->ya - 1)) < 0)
+	    fw->nf = 0;
+	  if (fw->srcha < 0)
+	    nsu = 0;
+	}
       else if (c == BDO)
-      {  if((fw->nf += (fw->ye-fw->ya-1)) > fw->df->anz-1)
-	 fw->nf = fw->df->anz-1;
-	 if(fw->srcha < 0) nsu = 0;
-      }
+	{
+	  if ((fw->nf += (fw->ye - fw->ya - 1)) > fw->df->anz - 1)
+	    fw->nf = fw->df->anz - 1;
+	  if (fw->srcha < 0)
+	    nsu = 0;
+	}
       else if (c == POS1 || c == CtrlA || c == CBUP)
-      {  fw->nf = 0; nsu = 0;  fw->ja = fw->srcha > 0 ? fw->srcha : 0;  }
+	{
+	  fw->nf = 0;
+	  nsu = 0;
+	  fw->ja = fw->srcha > 0 ? fw->srcha : 0;
+	}
       else if (c == ENDE || c == CtrlE || c == CBDO)
-      fw->nf = fw->df->anz-1;
+	fw->nf = fw->df->anz - 1;
       else if (c >= 32 && c < 127)
-      {  sustr[nsu] = c;  sustr[++nsu] = '\0';
-	 if(fw->srcha < 0)
-	 {  for(i = nsu > 1 ? fw->nf : fw->nf+1; i < fw->df->anz; i++)
-	    {  for(c = 0; *(fw->df->name[i]+c)
-			&& ( *(fw->df->name[i]+c) <= 32
-			  || *(fw->df->name[i]+c) >= 127); c++);
+	{
+	  sustr[nsu] = c;
+	  sustr[++nsu] = '\0';
+	  if (fw->srcha < 0)
+	    {
+	      for (i = nsu > 1 ? fw->nf : fw->nf + 1; i < fw->df->anz; i++)
+		{
+		  for (c = 0; *(fw->df->name[i] + c)
+		       && (*(fw->df->name[i] + c) <= 32
+			   || *(fw->df->name[i] + c) >= 127); c++);
 #ifdef UNIX
-	       if(!WpeIsXwin() && *(fw->df->name[i]+c-1) == 32) c += 3;
+		  if (!WpeIsXwin () && *(fw->df->name[i] + c - 1) == 32)
+		    c += 3;
 #endif
-	       if(strncmp(fw->df->name[i]+c, sustr, nsu) >= 0) break;
+		  if (strncmp (fw->df->name[i] + c, sustr, nsu) >= 0)
+		    break;
+		}
 	    }
-	 }
-	 else
-	 {  for(i = 0; i < fw->df->anz
-		  && strncmp(fw->df->name[i]+fw->srcha, sustr, nsu) < 0; i++);
-	 }
-	 fw->nf = i < fw->df->anz ? i : fw->df->anz-1;
-      }
-      else if (c == CCLE) return(c);
-      else if (c == CCRI) return(c);
-      else if(c) {  nsu = 0;  return(c);  }
-      else if(fw->srcha < 0) nsu = 0;
-      if(fw->nf > fw->df->anz-1) fw->nf = fw->df->anz-1;
-      len=strlen(*(fw->df->name+fw->nf));
-      if(fw->ja >= len) fw->ja = !len ? len : len-1;
-      if(fw->nf-fw->ia >= fw->ye - fw->ya) fw->ia = fw->nf+fw->ya-fw->ye+1;
-      else if(fw->nf-fw->ia < 0) fw->ia = fw->nf;
-   }
-   return(0);
+	  else
+	    {
+	      for (i = 0; i < fw->df->anz
+		   && strncmp (fw->df->name[i] + fw->srcha, sustr, nsu) < 0;
+		   i++);
+	    }
+	  fw->nf = i < fw->df->anz ? i : fw->df->anz - 1;
+	}
+      else if (c == CCLE)
+	return (c);
+      else if (c == CCRI)
+	return (c);
+      else if (c)
+	{
+	  nsu = 0;
+	  return (c);
+	}
+      else if (fw->srcha < 0)
+	nsu = 0;
+      if (fw->nf > fw->df->anz - 1)
+	fw->nf = fw->df->anz - 1;
+      len = strlen (*(fw->df->name + fw->nf));
+      if (fw->ja >= len)
+	fw->ja = !len ? len : len - 1;
+      if (fw->nf - fw->ia >= fw->ye - fw->ya)
+	fw->ia = fw->nf + fw->ya - fw->ye + 1;
+      else if (fw->nf - fw->ia < 0)
+	fw->ia = fw->nf;
+    }
+  return (0);
 }
 
-int e_pr_file_window(FLWND *fw, int c, int sw, int ft, int fz, int fs)
+int
+e_pr_file_window (FLWND * fw, int c, int sw, int ft, int fz, int fs)
 {
 #ifdef NEWSTYLE
- int xrt = 0;
+  int xrt = 0;
 #endif
- int i = fw->ia, len;
+  int i = fw->ia, len;
 
- if (fw->df != NULL)
- {
-  for (; i < fw->df->anz && i-fw->ia < fw->ye-fw->ya; i++)
-  {
-   if ((len=strlen(*(fw->df->name+i))) < 0)
-    len = 0;
-   if (i == fw->nf && c && len >= fw->ja)
-   {
-    e_pr_nstr(fw->xa+1, fw->ya+i-fw->ia, fw->xe-fw->xa, *(fw->df->name+i)+fw->ja, fz, fz);
+  if (fw->df != NULL)
+    {
+      for (; i < fw->df->anz && i - fw->ia < fw->ye - fw->ya; i++)
+	{
+	  if ((len = strlen (*(fw->df->name + i))) < 0)
+	    len = 0;
+	  if (i == fw->nf && c && len >= fw->ja)
+	    {
+	      e_pr_nstr (fw->xa + 1, fw->ya + i - fw->ia, fw->xe - fw->xa,
+			 *(fw->df->name + i) + fw->ja, fz, fz);
 #ifdef NEWSTYLE
-    xrt = 1;
+	      xrt = 1;
 #endif
-   }
-   else if (i == fw->nf && len >= fw->ja)
-    e_pr_nstr(fw->xa+1, fw->ya+i-fw->ia, fw->xe-fw->xa, *(fw->df->name+i)+fw->ja, fs, fs);
-   else if (len >= fw->ja)
-    e_pr_nstr(fw->xa+1, fw->ya+i-fw->ia, fw->xe-fw->xa, *(fw->df->name+i)+fw->ja, ft, ft);
-   else if (len < fw->ja)
-    e_blk(fw->xe-fw->xa-1, fw->xa+1, fw->ya+i-fw->ia, ft);
+	    }
+	  else if (i == fw->nf && len >= fw->ja)
+	    e_pr_nstr (fw->xa + 1, fw->ya + i - fw->ia, fw->xe - fw->xa,
+		       *(fw->df->name + i) + fw->ja, fs, fs);
+	  else if (len >= fw->ja)
+	    e_pr_nstr (fw->xa + 1, fw->ya + i - fw->ia, fw->xe - fw->xa,
+		       *(fw->df->name + i) + fw->ja, ft, ft);
+	  else if (len < fw->ja)
+	    e_blk (fw->xe - fw->xa - 1, fw->xa + 1, fw->ya + i - fw->ia, ft);
 /*
    if ((len -= fw->ja) < 0) len = 0;
    e_blk(fw->xe-fw->xa-len-1, fw->xa+len+1, fw->ya+i-fw->ia, ft);
 */
-   if (sw)
-   {
-    fw->nyfo = e_lst_zeichen(fw->xe, fw->ya, fw->ye-fw->ya, 0,
-      fw->f->fb->em.fb, fw->df->anz, fw->nyfo, fw->nf);
-    fw->nxfo = e_lst_zeichen(fw->xa, fw->ye, fw->xe-fw->xa, 1,
-      fw->f->fb->em.fb, len, fw->nxfo, fw->ja);
-   }
-  }
- }
- for (; i-fw->ia < fw->ye-fw->ya; i++)
-  e_blk(fw->xe-fw->xa, fw->xa, fw->ya+i-fw->ia, ft);
+	  if (sw)
+	    {
+	      fw->nyfo = e_lst_zeichen (fw->xe, fw->ya, fw->ye - fw->ya, 0,
+					fw->f->fb->em.fb, fw->df->anz,
+					fw->nyfo, fw->nf);
+	      fw->nxfo =
+		e_lst_zeichen (fw->xa, fw->ye, fw->xe - fw->xa, 1,
+			       fw->f->fb->em.fb, len, fw->nxfo, fw->ja);
+	    }
+	}
+    }
+  for (; i - fw->ia < fw->ye - fw->ya; i++)
+    e_blk (fw->xe - fw->xa, fw->xa, fw->ya + i - fw->ia, ft);
 #ifdef NEWSTYLE
- e_make_xrect(fw->xa, fw->ya, fw->xe-1, fw->ye-1, 1);
- if (xrt)
-  e_make_xrect_abs(fw->xa, fw->ya+fw->nf-fw->ia, fw->xe-1, fw->ya+fw->nf-fw->ia, 0);
+  e_make_xrect (fw->xa, fw->ya, fw->xe - 1, fw->ye - 1, 1);
+  if (xrt)
+    e_make_xrect_abs (fw->xa, fw->ya + fw->nf - fw->ia, fw->xe - 1,
+		      fw->ya + fw->nf - fw->ia, 0);
 #endif
- return(0);
+  return (0);
 }
 
 
 struct help_ud
 {
- struct help_ud *next;
- char *str, *nstr, *pstr, *file;
- int x, y, sw;
+  struct help_ud *next;
+  char *str, *nstr, *pstr, *file;
+  int x, y, sw;
 } *ud_help;
 
 #ifdef HAVE_LIBZ
@@ -554,8 +642,8 @@ typedef gzFile IFILE;
 #else
 typedef struct
 {
- FILE *fp;
- int sw;
+  FILE *fp;
+  int sw;
 } ifile_s;
 
 typedef ifile_s *IFILE;
@@ -563,956 +651,1141 @@ typedef ifile_s *IFILE;
 #define e_i_fgets(s, n, p) fgets(s, n, p->fp)
 #endif
 
-int e_mkdir_path(char *path)
+int
+e_mkdir_path (char *path)
 {
- int i, len;
- char *tmp = malloc(((len=strlen(path))+1)*sizeof(char));
+  int i, len;
+  char *tmp = malloc (((len = strlen (path)) + 1) * sizeof (char));
 
- if (!tmp)
-  return(-1);
- strcpy(tmp, path);
- for (i = len; i > 0 && tmp[i] != DIRC; i--)
-  ;
- if (i > 0)
- {
-  tmp[i] = '\0';
-  if (access(tmp, F_OK))
-  {
-   e_mkdir_path(tmp);
-   mkdir(tmp, 0700);
-  }
- }
- free(tmp);
- return(0);
+  if (!tmp)
+    return (-1);
+  strcpy (tmp, path);
+  for (i = len; i > 0 && tmp[i] != DIRC; i--)
+    ;
+  if (i > 0)
+    {
+      tmp[i] = '\0';
+      if (access (tmp, F_OK))
+	{
+	  e_mkdir_path (tmp);
+	  mkdir (tmp, 0700);
+	}
+    }
+  free (tmp);
+  return (0);
 }
 
-IFILE e_i_fopen(char *path, char *stat)
+IFILE
+e_i_fopen (char *path, char *stat)
 {
- char *tmp2;
+  char *tmp2;
 #ifdef HAVE_LIBZ
- IFILE fp;
+  IFILE fp;
 
- if (!path) {  return(NULL);  }
- if ((fp = gzopen(path, stat))) {  return(fp);  }
- if (!(tmp2 = malloc((strlen(path)+11)*sizeof(char))))
- {
-  free(fp);
-  return(NULL);
- }
- strcpy(tmp2, path);
- strcat(tmp2, ".info");
- if ((fp = gzopen(tmp2, stat)))
- {
-  free(tmp2);
-  return(fp);
- }
- strcpy(tmp2, path);
- strcat(tmp2, ".gz");
- if ((fp = gzopen(tmp2, stat)))
- {
-  free(tmp2);
-  return(fp);
- }
- strcpy(tmp2, path);
- strcat(tmp2, ".Z");
- if ((fp = gzopen(tmp2, stat)))
- {
-  free(tmp2);
-  return(fp);
- }
- strcpy(tmp2, path);
- strcat(tmp2, ".info.gz");
- if ((fp = gzopen(tmp2, stat)))
- {
-  free(tmp2);
-  return(fp);
- }
- strcpy(tmp2, path);
- strcat(tmp2, ".info.Z");
- if ((fp = gzopen(tmp2, stat)))
- {
-  free(tmp2);
-  return(fp);
- }
- free(fp);
- free(tmp2);
- return(NULL);
-#else
- extern char *e_tmp_dir;
- char *tmp, *command;
- int len;
- IFILE fp = malloc(sizeof(IFILE));
-
- if (!fp) return(NULL);
- if (!path) {  free(fp); return(NULL);  }
- if ((fp->fp = fopen(path, stat))) {  fp->sw = 0;  return(fp);  }
- if (!(tmp2 = malloc((strlen(path)+11)*sizeof(char)))) 
- {
-  free(fp);
-  return(NULL);
- }
- strcpy(tmp2, path);
- strcat(tmp2, ".info");
- if ((fp->fp = fopen(tmp2, stat))) 
- {
-  free(tmp2);
-  fp->sw = 0;
-  return(fp);
- }
- strcpy(tmp2, path);
- strcat(tmp2, ".gz");
- if (access(tmp2, F_OK))
- {
-  strcpy(tmp2, path);
-  strcat(tmp2, ".Z");
-  if (access(tmp2, F_OK))
-  {
-   strcpy(tmp2, path);
-   strcat(tmp2, ".info.gz");
-   if (access(tmp2, F_OK))
-   {
-    strcpy(tmp2, path);
-    strcat(tmp2, ".info.Z");
-    if (access(tmp2, F_OK))
+  if (!path)
     {
-     free(fp);
-     free(tmp2);
-     return(NULL);
+      return (NULL);
     }
-   }
-  }
- }
- if (!(tmp = malloc((strlen(path)+(len=strlen(e_tmp_dir))+2)*sizeof(char)))) 
- {
-  free(fp);
-  free(tmp2);
-  return(NULL);
- }
- strcpy(tmp, e_tmp_dir);
- if (path[0] != DIRC) {  tmp[len] = DIRC;  tmp[len+1] = '\0';  }
- strcat(tmp, path);
- if ((fp->fp = fopen(tmp, stat)))
- {
-  fp->sw = 1;
-  free(tmp);
-  free(tmp2);
-  return(fp);
- }
- command = malloc((strlen(tmp) + strlen(tmp2) + 14) * sizeof(char));
- if (!command) {  free(fp);  free(tmp);  free(tmp2);  return(NULL);  }
- e_mkdir_path(tmp);
- sprintf(command, "gunzip < %s > %s", tmp2, tmp);
- free(tmp2);
- int ret = system(command);
-	if (WIFSIGNALED(ret) && (WTERMSIG(ret) == SIGINT || WTERMSIG(ret) == SIGQUIT)) {
-		printf("System call command %s resulted in an interrupt.\n%s\n", 
-			command,
-			"Program will quit executing commands.\n");
-	} else if (ret == 127) {
-		printf("System call command %s failed with code 127\n%s\n%s\n%s\n", 
-			command, 
-			"This could mean one of two things:",
-			"1. No shell was available (should never happen unless using chroot)"
-			"2. The command returned 127.\n");
-	} else if (ret != 0) {
-		printf("System call command %s failed. Return code = %i.\n", command, ret);
+  if ((fp = gzopen (path, stat)))
+    {
+      return (fp);
+    }
+  if (!(tmp2 = malloc ((strlen (path) + 11) * sizeof (char))))
+    {
+      free (fp);
+      return (NULL);
+    }
+  strcpy (tmp2, path);
+  strcat (tmp2, ".info");
+  if ((fp = gzopen (tmp2, stat)))
+    {
+      free (tmp2);
+      return (fp);
+    }
+  strcpy (tmp2, path);
+  strcat (tmp2, ".gz");
+  if ((fp = gzopen (tmp2, stat)))
+    {
+      free (tmp2);
+      return (fp);
+    }
+  strcpy (tmp2, path);
+  strcat (tmp2, ".Z");
+  if ((fp = gzopen (tmp2, stat)))
+    {
+      free (tmp2);
+      return (fp);
+    }
+  strcpy (tmp2, path);
+  strcat (tmp2, ".info.gz");
+  if ((fp = gzopen (tmp2, stat)))
+    {
+      free (tmp2);
+      return (fp);
+    }
+  strcpy (tmp2, path);
+  strcat (tmp2, ".info.Z");
+  if ((fp = gzopen (tmp2, stat)))
+    {
+      free (tmp2);
+      return (fp);
+    }
+  free (fp);
+  free (tmp2);
+  return (NULL);
+#else
+  extern char *e_tmp_dir;
+  char *tmp, *command;
+  int len;
+  IFILE fp = malloc (sizeof (IFILE));
+
+  if (!fp)
+    return (NULL);
+  if (!path)
+    {
+      free (fp);
+      return (NULL);
+    }
+  if ((fp->fp = fopen (path, stat)))
+    {
+      fp->sw = 0;
+      return (fp);
+    }
+  if (!(tmp2 = malloc ((strlen (path) + 11) * sizeof (char))))
+    {
+      free (fp);
+      return (NULL);
+    }
+  strcpy (tmp2, path);
+  strcat (tmp2, ".info");
+  if ((fp->fp = fopen (tmp2, stat)))
+    {
+      free (tmp2);
+      fp->sw = 0;
+      return (fp);
+    }
+  strcpy (tmp2, path);
+  strcat (tmp2, ".gz");
+  if (access (tmp2, F_OK))
+    {
+      strcpy (tmp2, path);
+      strcat (tmp2, ".Z");
+      if (access (tmp2, F_OK))
+	{
+	  strcpy (tmp2, path);
+	  strcat (tmp2, ".info.gz");
+	  if (access (tmp2, F_OK))
+	    {
+	      strcpy (tmp2, path);
+	      strcat (tmp2, ".info.Z");
+	      if (access (tmp2, F_OK))
+		{
+		  free (fp);
+		  free (tmp2);
+		  return (NULL);
+		}
+	    }
 	}
- free(command);  
- fp->fp = fopen(tmp, stat);
- free(tmp);
- if (!fp->fp) {  free(fp);  return(NULL);  }
- fp->sw = 1;
- return(fp);  
+    }
+  if (!
+      (tmp =
+       malloc ((strlen (path) + (len = strlen (e_tmp_dir)) +
+		2) * sizeof (char))))
+    {
+      free (fp);
+      free (tmp2);
+      return (NULL);
+    }
+  strcpy (tmp, e_tmp_dir);
+  if (path[0] != DIRC)
+    {
+      tmp[len] = DIRC;
+      tmp[len + 1] = '\0';
+    }
+  strcat (tmp, path);
+  if ((fp->fp = fopen (tmp, stat)))
+    {
+      fp->sw = 1;
+      free (tmp);
+      free (tmp2);
+      return (fp);
+    }
+  command = malloc ((strlen (tmp) + strlen (tmp2) + 14) * sizeof (char));
+  if (!command)
+    {
+      free (fp);
+      free (tmp);
+      free (tmp2);
+      return (NULL);
+    }
+  e_mkdir_path (tmp);
+  sprintf (command, "gunzip < %s > %s", tmp2, tmp);
+  free (tmp2);
+  int ret = system (command);
+  if (WIFSIGNALED (ret)
+      && (WTERMSIG (ret) == SIGINT || WTERMSIG (ret) == SIGQUIT))
+    {
+      printf ("System call command %s resulted in an interrupt.\n%s\n",
+	      command, "Program will quit executing commands.\n");
+    }
+  else if (ret == 127)
+    {
+      printf ("System call command %s failed with code 127\n%s\n%s\n%s\n",
+	      command,
+	      "This could mean one of two things:",
+	      "1. No shell was available (should never happen unless using chroot)"
+	      "2. The command returned 127.\n");
+    }
+  else if (ret != 0)
+    {
+      printf ("System call command %s failed. Return code = %i.\n", command,
+	      ret);
+    }
+  free (command);
+  fp->fp = fopen (tmp, stat);
+  free (tmp);
+  if (!fp->fp)
+    {
+      free (fp);
+      return (NULL);
+    }
+  fp->sw = 1;
+  return (fp);
 #endif
 }
 
 #ifndef HAVE_LIBZ
-int e_i_fclose(IFILE fp)
+int
+e_i_fclose (IFILE fp)
 {
- int ret = fclose(fp->fp);
+  int ret = fclose (fp->fp);
 
- free(fp);
- return(ret);
+  free (fp);
+  return (ret);
 }
 #endif
 
-int e_read_help(char *str, FENSTER *f, int sw)
+int
+e_read_help (char *str, FENSTER * f, int sw)
 {
- IFILE fp;
- char *ptmp, tstr[256];
- int i;
+  IFILE fp;
+  char *ptmp, tstr[256];
+  int i;
 
- ptmp = e_mkfilename(LIBRARY_DIR, HELP_FILE);
- fp = e_i_fopen(ptmp, "rb");
- free(ptmp);
- if (!fp)
-  return(1);
- e_close_buffer(f->b);
- if ((f->b = (BUFFER *) malloc(sizeof(BUFFER))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
- if ((f->b->bf = (STRING *) malloc(MAXLINES*sizeof(STRING))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
- f->b->f = f;
- f->b->b = e_set_pnt(0, 0);
- f->b->mx = e_set_pnt(f->ed->maxcol, MAXLINES);
- f->b->mxlines = 0;
- f->b->fb = f->fb;
- f->b->cn = f->ed;
- f->b->ud = NULL;
- e_new_line(0, f->b);
- if (str && str[0])
- {
-  while ((ptmp = e_i_fgets(tstr, 256, fp)) && !WpeStrcstr(tstr, str))
-   ;
-  if (ptmp && !sw)
-  {
-   strcpy((char *)f->b->bf[f->b->mxlines-1].s, tstr);
-   f->b->bf[f->b->mxlines-1].len = e_str_len(f->b->bf[f->b->mxlines-1].s);
-   f->b->bf[f->b->mxlines-1].nrc = strlen((const char *)f->b->bf[f->b->mxlines-1].s);
-  }
- }
- if (sw)
- {
-  char *tp = NULL, tmp[128], ts[2];
+  ptmp = e_mkfilename (LIBRARY_DIR, HELP_FILE);
+  fp = e_i_fopen (ptmp, "rb");
+  free (ptmp);
+  if (!fp)
+    return (1);
+  e_close_buffer (f->b);
+  if ((f->b = (BUFFER *) malloc (sizeof (BUFFER))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  if ((f->b->bf = (STRING *) malloc (MAXLINES * sizeof (STRING))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  f->b->f = f;
+  f->b->b = e_set_pnt (0, 0);
+  f->b->mx = e_set_pnt (f->ed->maxcol, MAXLINES);
+  f->b->mxlines = 0;
+  f->b->fb = f->fb;
+  f->b->cn = f->ed;
+  f->b->ud = NULL;
+  e_new_line (0, f->b);
+  if (str && str[0])
+    {
+      while ((ptmp = e_i_fgets (tstr, 256, fp)) && !WpeStrcstr (tstr, str))
+	;
+      if (ptmp && !sw)
+	{
+	  strcpy ((char *) f->b->bf[f->b->mxlines - 1].s, tstr);
+	  f->b->bf[f->b->mxlines - 1].len =
+	    e_str_len (f->b->bf[f->b->mxlines - 1].s);
+	  f->b->bf[f->b->mxlines - 1].nrc =
+	    strlen ((const char *) f->b->bf[f->b->mxlines - 1].s);
+	}
+    }
+  if (sw)
+    {
+      char *tp = NULL, tmp[128], ts[2];
 
-  ts[0] = HHD; ts[1] = '\0';
-  while ((ptmp = e_i_fgets(tstr, 256, fp)) && !(tp = strstr(tstr, ts)))
-   ;
-  if (!str || !str[0])
-   while((ptmp = e_i_fgets(tstr, 256, fp)) && !(tp = strstr(tstr, ts)))
-    ;
-  if (!ptmp)
-  {
-   e_i_fclose(fp);
-   return(e_error("No Next Page", 0, f->fb));
-  }
-  else
-  {
-   for (i = 0; (tmp[i] = tp[i]) && tp[i] != HED; i++)
-    ;
-   tmp[i] = HED;  tmp[i+1] = '\0';
-   if ((ud_help->str = malloc((strlen(tmp)+1)*sizeof(char))) != NULL)
-    strcpy(ud_help->str, tmp);
-   strcpy((char *)f->b->bf[f->b->mxlines-1].s, tstr);
-   f->b->bf[f->b->mxlines-1].len = e_str_len(f->b->bf[f->b->mxlines-1].s);
-   f->b->bf[f->b->mxlines-1].nrc = strlen((const char *)f->b->bf[f->b->mxlines-1].s);
-  }
- }
- while(e_i_fgets(tstr, 256, fp))
- {
-  for(i = 0; tstr[i]; i++)
-  if (tstr[i] == HFE)  {  e_i_fclose(fp);  return(0);  }
-  e_new_line(f->b->mxlines, f->b);
-  strcpy((char *)f->b->bf[f->b->mxlines-1].s, tstr);
-  f->b->bf[f->b->mxlines-1].len = e_str_len(f->b->bf[f->b->mxlines-1].s);
-  f->b->bf[f->b->mxlines-1].nrc = strlen((const char *)f->b->bf[f->b->mxlines-1].s);
- }
- e_i_fclose(fp);
- return(2);
-}
-
-int e_help_ret(FENSTER *f)
-{
- BUFFER *b = f->b;
- int i, j;
- unsigned char str[126];
- struct help_ud *next;
-
-   for(i = b->b.x; i >= 0 && b->bf[b->b.y].s[i] != HED; i--)
-   {  if(b->bf[b->b.y].s[i] == HBG)
-      {  str[0] = HHD;
-	 for(j = i+1; j < b->bf[b->b.y].len
-			&& (str[j-i] = b->bf[b->b.y].s[j]) != HED; j++);
-	 str[j-i+1] = '\0';
-	 if((next = malloc(sizeof(struct help_ud))) != NULL)
-	 {  next->str = malloc((strlen((const char *)str)+1) * sizeof(char));
-	    if(next->str) strcpy(next->str, (const char *)str);
-            if(ud_help && ud_help->file)
-            {  next->file = malloc((strlen(ud_help->file)+1) * sizeof(char));
-               if(next->file) strcpy(next->file, ud_help->file);
-            }
-            else next->file = NULL;
-            next->nstr = next->pstr = NULL;
-            next->x = b->b.x;
-            next->y = b->b.y;
-            next->sw = ud_help ? ud_help->sw : 0;
-	    next->next = ud_help;
-	    ud_help = next;
-	 }
-         if(ud_help->sw) e_read_info(str, f, ud_help->file);
-	 else e_read_help((char *)str, f, 0);
-	 b = f->b; b->b.x = b->b.y = 0;
-	 e_cursor(f, 1);
-	 e_schirm(f, 1);
-	 return(0);
-      }
-      else if(b->bf[b->b.y].s[i] == HNF)
-      {  for(i++; i < b->bf[b->b.y].len && b->bf[b->b.y].s[i] != HED; i++) {
-		;
-	 }
-	 for(i++, j = 0; j+i < b->bf[b->b.y].len
-			&& (str[j] = b->bf[b->b.y].s[j+i]) != HED; j++);
-	 str[j] = '\0';
-	 if((next = malloc(sizeof(struct help_ud))) != NULL)
-	 {  next->str = malloc(4 * sizeof(char));
-	    if(next->str) strcpy(next->str, "Top");
-            next->file = malloc((strlen((const char *)str)+1) * sizeof(char));
-            if(next->file) strcpy(next->file, (const char *)str);
-            next->sw = 1;
-	    next->next = ud_help;
-            next->x = b->b.x;
-            next->y = b->b.y;
-            next->nstr = next->pstr = NULL;
-	    ud_help = next;
-	 }
-         e_read_info("Top", f, ud_help->file);
-	 b = f->b; b->b.x = b->b.y = 0;
-	 e_cursor(f, 1);
-	 e_schirm(f, 1);
-	 return(0);
-      }
-      else if(b->bf[b->b.y].s[i] == HFB)
-      {  for(j = i+1; j < b->bf[b->b.y].len
-			&& (str[j-i-1] = b->bf[b->b.y].s[j]) != HED; j++) {
-		;
-	 }
-	 str[j-i-1] = '\0';
-	 return(e_ed_man(str, f));
-      }
-      else if(b->bf[b->b.y].s[i] == HHD) return(e_help_last(f));
-   }
-   return(1);
-}
-
-int e_help_last(FENSTER *f)
-{
- struct help_ud *last = ud_help;
-
- if (!last)
-  return(1);
- if (last->sw)
- {
-  if (last->next == NULL)
-   e_read_info(NULL, f, NULL);
-  else
-   e_read_info(last->next->str, f, last->next->file);
- }
- else
- {
-  if (last->next == NULL)
-   e_read_help(NULL, f, 0);
-  else
-   e_read_help(last->next->str, f, 0);
- }
- f->b->b.x = last->x;  
- f->b->b.y = last->y;
- e_cursor(f, 1);
- e_schirm(f, 1);
- ud_help = last->next;
- free(last->str);
- free(last);
- return(0);
-}
-
-int e_help_next(FENSTER *f, int sw)
-{
-   struct help_ud *last = ud_help;
-   if(last && last->sw)
-   {  if(sw && last->nstr)
-      {  if(last->str) free(last->str);
-         if(last->pstr) free(last->pstr);
-         last->str = last->nstr;
-         last->nstr = NULL;
-      }
-      else if(!sw && last->pstr)
-      {  if(last->str) free(last->str);
-         if(last->nstr) free(last->nstr);
-         last->str = last->pstr;
-         last->pstr = NULL;
-      }
+      ts[0] = HHD;
+      ts[1] = '\0';
+      while ((ptmp = e_i_fgets (tstr, 256, fp)) && !(tp = strstr (tstr, ts)))
+	;
+      if (!str || !str[0])
+	while ((ptmp = e_i_fgets (tstr, 256, fp))
+	       && !(tp = strstr (tstr, ts)))
+	  ;
+      if (!ptmp)
+	{
+	  e_i_fclose (fp);
+	  return (e_error ("No Next Page", 0, f->fb));
+	}
       else
-         return(e_error(sw ? "No Next Page" : "No Previous Page", 0, f->fb));
-      e_read_info(last->str, f, last->file);
+	{
+	  for (i = 0; (tmp[i] = tp[i]) && tp[i] != HED; i++)
+	    ;
+	  tmp[i] = HED;
+	  tmp[i + 1] = '\0';
+	  if ((ud_help->str =
+	       malloc ((strlen (tmp) + 1) * sizeof (char))) != NULL)
+	    strcpy (ud_help->str, tmp);
+	  strcpy ((char *) f->b->bf[f->b->mxlines - 1].s, tstr);
+	  f->b->bf[f->b->mxlines - 1].len =
+	    e_str_len (f->b->bf[f->b->mxlines - 1].s);
+	  f->b->bf[f->b->mxlines - 1].nrc =
+	    strlen ((const char *) f->b->bf[f->b->mxlines - 1].s);
+	}
+    }
+  while (e_i_fgets (tstr, 256, fp))
+    {
+      for (i = 0; tstr[i]; i++)
+	if (tstr[i] == HFE)
+	  {
+	    e_i_fclose (fp);
+	    return (0);
+	  }
+      e_new_line (f->b->mxlines, f->b);
+      strcpy ((char *) f->b->bf[f->b->mxlines - 1].s, tstr);
+      f->b->bf[f->b->mxlines - 1].len =
+	e_str_len (f->b->bf[f->b->mxlines - 1].s);
+      f->b->bf[f->b->mxlines - 1].nrc =
+	strlen ((const char *) f->b->bf[f->b->mxlines - 1].s);
+    }
+  e_i_fclose (fp);
+  return (2);
+}
+
+int
+e_help_ret (FENSTER * f)
+{
+  BUFFER *b = f->b;
+  int i, j;
+  unsigned char str[126];
+  struct help_ud *next;
+
+  for (i = b->b.x; i >= 0 && b->bf[b->b.y].s[i] != HED; i--)
+    {
+      if (b->bf[b->b.y].s[i] == HBG)
+	{
+	  str[0] = HHD;
+	  for (j = i + 1; j < b->bf[b->b.y].len
+	       && (str[j - i] = b->bf[b->b.y].s[j]) != HED; j++);
+	  str[j - i + 1] = '\0';
+	  if ((next = malloc (sizeof (struct help_ud))) != NULL)
+	    {
+	      next->str =
+		malloc ((strlen ((const char *) str) + 1) * sizeof (char));
+	      if (next->str)
+		strcpy (next->str, (const char *) str);
+	      if (ud_help && ud_help->file)
+		{
+		  next->file =
+		    malloc ((strlen (ud_help->file) + 1) * sizeof (char));
+		  if (next->file)
+		    strcpy (next->file, ud_help->file);
+		}
+	      else
+		next->file = NULL;
+	      next->nstr = next->pstr = NULL;
+	      next->x = b->b.x;
+	      next->y = b->b.y;
+	      next->sw = ud_help ? ud_help->sw : 0;
+	      next->next = ud_help;
+	      ud_help = next;
+	    }
+	  if (ud_help->sw)
+	    e_read_info (str, f, ud_help->file);
+	  else
+	    e_read_help ((char *) str, f, 0);
+	  b = f->b;
+	  b->b.x = b->b.y = 0;
+	  e_cursor (f, 1);
+	  e_schirm (f, 1);
+	  return (0);
+	}
+      else if (b->bf[b->b.y].s[i] == HNF)
+	{
+	  for (i++; i < b->bf[b->b.y].len && b->bf[b->b.y].s[i] != HED; i++)
+	    {
+	      ;
+	    }
+	  for (i++, j = 0; j + i < b->bf[b->b.y].len
+	       && (str[j] = b->bf[b->b.y].s[j + i]) != HED; j++);
+	  str[j] = '\0';
+	  if ((next = malloc (sizeof (struct help_ud))) != NULL)
+	    {
+	      next->str = malloc (4 * sizeof (char));
+	      if (next->str)
+		strcpy (next->str, "Top");
+	      next->file =
+		malloc ((strlen ((const char *) str) + 1) * sizeof (char));
+	      if (next->file)
+		strcpy (next->file, (const char *) str);
+	      next->sw = 1;
+	      next->next = ud_help;
+	      next->x = b->b.x;
+	      next->y = b->b.y;
+	      next->nstr = next->pstr = NULL;
+	      ud_help = next;
+	    }
+	  e_read_info ("Top", f, ud_help->file);
+	  b = f->b;
+	  b->b.x = b->b.y = 0;
+	  e_cursor (f, 1);
+	  e_schirm (f, 1);
+	  return (0);
+	}
+      else if (b->bf[b->b.y].s[i] == HFB)
+	{
+	  for (j = i + 1; j < b->bf[b->b.y].len
+	       && (str[j - i - 1] = b->bf[b->b.y].s[j]) != HED; j++)
+	    {
+	      ;
+	    }
+	  str[j - i - 1] = '\0';
+	  return (e_ed_man (str, f));
+	}
+      else if (b->bf[b->b.y].s[i] == HHD)
+	return (e_help_last (f));
+    }
+  return (1);
+}
+
+int
+e_help_last (FENSTER * f)
+{
+  struct help_ud *last = ud_help;
+
+  if (!last)
+    return (1);
+  if (last->sw)
+    {
+      if (last->next == NULL)
+	e_read_info (NULL, f, NULL);
+      else
+	e_read_info (last->next->str, f, last->next->file);
+    }
+  else
+    {
+      if (last->next == NULL)
+	e_read_help (NULL, f, 0);
+      else
+	e_read_help (last->next->str, f, 0);
+    }
+  f->b->b.x = last->x;
+  f->b->b.y = last->y;
+  e_cursor (f, 1);
+  e_schirm (f, 1);
+  ud_help = last->next;
+  free (last->str);
+  free (last);
+  return (0);
+}
+
+int
+e_help_next (FENSTER * f, int sw)
+{
+  struct help_ud *last = ud_help;
+  if (last && last->sw)
+    {
+      if (sw && last->nstr)
+	{
+	  if (last->str)
+	    free (last->str);
+	  if (last->pstr)
+	    free (last->pstr);
+	  last->str = last->nstr;
+	  last->nstr = NULL;
+	}
+      else if (!sw && last->pstr)
+	{
+	  if (last->str)
+	    free (last->str);
+	  if (last->nstr)
+	    free (last->nstr);
+	  last->str = last->pstr;
+	  last->pstr = NULL;
+	}
+      else
+	return (e_error (sw ? "No Next Page" : "No Previous Page", 0, f->fb));
+      e_read_info (last->str, f, last->file);
       f->b->b.x = f->b->b.y = 0;
-      e_cursor(f, 1);
-      e_schirm(f, 1);
-      return(0);
-   }
-   else
-   {  if(sw)
-      {  if((last = malloc(sizeof(struct help_ud))) != NULL)
-	 {  last->str = NULL;
-            last->file = NULL;
-	    last->x = last->y = 0;
-	    last->nstr = last->pstr = NULL;
-	    last->sw = 0;
-	    last->next = ud_help;
-	    ud_help = last;
-	    e_read_help(ud_help->next ? ud_help->next->str : NULL, f, 1);
-            f->b->b.x = f->b->b.y = 0;
-            e_cursor(f, 1);
-            e_schirm(f, 1);
-            return(0);
-	 }
-      }
-      else return(e_help_last(f));
-   }
-   return(e_error(sw ? "No Next Page" : "No Previous Page", 0, f->fb));
+      e_cursor (f, 1);
+      e_schirm (f, 1);
+      return (0);
+    }
+  else
+    {
+      if (sw)
+	{
+	  if ((last = malloc (sizeof (struct help_ud))) != NULL)
+	    {
+	      last->str = NULL;
+	      last->file = NULL;
+	      last->x = last->y = 0;
+	      last->nstr = last->pstr = NULL;
+	      last->sw = 0;
+	      last->next = ud_help;
+	      ud_help = last;
+	      e_read_help (ud_help->next ? ud_help->next->str : NULL, f, 1);
+	      f->b->b.x = f->b->b.y = 0;
+	      e_cursor (f, 1);
+	      e_schirm (f, 1);
+	      return (0);
+	    }
+	}
+      else
+	return (e_help_last (f));
+    }
+  return (e_error (sw ? "No Next Page" : "No Previous Page", 0, f->fb));
 }
 
-int e_help_free(FENSTER *f)
+int
+e_help_free (FENSTER * f)
 {
- UNUSED(f);
- struct help_ud *next, *last = ud_help;
+  UNUSED (f);
+  struct help_ud *next, *last = ud_help;
 
- while (last)
- {
-  next = last->next;
-  if (last->str) free(last->str);
-  if (last->pstr) free(last->pstr);
-  if (last->nstr) free(last->nstr);
-  if (last->file) free(last->file);
-  free(last);
-  last = next;
- }
- ud_help = NULL;
- return(0);
+  while (last)
+    {
+      next = last->next;
+      if (last->str)
+	free (last->str);
+      if (last->pstr)
+	free (last->pstr);
+      if (last->nstr)
+	free (last->nstr);
+      if (last->file)
+	free (last->file);
+      free (last);
+      last = next;
+    }
+  ud_help = NULL;
+  return (0);
 }
 
-int e_help_comp(FENSTER *f)
+int
+e_help_comp (FENSTER * f)
 {
- BUFFER *b = f->b;
- int i, j, k, hn = 0, sn = 0;
- char **swtch = malloc(sizeof(char *));
- char **hdrs = malloc(sizeof(char *));
- char str[256];
+  BUFFER *b = f->b;
+  int i, j, k, hn = 0, sn = 0;
+  char **swtch = malloc (sizeof (char *));
+  char **hdrs = malloc (sizeof (char *));
+  char str[256];
 
- if (f->dtmd != DTMD_HELP) return(1);
- for (j = 0; j < b->mxlines; j++)
- {
-  for (i = 0; i < b->bf[j].len; i++)
-  {
-   if (b->bf[j].s[i] == HBG)
-   {
-    for (k = i+1; k < b->bf[j].len && (str[k-i-1] = b->bf[j].s[k]) != HED &&
-      str[k-i-1] != HBG && str[k-i-1] != HHD && str[k-i-1] != HFE ; k++)
-     ;
-    if (str[k-i-1] != HED)
+  if (f->dtmd != DTMD_HELP)
+    return (1);
+  for (j = 0; j < b->mxlines; j++)
     {
-     e_error("Error in Switch!", 0, f->fb);
-     b->b.x = k;  b->b.y = j;
-     e_cursor(f, 1);
-     return(2);
+      for (i = 0; i < b->bf[j].len; i++)
+	{
+	  if (b->bf[j].s[i] == HBG)
+	    {
+	      for (k = i + 1;
+		   k < b->bf[j].len && (str[k - i - 1] = b->bf[j].s[k]) != HED
+		   && str[k - i - 1] != HBG && str[k - i - 1] != HHD
+		   && str[k - i - 1] != HFE; k++)
+		;
+	      if (str[k - i - 1] != HED)
+		{
+		  e_error ("Error in Switch!", 0, f->fb);
+		  b->b.x = k;
+		  b->b.y = j;
+		  e_cursor (f, 1);
+		  return (2);
+		}
+	      str[k - i - 1] = '\0';
+	      sn++;
+	      swtch = realloc (swtch, sn * sizeof (char *));
+	      swtch[sn - 1] = malloc ((strlen (str) + 1) + sizeof (char));
+	      strcpy (swtch[sn - 1], str);
+	    }
+	}
     }
-    str[k-i-1] = '\0';
-    sn++;
-    swtch = realloc(swtch, sn * sizeof(char *));
-    swtch[sn-1] = malloc((strlen(str) + 1) + sizeof(char));
-    strcpy(swtch[sn-1], str);
-   }
-  }
- }
- for (j = 0; j < b->mxlines; j++)
- {
-  for (i = 0; i < b->bf[j].len; i++)
-  {
-   if (b->bf[j].s[i] == HHD)
-   {
-    for (k = i+1; k < b->bf[j].len && (str[k-i-1] = b->bf[j].s[k]) != HED &&
-      str[k-i-1] != HBG && str[k-i-1] != HHD && str[k-i-1] != HFE ; k++)
-     ;
-    if (str[k-i-1] != HED)
+  for (j = 0; j < b->mxlines; j++)
     {
-     e_error("Error in Header!", 0, f->fb);
-     b->b.x = k;  b->b.y = j;
-     e_cursor(f, 1);
-     return(2);
+      for (i = 0; i < b->bf[j].len; i++)
+	{
+	  if (b->bf[j].s[i] == HHD)
+	    {
+	      for (k = i + 1;
+		   k < b->bf[j].len && (str[k - i - 1] = b->bf[j].s[k]) != HED
+		   && str[k - i - 1] != HBG && str[k - i - 1] != HHD
+		   && str[k - i - 1] != HFE; k++)
+		;
+	      if (str[k - i - 1] != HED)
+		{
+		  e_error ("Error in Header!", 0, f->fb);
+		  b->b.x = k;
+		  b->b.y = j;
+		  e_cursor (f, 1);
+		  return (2);
+		}
+	      str[k - i - 1] = '\0';
+	      hn++;
+	      hdrs = realloc (hdrs, hn * sizeof (char *));
+	      hdrs[hn - 1] = malloc ((strlen (str) + 1) + sizeof (char));
+	      strcpy (hdrs[hn - 1], str);
+	    }
+	}
     }
-    str[k-i-1] = '\0';
-    hn++;
-    hdrs = realloc(hdrs, hn * sizeof(char *));
-    hdrs[hn-1] = malloc((strlen(str) + 1) + sizeof(char));
-    strcpy(hdrs[hn-1], str);
-   }
-  }
- }
- for (j = 0; j < sn; j++)
- {
-  for (i = 0; i < hn; i++) if(!WpeStrccmp(swtch[j], hdrs[i])) break;
-  if (i >= hn)
-  {
-   sprintf(str, "Switch \'%s\' has no Header!", swtch[j]);
-   e_error(str, 0, f->fb);
-   goto ende;
-  }
- }
- for (j = 0; j < hn; j++)
- {
-  for (i = 0; i < sn; i++) if(!WpeStrccmp(swtch[i], hdrs[j])) break;
-  if (i >= sn)
-  {
-   sprintf(str, "No Jump to Header \'%s\'!", hdrs[j]);
-   e_error(str, 0, f->fb);
-   goto ende;
-  }
- }
+  for (j = 0; j < sn; j++)
+    {
+      for (i = 0; i < hn; i++)
+	if (!WpeStrccmp (swtch[j], hdrs[i]))
+	  break;
+      if (i >= hn)
+	{
+	  sprintf (str, "Switch \'%s\' has no Header!", swtch[j]);
+	  e_error (str, 0, f->fb);
+	  goto ende;
+	}
+    }
+  for (j = 0; j < hn; j++)
+    {
+      for (i = 0; i < sn; i++)
+	if (!WpeStrccmp (swtch[i], hdrs[j]))
+	  break;
+      if (i >= sn)
+	{
+	  sprintf (str, "No Jump to Header \'%s\'!", hdrs[j]);
+	  e_error (str, 0, f->fb);
+	  goto ende;
+	}
+    }
 ende:
- for (i = 0; i < sn; i++) free(swtch[i]);
- for (i = 0; i < hn; i++) free(hdrs[i]);
- free(swtch);
- free(hdrs);
- return(0);
+  for (i = 0; i < sn; i++)
+    free (swtch[i]);
+  for (i = 0; i < hn; i++)
+    free (hdrs[i]);
+  free (swtch);
+  free (hdrs);
+  return (0);
 }
 
 /*          Help window    */
-int e_help(FENSTER *f)
+int
+e_help (FENSTER * f)
 {
- extern char *e_hlp;
+  extern char *e_hlp;
 
- e_hlp = NULL;
- return(e_help_loc(f, 0));
+  e_hlp = NULL;
+  return (e_help_loc (f, 0));
 }
 
-int e_info(FENSTER *f)
+int
+e_info (FENSTER * f)
 {
- extern char *e_hlp;
+  extern char *e_hlp;
 
- e_hlp = NULL;
- return(e_help_loc(f, 1));
+  e_hlp = NULL;
+  return (e_help_loc (f, 1));
 }
 
 #define IFE 31
 
-int e_mk_info_button(char *str)
+int
+e_mk_info_button (char *str)
 {
- int i, bg, nd, len = strlen(str);
+  int i, bg, nd, len = strlen (str);
 
- if (str[0] == '\n' || str[0] == '\0')
-  return(1);
- for (bg = 0; str[bg] && isspace(str[bg]); bg++)
-  ;
- for (nd = bg; str[nd] && (str[nd] != ':' || 
-   (!isspace(str[nd+1]) && (str[nd+1] != '(') && (str[nd+1] != ':' || 
-   (!isspace(str[nd+2]) && str[nd+2] != '.')))); nd++)
-  ;
- if (!str[nd]) return(-1);
- if (str[nd+1] != ':')
- {
-  for (nd++; str[nd] && isspace(str[nd]); nd++);
-  if (str[nd] == '(')
-  {
-   for (i = len; i >= bg; i--)
-    str[i+1] = str[i];
-   str[bg] = HNF;
-   str[nd+1] = HED;
-   for (nd++; str[nd] && str[nd] && str[nd] != ')'; nd++);
-   if (str[nd])
-    str[nd] = HED;
-   return(0);
-  }
-  for (; str[nd] && (str[nd] != '.' || isalnum1(str[nd+1])); nd++);
-  if (!str[nd]) return(-1);
-  for (bg = nd; str[bg] != ':' || !isspace(str[bg+1]); bg--);
-  for (bg++; isspace(str[bg]); bg++);
- }
- for (i = len; i >= nd; i--)
-  str[i+2] = str[i];
- str[nd+1] = HED;
- for (; i >= bg; i--)
-  str[i+1] = str[i];
- str[bg] = HBG;
- return(0);
-}
-
-int e_mk_info_mrk(char *str)
-{
- int bg, nd = -1;
-
- do
- {
-  for (bg = nd+1; str[bg] && str[bg] != '`'; bg++)
-   ;
-  for (nd = bg; str[nd] && str[nd] != '\''; nd++)
-   ;
-  if (str[nd])
-  {
-   str[bg] = HBB;
-   str[nd] = HED;
-  }
- } while(str[nd]);
- return(0);
-}
-
-IFILE e_info_jump(char *str, char **path, IFILE fp)
-{
- IFILE fpn;
- int i, j, n, anz = 0;
- char *ptmp, *fstr, tstr[256], nfl[128];
- struct FL_INFO{  char *name; int line;  } **files = malloc(1);
-
- while (e_i_fgets(tstr, 256, fp) && tstr[0] != IFE)
- {
-  for (i = 0; (nfl[i] = tstr[i]) && tstr[i] != ':'; i++)
-   ;
-  if (!tstr[i]) continue;
-  nfl[i] = '\0';
-  anz++;
-  files = realloc(files, anz * sizeof(struct FL_INFO *));
-  files[anz-1] = malloc(sizeof(struct FL_INFO));
-  files[anz-1]->name = malloc((strlen(nfl)+1)*sizeof(char));
-  strcpy(files[anz-1]->name, nfl);
-  files[anz-1]->line = atoi(tstr+i+1);
- }
- i = (strlen(str) + 6);
- fstr = malloc((i+1) * sizeof(char));
- strcat(strcpy(fstr, "Node: "), str);
- if (fstr[n = strlen(fstr)-1] == HED) {  fstr[n] = '\0';  i--;  }
- while ((ptmp = e_i_fgets(tstr, 256, fp)) && strncmp(tstr, fstr, i))
-  ;
- if (ptmp)
- {
-  n = atoi(tstr+i+1);
-  for (i = 1; i < anz && n >= files[i]->line; i++)
-   ;
-  if (files[i-1]->name[0] == DIRC)
-  {
-   ptmp = malloc((strlen(files[i-1]->name)+1)*sizeof(char));
-   strcpy(ptmp, files[i-1]->name);
-  }
-  else
-  {
-   for (n = strlen(*path)-1; n >= 0 && *(*path+n) != DIRC; n--)
+  if (str[0] == '\n' || str[0] == '\0')
+    return (1);
+  for (bg = 0; str[bg] && isspace (str[bg]); bg++)
     ;
-   n++;
-   ptmp = malloc((strlen(files[i-1]->name)+n+1)*sizeof(char));
-   for (j = 0; j < n; j++)
-    ptmp[j] = *(*path+j);
-   ptmp[j] = '\0';
-   strcat(ptmp, files[i-1]->name);
-  }
-  if ((fpn = e_i_fopen(ptmp, "rb")) != NULL)
+  for (nd = bg; str[nd] && (str[nd] != ':' ||
+			    (!isspace (str[nd + 1]) && (str[nd + 1] != '(')
+			     && (str[nd + 1] != ':'
+				 || (!isspace (str[nd + 2])
+				     && str[nd + 2] != '.')))); nd++)
+    ;
+  if (!str[nd])
+    return (-1);
+  if (str[nd + 1] != ':')
+    {
+      for (nd++; str[nd] && isspace (str[nd]); nd++);
+      if (str[nd] == '(')
+	{
+	  for (i = len; i >= bg; i--)
+	    str[i + 1] = str[i];
+	  str[bg] = HNF;
+	  str[nd + 1] = HED;
+	  for (nd++; str[nd] && str[nd] && str[nd] != ')'; nd++);
+	  if (str[nd])
+	    str[nd] = HED;
+	  return (0);
+	}
+      for (; str[nd] && (str[nd] != '.' || isalnum1 (str[nd + 1])); nd++);
+      if (!str[nd])
+	return (-1);
+      for (bg = nd; str[bg] != ':' || !isspace (str[bg + 1]); bg--);
+      for (bg++; isspace (str[bg]); bg++);
+    }
+  for (i = len; i >= nd; i--)
+    str[i + 2] = str[i];
+  str[nd + 1] = HED;
+  for (; i >= bg; i--)
+    str[i + 1] = str[i];
+  str[bg] = HBG;
+  return (0);
+}
+
+int
+e_mk_info_mrk (char *str)
+{
+  int bg, nd = -1;
+
+  do
+    {
+      for (bg = nd + 1; str[bg] && str[bg] != '`'; bg++)
+	;
+      for (nd = bg; str[nd] && str[nd] != '\''; nd++)
+	;
+      if (str[nd])
+	{
+	  str[bg] = HBB;
+	  str[nd] = HED;
+	}
+    }
+  while (str[nd]);
+  return (0);
+}
+
+IFILE
+e_info_jump (char *str, char **path, IFILE fp)
+{
+  IFILE fpn;
+  int i, j, n, anz = 0;
+  char *ptmp, *fstr, tstr[256], nfl[128];
+  struct FL_INFO
   {
-   e_i_fclose(fp);
-   fp = fpn;
-   free(*path);
-   *path = ptmp;
-  }
+    char *name;
+    int line;
+  } **files = malloc (1);
+
+  while (e_i_fgets (tstr, 256, fp) && tstr[0] != IFE)
+    {
+      for (i = 0; (nfl[i] = tstr[i]) && tstr[i] != ':'; i++)
+	;
+      if (!tstr[i])
+	continue;
+      nfl[i] = '\0';
+      anz++;
+      files = realloc (files, anz * sizeof (struct FL_INFO *));
+      files[anz - 1] = malloc (sizeof (struct FL_INFO));
+      files[anz - 1]->name = malloc ((strlen (nfl) + 1) * sizeof (char));
+      strcpy (files[anz - 1]->name, nfl);
+      files[anz - 1]->line = atoi (tstr + i + 1);
+    }
+  i = (strlen (str) + 6);
+  fstr = malloc ((i + 1) * sizeof (char));
+  strcat (strcpy (fstr, "Node: "), str);
+  if (fstr[n = strlen (fstr) - 1] == HED)
+    {
+      fstr[n] = '\0';
+      i--;
+    }
+  while ((ptmp = e_i_fgets (tstr, 256, fp)) && strncmp (tstr, fstr, i))
+    ;
+  if (ptmp)
+    {
+      n = atoi (tstr + i + 1);
+      for (i = 1; i < anz && n >= files[i]->line; i++)
+	;
+      if (files[i - 1]->name[0] == DIRC)
+	{
+	  ptmp = malloc ((strlen (files[i - 1]->name) + 1) * sizeof (char));
+	  strcpy (ptmp, files[i - 1]->name);
+	}
+      else
+	{
+	  for (n = strlen (*path) - 1; n >= 0 && *(*path + n) != DIRC; n--)
+	    ;
+	  n++;
+	  ptmp =
+	    malloc ((strlen (files[i - 1]->name) + n + 1) * sizeof (char));
+	  for (j = 0; j < n; j++)
+	    ptmp[j] = *(*path + j);
+	  ptmp[j] = '\0';
+	  strcat (ptmp, files[i - 1]->name);
+	}
+      if ((fpn = e_i_fopen (ptmp, "rb")) != NULL)
+	{
+	  e_i_fclose (fp);
+	  fp = fpn;
+	  free (*path);
+	  *path = ptmp;
+	}
+      else
+	free (ptmp);
+    }
+  free (fstr);
+  for (i = 0; i < anz; i++)
+    {
+      free (files[i]->name);
+      free (files[i]);
+    }
+  free (files);
+  return (fp);
+}
+
+char *
+e_mk_info_pt (char *str, char *node)
+{
+  int i;
+  char *ptmp, tmp[128];
+
+  do
+    {
+      if (!(ptmp = strstr (str, node)))
+	return (NULL);
+      while (*ptmp && *ptmp != ',' && *ptmp != ':')
+	ptmp++;
+      if (!*ptmp)
+	return (NULL);
+    }
+  while (*ptmp == ',');
+  for (ptmp++; isspace (*ptmp); ptmp++)
+    ;
+  for (i = 0; (tmp[i] = ptmp[i]) && ptmp[i] != ',' && ptmp[i] != '\n'; i++)
+    ;
+  tmp[i] = '\0';
+  if (i == 0)
+    return (NULL);
+  ptmp = malloc ((strlen (tmp) + 1) * sizeof (char));
+  strcpy (ptmp, tmp);
+  return (ptmp);
+}
+
+char *
+e_mk_info_path (char *path, char *file)
+{
+  int n;
+  char *tp;
+
+  if (!info_file || !*info_file)
+    return (NULL);
+  if (file[0] == DIRC)
+    {
+      if (path && !strcmp (path, file))
+	{
+	  free (path);
+	  return (NULL);
+	}
+      else if (path)
+	free (path);
+      if (!(path = malloc ((strlen (file) + 1) * sizeof (char))))
+	return (NULL);
+      return (strcpy (path, file));
+    }
+  tp = info_file;
+  if (path)
+    {
+      n = strlen (path) - strlen (file);
+      if (n > 1)
+	path[n - 1] = PTHD;
+      else if (n == 1)
+	path[n++] = PTHD;
+      while (strncmp (tp, path, n) && (tp = strchr (tp, PTHD)) != NULL
+	     && *++tp);
+      if (tp == NULL || !*tp || !*(tp += n))
+	return (NULL);
+      free (path);
+    }
+  for (n = 0; tp[n] && tp[n] != PTHD; n++);
+  if (!(path = malloc ((strlen (file) + n + 2) * sizeof (char))))
+    return (NULL);
+  strncpy (path, tp, n);
+  if (n > 1)
+    path[n++] = DIRC;
+  strcpy (path + n, file);
+  return (path);
+}
+
+int
+e_read_info (char *str, FENSTER * f, char *file)
+{
+  IFILE fp = NULL;
+  char *path = NULL, *ptmp, tstr[256], fstr[128];
+  int i, len, sw = 0, bsw = 0;
+  if (!str)
+    str = "Top";
+  if (str[0] == HHD)
+    str++;
+  strcat (strcpy (fstr, "Node: "), str);
+  len = strlen (fstr);
+  if (fstr[len - 1] == HED)
+    fstr[len - 1] = '\0';
+  if (!file || !file[0])
+    file = "dir";
+  do
+    {
+      path = e_mk_info_path (path, file);
+      fp = e_i_fopen (path, "rb");
+    }
+  while (!fp && path);
+  if (!fp)
+    return (1);
+  e_close_buffer (f->b);
+  if ((f->b = (BUFFER *) malloc (sizeof (BUFFER))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  if ((f->b->bf = (STRING *) malloc (MAXLINES * sizeof (STRING))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  f->b->f = f;
+  f->b->b = e_set_pnt (0, 0);
+  f->b->mx = e_set_pnt (f->ed->maxcol, MAXLINES);
+  f->b->mxlines = 0;
+  f->b->fb = f->fb;
+  f->b->cn = f->ed;
+  f->b->ud = NULL;
+  e_new_line (0, f->b);
+  while ((ptmp = e_i_fgets (tstr, 256, fp)) != NULL)
+    {
+      if (!strncmp (tstr, "Indirect:", 9))
+	fp = e_info_jump (str, &path, fp);
+      else if (!strncmp (tstr, "File:", 5) && strstr (tstr, fstr))
+	break;
+    }
+  free (path);
+  if (ptmp)
+    {
+      ud_help->nstr = e_mk_info_pt (tstr, "Next");
+      ud_help->pstr = e_mk_info_pt (tstr, "Prev");
+    }
+  if (!strcmp (file, "dir"))
+    while ((ptmp = e_i_fgets (tstr, 256, fp))
+	   && WpeStrnccmp (tstr, "* Menu:", 7));
   else
-   free(ptmp);
- }
- free(fstr);
- for (i = 0; i < anz; i++)
- {
-  free(files[i]->name);
-  free(files[i]);
- }
- free(files);
- return(fp);
+    while ((ptmp = e_i_fgets (tstr, 256, fp)) && tstr[0] == '\n');
+  if (ptmp)
+    {
+      if (!sw && !WpeStrnccmp (tstr, "* Menu:", 7))
+	sw = 1;
+      for (i = len = strlen (tstr); i >= 0; i--)
+	tstr[i + 1] = tstr[i];
+      tstr[0] = HHD;
+      tstr[len + 1] = HED;
+      tstr[len + 1] = '\0';
+      strcpy ((char *) f->b->bf[f->b->mxlines - 1].s, tstr);
+      f->b->bf[f->b->mxlines - 1].len =
+	e_str_len (f->b->bf[f->b->mxlines - 1].s);
+      f->b->bf[f->b->mxlines - 1].nrc =
+	strlen ((const char *) f->b->bf[f->b->mxlines - 1].s);
+    }
+  while (e_i_fgets (tstr, 256, fp))
+    {
+      for (i = 0; tstr[i]; i++)
+	if (tstr[i] == IFE)
+	  {
+	    e_i_fclose (fp);
+	    return (0);
+	  }
+      if (bsw == 1)
+	{
+	  bsw = e_mk_info_button (tstr);
+	  for (ptmp = tstr; (ptmp = WpeStrcstr (ptmp, "*note")); ptmp += 5)
+	    bsw = e_mk_info_button (ptmp + 5);
+	}
+      else if (!sw && !WpeStrnccmp (tstr, "* Menu:", 7))
+	sw = 1;
+      else if ((ptmp = WpeStrcstr (tstr, "*note")))
+	{
+	  bsw = e_mk_info_button (ptmp + 5);
+	  for (ptmp += 5; (ptmp = WpeStrcstr (ptmp, "*note")); ptmp += 5)
+	    bsw = e_mk_info_button (ptmp + 5);
+	}
+      else if (sw && tstr[0] == '*')
+	{
+	  bsw = e_mk_info_button (tstr + 1);
+	  for (ptmp = tstr + 1; (ptmp = WpeStrcstr (ptmp, "*note"));
+	       ptmp += 5)
+	    bsw = e_mk_info_button (ptmp + 5);
+	}
+      e_mk_info_mrk (tstr);
+      e_new_line (f->b->mxlines, f->b);
+      strcpy ((char *) f->b->bf[f->b->mxlines - 1].s, tstr);
+      f->b->bf[f->b->mxlines - 1].len =
+	e_str_len (f->b->bf[f->b->mxlines - 1].s);
+      f->b->bf[f->b->mxlines - 1].nrc =
+	strlen ((const char *) f->b->bf[f->b->mxlines - 1].s);
+    }
+  e_i_fclose (fp);
+  return (2);
 }
 
-char *e_mk_info_pt(char *str, char *node)
+int
+e_help_loc (FENSTER * f, int sw)
 {
- int i;
- char *ptmp, tmp[128];
+  extern char *e_hlp;
+  int i;
+  char *tmp = NULL;
+  struct help_ud *next;
 
- do
- {
-  if (!(ptmp = strstr(str, node)))
-   return(NULL);
-  while (*ptmp && *ptmp != ',' && *ptmp != ':')
-   ptmp++;
-  if (!*ptmp)
-   return(NULL);
- } while (*ptmp == ',');
- for (ptmp++; isspace(*ptmp); ptmp++)
-  ;
- for (i = 0; (tmp[i] = ptmp[i]) && ptmp[i] != ',' && ptmp[i] != '\n'; i++)
-  ;
- tmp[i] = '\0';
- if (i == 0)
-  return(NULL);
- ptmp = malloc((strlen(tmp)+1)*sizeof(char));
- strcpy(ptmp, tmp);
- return(ptmp);
-}
-
-char *e_mk_info_path(char *path, char *file)
-{
- int n;
- char *tp;
-
- if (!info_file || !*info_file) return(NULL);
- if (file[0] == DIRC)
- {
-  if (path && !strcmp(path, file)) {  free(path);  return(NULL);  }
-  else if(path) free(path);
-  if (!(path = malloc((strlen(file) + 1) * sizeof(char)))) return(NULL);
-  return (strcpy(path, file));
- }
- tp = info_file;
- if (path)
- {
-  n = strlen(path) - strlen(file);
-  if (n > 1) path[n - 1] = PTHD;
-  else if (n == 1) path[n++] = PTHD;
-  while (strncmp(tp, path, n) && (tp = strchr(tp, PTHD)) != NULL && *++tp);
-  if (tp == NULL || !*tp || !*(tp += n)) return(NULL);
-  free(path);
- }
- for (n = 0; tp[n] && tp[n] != PTHD; n++);
- if (!(path = malloc((strlen(file) + n + 2) * sizeof(char)))) return(NULL);
- strncpy(path, tp, n);
- if (n > 1) path[n++] = DIRC;
- strcpy(path + n, file);
- return(path);
-}
-
-int e_read_info(char *str, FENSTER *f, char *file)
-{
-   IFILE fp = NULL;
-   char *path = NULL, *ptmp, tstr[256], fstr[128];
-   int i, len, sw = 0, bsw = 0;
-   if(!str) str = "Top";
-   if(str[0] == HHD) str++;
-   strcat(strcpy(fstr, "Node: "), str);
-   len = strlen(fstr);
-   if(fstr[len-1] == HED) fstr[len-1] = '\0';
-   if(!file || !file[0]) file = "dir";
-   do
-   {  path = e_mk_info_path(path, file);
-      fp = e_i_fopen(path, "rb");
-   } while(!fp && path);
-   if(!fp) return(1);
-   e_close_buffer(f->b);
-   if( (f->b = (BUFFER *) malloc(sizeof(BUFFER))) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-   if( (f->b->bf = (STRING *) malloc(MAXLINES*sizeof(STRING))) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-   f->b->f = f;
-   f->b->b = e_set_pnt(0, 0);
-   f->b->mx = e_set_pnt(f->ed->maxcol, MAXLINES);
-   f->b->mxlines = 0;
-   f->b->fb = f->fb;
-   f->b->cn = f->ed;
-   f->b->ud = NULL;
-   e_new_line(0, f->b);
-   while((ptmp = e_i_fgets(tstr, 256, fp)) != NULL)
-   {  if(!strncmp(tstr, "Indirect:", 9)) fp = e_info_jump(str, &path, fp);
-      else if(!strncmp(tstr, "File:", 5) && strstr(tstr, fstr)) break;
-   }
-   free(path);
-   if(ptmp)
-   {  ud_help->nstr = e_mk_info_pt(tstr, "Next");
-      ud_help->pstr = e_mk_info_pt(tstr, "Prev");
-   }
-   if(!strcmp(file, "dir"))
-      while((ptmp = e_i_fgets(tstr, 256, fp)) 
-         && WpeStrnccmp(tstr, "* Menu:", 7));
-   else while((ptmp = e_i_fgets(tstr, 256, fp)) && tstr[0] == '\n');
-   if(ptmp)
-   {  if(!sw && !WpeStrnccmp(tstr, "* Menu:", 7)) sw = 1;
-      for(i = len = strlen(tstr); i >= 0; i--) tstr[i+1] = tstr[i];
-      tstr[0] = HHD;  tstr[len+1] = HED;  tstr[len+1] = '\0';
-      strcpy((char *)f->b->bf[f->b->mxlines-1].s, tstr);
-      f->b->bf[f->b->mxlines-1].len = e_str_len(f->b->bf[f->b->mxlines-1].s);
-      f->b->bf[f->b->mxlines-1].nrc = strlen((const char *)f->b->bf[f->b->mxlines-1].s);
-   }
-   while(e_i_fgets(tstr, 256, fp))
-   {  for(i = 0; tstr[i]; i++)
-      if(tstr[i] == IFE)  {  e_i_fclose(fp);  return(0);  }
-      if(bsw == 1)
-      {  bsw = e_mk_info_button(tstr);
-         for(ptmp = tstr; (ptmp = WpeStrcstr(ptmp, "*note")); ptmp += 5)
-            bsw = e_mk_info_button(ptmp+5);
-      }
-      else if(!sw && !WpeStrnccmp(tstr, "* Menu:", 7)) sw = 1;
-      else if((ptmp = WpeStrcstr(tstr, "*note")))
-      {  bsw = e_mk_info_button(ptmp+5);
-         for(ptmp += 5; (ptmp = WpeStrcstr(ptmp, "*note")); ptmp += 5)
-            bsw = e_mk_info_button(ptmp+5);
-      }
-      else if(sw && tstr[0] == '*') 
-      {  bsw = e_mk_info_button(tstr+1);
-         for(ptmp = tstr+1; (ptmp = WpeStrcstr(ptmp, "*note")); ptmp += 5)
-            bsw = e_mk_info_button(ptmp+5);
-      }
-      e_mk_info_mrk(tstr);
-      e_new_line(f->b->mxlines, f->b);
-      strcpy((char *)f->b->bf[f->b->mxlines-1].s, tstr);
-      f->b->bf[f->b->mxlines-1].len = e_str_len(f->b->bf[f->b->mxlines-1].s);
-      f->b->bf[f->b->mxlines-1].nrc = strlen((const char *)f->b->bf[f->b->mxlines-1].s);
-   }
-   e_i_fclose(fp);
-   return(2);
-}
-
-int e_help_loc(FENSTER *f, int sw)
-{
- extern char *e_hlp;
- int i;
- char *tmp = NULL;
- struct help_ud *next;
-
- if (!sw)
-  tmp = e_hlp;
- for (i = f->ed->mxedt; i >= 0; i--)
- {
-  if (!strcmp(f->ed->f[i]->datnam, "Help"))
-  {
-   e_switch_window(f->ed->edt[i], f);
-   if (ud_help && sw != ud_help->sw)
-   {
-    e_close_window(f->ed->f[f->ed->mxedt]);
-    i = -1;
-   }
-   break;
-  }
- }
- if (i < 0)
-  e_edit(f->ed, "Help");
- if ((tmp || sw) && (next = malloc(sizeof(struct help_ud))))
- {
-  if (tmp)
-  {
-   next->str = malloc((strlen(tmp)+1) * sizeof(char));
-   if (next->str)
-    strcpy(next->str, tmp);
-  }
+  if (!sw)
+    tmp = e_hlp;
+  for (i = f->ed->mxedt; i >= 0; i--)
+    {
+      if (!strcmp (f->ed->f[i]->datnam, "Help"))
+	{
+	  e_switch_window (f->ed->edt[i], f);
+	  if (ud_help && sw != ud_help->sw)
+	    {
+	      e_close_window (f->ed->f[f->ed->mxedt]);
+	      i = -1;
+	    }
+	  break;
+	}
+    }
+  if (i < 0)
+    e_edit (f->ed, "Help");
+  if ((tmp || sw) && (next = malloc (sizeof (struct help_ud))))
+    {
+      if (tmp)
+	{
+	  next->str = malloc ((strlen (tmp) + 1) * sizeof (char));
+	  if (next->str)
+	    strcpy (next->str, tmp);
+	}
+      else
+	next->str = NULL;
+      next->file = NULL;
+      next->x = next->y = 0;
+      next->nstr = next->pstr = NULL;
+      next->sw = sw;
+      next->next = ud_help;
+      ud_help = next;
+    }
+  if (sw)
+    e_read_info (NULL, f->ed->f[f->ed->mxedt], NULL);
   else
-   next->str = NULL;
-  next->file = NULL;
-  next->x = next->y = 0;
-  next->nstr = next->pstr = NULL;
-  next->sw = sw;
-  next->next = ud_help;
-  ud_help = next;
- }
- if (sw)
-  e_read_info(NULL, f->ed->f[f->ed->mxedt], NULL);
- else
-  e_read_help(tmp, f->ed->f[f->ed->mxedt], 0);
- e_schirm(f->ed->f[f->ed->mxedt], 1);
- return(0);
+    e_read_help (tmp, f->ed->f[f->ed->mxedt], 0);
+  e_schirm (f->ed->f[f->ed->mxedt], 1);
+  return (0);
 }
 
-int e_help_options(FENSTER *f)
+int
+e_help_options (FENSTER * f)
 {
- char str[128];
+  char str[128];
 
- if (!info_file)
- {
-  info_file = malloc(1);
-  info_file[0] = '\0';
- }
- strcpy(str, info_file);
- if (e_add_arguments(str, "Info-Path", f, 0 , AltI, NULL))
- {
-  info_file = realloc(info_file, strlen(str) + 1);
-  strcpy(info_file, str);
- }
- return(0);
+  if (!info_file)
+    {
+      info_file = malloc (1);
+      info_file[0] = '\0';
+    }
+  strcpy (str, info_file);
+  if (e_add_arguments (str, "Info-Path", f, 0, AltI, NULL))
+    {
+      info_file = realloc (info_file, strlen (str) + 1);
+      strcpy (info_file, str);
+    }
+  return (0);
 }
 
-int e_hp_next(FENSTER *f)
+int
+e_hp_next (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i >= 0; i--)
- {
-  if (!strcmp(f->ed->f[i]->datnam, "Help"))
-  {
-   e_switch_window(f->ed->edt[i], f);
-   f = f->ed->f[f->ed->mxedt];
-   break;
-  }
- }
- if (i < 0)
-  return(e_help_loc(f, 0));
- else
-  return(e_help_next(f, 1));
-}   
+  for (i = f->ed->mxedt; i >= 0; i--)
+    {
+      if (!strcmp (f->ed->f[i]->datnam, "Help"))
+	{
+	  e_switch_window (f->ed->edt[i], f);
+	  f = f->ed->f[f->ed->mxedt];
+	  break;
+	}
+    }
+  if (i < 0)
+    return (e_help_loc (f, 0));
+  else
+    return (e_help_next (f, 1));
+}
 
-int e_hp_prev(FENSTER *f)
+int
+e_hp_prev (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i >= 0; i--)
- {
-  if (!strcmp(f->ed->f[i]->datnam, "Help"))
-  {
-   e_switch_window(f->ed->edt[i], f);
-   f = f->ed->f[f->ed->mxedt];
-   break;
-  }
- }
- if (i < 0)
-  return(e_help_loc(f, 0));
- else
-  return(e_help_next(f, 0));
-}   
+  for (i = f->ed->mxedt; i >= 0; i--)
+    {
+      if (!strcmp (f->ed->f[i]->datnam, "Help"))
+	{
+	  e_switch_window (f->ed->edt[i], f);
+	  f = f->ed->f[f->ed->mxedt];
+	  break;
+	}
+    }
+  if (i < 0)
+    return (e_help_loc (f, 0));
+  else
+    return (e_help_next (f, 0));
+}
 
-int e_hp_back(FENSTER *f)
+int
+e_hp_back (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i >= 0; i--)
- {
-  if (!strcmp(f->ed->f[i]->datnam, "Help"))
-  {
-   e_switch_window(f->ed->edt[i], f);
-   f = f->ed->f[f->ed->mxedt];
-   break;
-  }
- }
- if (i < 0)
-  return(e_help_loc(f, 0));
- else
-  return(e_help_last(f));
-}   
+  for (i = f->ed->mxedt; i >= 0; i--)
+    {
+      if (!strcmp (f->ed->f[i]->datnam, "Help"))
+	{
+	  e_switch_window (f->ed->edt[i], f);
+	  f = f->ed->f[f->ed->mxedt];
+	  break;
+	}
+    }
+  if (i < 0)
+    return (e_help_loc (f, 0));
+  else
+    return (e_help_last (f));
+}
 
-int e_hp_ret(FENSTER *f)
+int
+e_hp_ret (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i >= 0; i--)
- {
-  if (!strcmp(f->ed->f[i]->datnam, "Help"))
-  {
-   e_switch_window(f->ed->edt[i], f);
-   f = f->ed->f[f->ed->mxedt];
-   break;
-  }
- }
- if (i < 0)
-  return(e_help_loc(f, 0));
- else
-  return(e_help_ret(f));
-}   
+  for (i = f->ed->mxedt; i >= 0; i--)
+    {
+      if (!strcmp (f->ed->f[i]->datnam, "Help"))
+	{
+	  e_switch_window (f->ed->edt[i], f);
+	  f = f->ed->f[f->ed->mxedt];
+	  break;
+	}
+    }
+  if (i < 0)
+    return (e_help_loc (f, 0));
+  else
+    return (e_help_ret (f));
+}
 
 /* Give a context-sensitive help for the identifier under cursor */
-int e_topic_search(FENSTER *f)
+int
+e_topic_search (FENSTER * f)
 {
- int x, y;
- unsigned char *s;
- BUFFER *b;
- unsigned char item[100], *ptr=item;
+  int x, y;
+  unsigned char *s;
+  BUFFER *b;
+  unsigned char item[100], *ptr = item;
 
- if (!DTMD_ISTEXT(f->ed->f[f->ed->mxedt]->dtmd))
-  return(0);
- b = f->ed->f[f->ed->mxedt]->b;
- y=b->b.y;
- x=b->b.x;
- s=b->bf[y].s;
- if(!isalnum(s[x]) && s[x]!='_')
+  if (!DTMD_ISTEXT (f->ed->f[f->ed->mxedt]->dtmd))
+    return (0);
+  b = f->ed->f[f->ed->mxedt]->b;
+  y = b->b.y;
+  x = b->b.x;
+  s = b->bf[y].s;
+  if (!isalnum (s[x]) && s[x] != '_')
+    return (0);
+  for (; x >= 0 && (isalnum (s[x]) || s[x] == '_'); x--);
+  if (x < 0 && !isalnum (s[0]) && s[0] != '_')
+    return (0);
+  x++;
+  for (; x <= b->bf[y].len && (isalnum (s[x]) || s[x] == '_'); x++, ptr++)
+    *ptr = s[x];
+  *ptr = 0;
+  e_ed_man (item, f);
   return (0);
- for(;x>=0 && (isalnum(s[x])||s[x]=='_');x--);
- if(x<0 && !isalnum(s[0]) && s[0]!='_')
-  return(0);
- x++;
- for(; x<=b->bf[y].len && (isalnum(s[x])||s[x]=='_');x++,ptr++)
-  *ptr=s[x];
- *ptr=0; 
- e_ed_man(item, f);
- return(0); 
 }
-

--- a/src/we_fl_fkt.h
+++ b/src/we_fl_fkt.h
@@ -10,25 +10,25 @@
 #include "we_debug.h"
 
 /*   we_fl_fkt.c   */
-char *e_mkfilename(char *dr, char *fn);
-POINT e_readin(int i, int j, FILE *fp, BUFFER *b, char *sw);
-int e_new(FENSTER *f);
-int e_m_save(FENSTER *f);
-int e_save(FENSTER *f);
-int e_saveall(FENSTER *f);
-int e_quit(FENSTER *f);
-int e_write(int xa, int ya, int xe, int ye, FENSTER *f, int backup);
-char *e_new_qual(char *s, char *ns, char *sb);
-char *e_bakfilename(char *s);
-int freedf(struct dirfile *df);
-int e_file_window(int sw, FLWND *fw, int ft, int fz);
-int e_pr_file_window(FLWND *fw, int c, int sw, int ft, int fz, int fs);
-int e_help_last(FENSTER *f);
-int e_help_comp(FENSTER *f);
-int e_help(FENSTER *f);
-int e_help_loc(FENSTER *f, int sw);
-int e_help_free(FENSTER *f);
-int e_help_ret(FENSTER *f);
-int e_topic_search(FENSTER *f);
+char *e_mkfilename (char *dr, char *fn);
+POINT e_readin (int i, int j, FILE * fp, BUFFER * b, char *sw);
+int e_new (FENSTER * f);
+int e_m_save (FENSTER * f);
+int e_save (FENSTER * f);
+int e_saveall (FENSTER * f);
+int e_quit (FENSTER * f);
+int e_write (int xa, int ya, int xe, int ye, FENSTER * f, int backup);
+char *e_new_qual (char *s, char *ns, char *sb);
+char *e_bakfilename (char *s);
+int freedf (struct dirfile *df);
+int e_file_window (int sw, FLWND * fw, int ft, int fz);
+int e_pr_file_window (FLWND * fw, int c, int sw, int ft, int fz, int fs);
+int e_help_last (FENSTER * f);
+int e_help_comp (FENSTER * f);
+int e_help (FENSTER * f);
+int e_help_loc (FENSTER * f, int sw);
+int e_help_free (FENSTER * f);
+int e_help_ret (FENSTER * f);
+int e_topic_search (FENSTER * f);
 
 #endif

--- a/src/we_fl_unix.c
+++ b/src/we_fl_unix.c
@@ -14,7 +14,7 @@
 #include "model.h"
 #include "options.h"
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
-#  include "curses.h"
+#include "curses.h"
 #endif
 #include "edit.h"
 #include "we_fl_unix.h"
@@ -28,34 +28,35 @@
 #include <sys/stat.h>
 #include <errno.h>
 
-struct dirfile *e_make_win_list(FENSTER * f);
-extern char    *e_tmp_dir;
+struct dirfile *e_make_win_list (FENSTER * f);
+extern char *e_tmp_dir;
 
 #ifndef HAVE_SYMLINK
-#  define readlink(x, y, z) -1
-#  define WpeRenameLink(x, y, z, f) 0
-#  define WpeLinkFile(x, y, sw, f) link(x, y)
-#  define lstat(x,y)  stat(x,y)
-#  undef S_ISLNK
-#  define S_ISLNK(x)  0
+#define readlink(x, y, z) -1
+#define WpeRenameLink(x, y, z, f) 0
+#define WpeLinkFile(x, y, sw, f) link(x, y)
+#define lstat(x,y)  stat(x,y)
+#undef S_ISLNK
+#define S_ISLNK(x)  0
 #else
-#  include <unistd.h>
-#endif  // #ifndef HAVE_SYMLINK
+#include <unistd.h>
+#endif // #ifndef HAVE_SYMLINK
 
 #define WPE_PATHMAX 2048
 
 /* buffer size for copying */
-#define E_C_BUFFERSIZE 524288        /*   1/2  Mega Byte   */
+#define E_C_BUFFERSIZE 524288	/*   1/2  Mega Byte   */
 
 #ifdef DEBUG
-int SpecialError(char *text, int sw, FARBE *f, char *file, int line)
+int
+SpecialError (char *text, int sw, FARBE * f, char *file, int line)
 {
-  fprintf(stderr, "\nFile \"%s\" line %d\n", file, line);
-  return e_error(text, sw, f);
+  fprintf (stderr, "\nFile \"%s\" line %d\n", file, line);
+  return e_error (text, sw, f);
 }
 
 #define e_error(text, sw, f) SpecialError(text, sw, f, __FILE__, __LINE__)
-#endif  // #ifdef DEBUG
+#endif // #ifdef DEBUG
 
 
 /* setup the file-manager structures 
@@ -72,34 +73,35 @@ int SpecialError(char *text, int sw, FARBE *f, char *file, int line)
    6  | wastebasket
 
 */
-int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
+int
+WpeCreateFileManager (int sw, ECNT * cn, char *dirct)
 {
-  extern char    *e_hlp_str[];
-  extern WOPT    *fblst, *rblst, *wblst, *xblst, *sblst, *ablst;
-  FENSTER        *f;
-  int             i, j;
-  FLBFFR         *b;
-  int             allocate_size;  /* inital memory size for allocation */
-  char           *sfile;
+  extern char *e_hlp_str[];
+  extern WOPT *fblst, *rblst, *wblst, *xblst, *sblst, *ablst;
+  FENSTER *f;
+  int i, j;
+  FLBFFR *b;
+  int allocate_size;		/* inital memory size for allocation */
+  char *sfile;
 
   /* check whether we reached the maximum number of windows */
-  if(cn->mxedt >= MAXEDT)
-  {
-    e_error(e_msg[ERR_MAXWINS], 0, cn->fb);
-    return(-1);
-  }
+  if (cn->mxedt >= MAXEDT)
+    {
+      e_error (e_msg[ERR_MAXWINS], 0, cn->fb);
+      return (-1);
+    }
 
   /* search for a not used window ID number (j) */
-  for(j = 1; j <= MAXEDT; j++)
-  {
-    for(i = 1; i <= cn->mxedt && cn->edt[i] != j; i++)
-      ;
-    if(i > cn->mxedt)
-      break;
-  }
+  for (j = 1; j <= MAXEDT; j++)
+    {
+      for (i = 1; i <= cn->mxedt && cn->edt[i] != j; i++)
+	;
+      if (i > cn->mxedt)
+	break;
+    }
 
   /* change the shape of the mouse :-) */
-  WpeMouseChangeShape(WpeWorkingShape);
+  WpeMouseChangeShape (WpeWorkingShape);
 
   /* currently active window, 
      one more window in the system, 
@@ -109,17 +111,17 @@ int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
   cn->edt[cn->mxedt] = j;
 
   /* allocate window structure */
-  if((f = (FENSTER *)malloc(sizeof(FENSTER))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((f = (FENSTER *) malloc (sizeof (FENSTER))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* allocate buffer related to the window (NOT proper type, later casted) */
-  if((b = (FLBFFR *) malloc(sizeof(FLBFFR))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((b = (FLBFFR *) malloc (sizeof (FLBFFR))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
   f->fb = cn->fb;
-  cn->f[cn->mxedt] = f;        /* store the window structure at appropriate place */
-  f->a = e_set_pnt(11, 2);     /* beginning of the box */
-  f->e = e_set_pnt(f->a.x + 55, f->a.y + 20); /* other coord. of the box */
+  cn->f[cn->mxedt] = f;		/* store the window structure at appropriate place */
+  f->a = e_set_pnt (11, 2);	/* beginning of the box */
+  f->e = e_set_pnt (f->a.x + 55, f->a.y + 20);	/* other coord. of the box */
   f->winnum = cn->curedt;
   f->dtmd = DTMD_FILEMANAGER;
   f->ins = 1;
@@ -129,118 +131,118 @@ int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
   f->c_sw = NULL;
   f->c_st = NULL;
   f->pic = NULL;
-  if(sw == 6)
-  {
-    sw = 0;
-    f->datnam = "Wastebasket";
-    f->save = 1;
-  }
+  if (sw == 6)
+    {
+      sw = 0;
+      f->datnam = "Wastebasket";
+      f->save = 1;
+    }
   else
-    f->datnam = "File-Manager";  /* window header text */
+    f->datnam = "File-Manager";	/* window header text */
 
   /* status line text for different mode */
-  if(sw == 0)
-  {
-    f->blst = fblst;
-    f->nblst = 8;
-  }
-  else if(sw == 1)
-  {
-    f->blst = rblst;
-    f->nblst = 4;
-  }
-  else if(sw == 2)
-  {
-    f->blst = wblst;
-    f->nblst = 4;
-  }
-  else if(sw == 3)
-  {
-    f->blst = xblst;
-    f->nblst = 4;
-  }
-  else if(sw == 4)
-  {
-    f->blst = sblst;
-    f->nblst = 5;
-  }
-  else if(sw == 5)
-  {
-    f->blst = ablst;
-    f->nblst = 4;
-  }
+  if (sw == 0)
+    {
+      f->blst = fblst;
+      f->nblst = 8;
+    }
+  else if (sw == 1)
+    {
+      f->blst = rblst;
+      f->nblst = 4;
+    }
+  else if (sw == 2)
+    {
+      f->blst = wblst;
+      f->nblst = 4;
+    }
+  else if (sw == 3)
+    {
+      f->blst = xblst;
+      f->nblst = 4;
+    }
+  else if (sw == 4)
+    {
+      f->blst = sblst;
+      f->nblst = 5;
+    }
+  else if (sw == 5)
+    {
+      f->blst = ablst;
+      f->nblst = 4;
+    }
 
-  if(sw == 3)
+  if (sw == 3)
     f->hlp_str = e_hlp_str[5];
   else
     f->hlp_str = e_hlp_str[4];
 
-  if(!dirct || dirct[0] == '\0')
-  {
-    /* no working directory has been given */
-    f->dirct = WpeGetCurrentDir(cn);
-  }
+  if (!dirct || dirct[0] == '\0')
+    {
+      /* no working directory has been given */
+      f->dirct = WpeGetCurrentDir (cn);
+    }
   else
-  {
-    /* working directory is given, copy it over */
-    allocate_size = strlen(dirct);
-    if((f->dirct = malloc(allocate_size+1)) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+    {
+      /* working directory is given, copy it over */
+      allocate_size = strlen (dirct);
+      if ((f->dirct = malloc (allocate_size + 1)) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
-    strcpy(f->dirct, dirct);
-  }
+      strcpy (f->dirct, dirct);
+    }
 
-  strcpy(f->fd.search, "");
-  strcpy(f->fd.replace, "");
-  strcpy(f->fd.file, SUDIR);
-  f->fd.dirct = WpeStrdup(f->dirct);
+  strcpy (f->fd.search, "");
+  strcpy (f->fd.replace, "");
+  strcpy (f->fd.file, SUDIR);
+  f->fd.dirct = WpeStrdup (f->dirct);
 
   f->fd.sw = 16;
   f->fd.sn = 0;
   f->fd.rn = 0;
 
-  f->b = (BUFFER *)b;
+  f->b = (BUFFER *) b;
   /* the find pattern can only be 79 see FIND structure */
-  if((b->rdfile = malloc(80)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-  strcpy(b->rdfile, f->fd.file);               /* find file pattern */
+  if ((b->rdfile = malloc (80)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+  strcpy (b->rdfile, f->fd.file);	/* find file pattern */
 
   b->sw = sw;
 
   /* window for files */
-  if((b->fw = (FLWND *) malloc(sizeof(FLWND))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((b->fw = (FLWND *) malloc (sizeof (FLWND))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* window for directory */
-  if((b->dw = (FLWND *) malloc(sizeof(FLWND))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((b->dw = (FLWND *) malloc (sizeof (FLWND))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
 
-  if((sfile = malloc(strlen(f->dirct)+strlen(b->rdfile)+2)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((sfile = malloc (strlen (f->dirct) + strlen (b->rdfile) + 2)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* determine current directory */
-  b->cd = WpeCreateWorkingDirTree(f->save, cn);
+  b->cd = WpeCreateWorkingDirTree (f->save, cn);
   /* it is necessary to do this, because the file manager may not be
      in the appropriate directory here */
-  sprintf(sfile, "%s/%s", f->dirct, SUDIR);
+  sprintf (sfile, "%s/%s", f->dirct, SUDIR);
   /* find all other directories in the current */
-  b->dd = e_find_dir(sfile, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+  b->dd = e_find_dir (sfile, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
   /* setup the drawing in the dir tree window */
-  b->dw->df = WpeGraphicalDirTree(b->cd, b->dd, cn);
+  b->dw->df = WpeGraphicalDirTree (b->cd, b->dd, cn);
 
   i = f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0;
-  if(sw == 3)
+  if (sw == 3)
     i |= 2;
 
   /* finds all files matching the pattern */
-  sprintf(sfile, "%s/%s", f->dirct, b->rdfile);
-  b->df = e_find_files(sfile, i);
+  sprintf (sfile, "%s/%s", f->dirct, b->rdfile);
+  b->df = e_find_files (sfile, i);
 
-  free(sfile);
+  free (sfile);
 
   /* setup the drawing in the file list window */
-  b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
+  b->fw->df = WpeGraphicalFileList (b->df, f->ed->flopt >> 9, cn);
 
   /* file box - geometry and vertical slider settings */
   b->fw->mxa = f->a.x;
@@ -269,118 +271,119 @@ int WpeCreateFileManager(int sw, ECNT *cn, char *dirct)
   b->dw->srcha = -1;
   b->dw->nf = b->dw->nyfo = b->cd->anz - 1;
 
-  if(cn->mxedt > 1)
-    e_ed_rahmen(cn->f[cn->mxedt - 1], 0);
+  if (cn->mxedt > 1)
+    e_ed_rahmen (cn->f[cn->mxedt - 1], 0);
 
-  e_firstl(f, 1);
+  e_firstl (f, 1);
 
   /* basically it draws the window out */
-  WpeDrawFileManager(f);
+  WpeDrawFileManager (f);
 
   /* restore the shape of the mouse */
-  WpeMouseRestoreShape();
-  return(0);
+  WpeMouseRestoreShape ();
+  return (0);
 }
 
 /* drawing out the file-manager, 
    first buttons, than the dir tree and file list */
-int WpeDrawFileManager(FENSTER * f)
+int
+WpeDrawFileManager (FENSTER * f)
 {
-  FLBFFR         *b = (FLBFFR *)f->b;
-  int             i, j;
-  int             bx1 = 1, bx2 = 1, bx3 = 1, by = 4;
+  FLBFFR *b = (FLBFFR *) f->b;
+  int i, j;
+  int bx1 = 1, bx2 = 1, bx3 = 1, by = 4;
 
-  for(j = f->a.y + 1; j < f->e.y; j++)
-    for(i = f->a.x + 1; i < f->e.x; i++)
-      e_pr_char(i, j, ' ', f->fb->nt.fb);
+  for (j = f->a.y + 1; j < f->e.y; j++)
+    for (i = f->a.x + 1; i < f->e.x; i++)
+      e_pr_char (i, j, ' ', f->fb->nt.fb);
 
-  if(NUM_LINES_ON_SCREEN <= 17)
+  if (NUM_LINES_ON_SCREEN <= 17)
     by = -1;
-  else if(b->sw != 0 || NUM_LINES_ON_SCREEN <= 19)
+  else if (b->sw != 0 || NUM_LINES_ON_SCREEN <= 19)
     by = 2;
 
-  if(NUM_LINES_ON_SCREEN > 17)
-  {
-    e_pr_str((f->a.x + 4), f->e.y - by, "Cancel", f->fb->nz.fb, -1, -1,
-             f->fb->ns.fb, f->fb->nt.fb);
-    e_pr_str((f->a.x + 14), f->e.y - by, "Change Dir", f->fb->nz.fb, 0, -1,
-             f->fb->ns.fb, f->fb->nt.fb);
-    if(b->sw == 1 && NUM_COLS_ON_SCREEN >= 34)
-      e_pr_str((f->a.x + 28), f->e.y - by, "Read", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-    else if(b->sw == 2 && NUM_COLS_ON_SCREEN >= 35)
-      e_pr_str((f->a.x + 28), f->e.y - by, "Write", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-    else if(b->sw == 4)
+  if (NUM_LINES_ON_SCREEN > 17)
     {
-      if(NUM_COLS_ON_SCREEN >= 34)
-        e_pr_str((f->a.x + 28), f->e.y - by, "Save", f->fb->nz.fb, 0, -1,
-                 f->fb->ns.fb, f->fb->nt.fb);
+      e_pr_str ((f->a.x + 4), f->e.y - by, "Cancel", f->fb->nz.fb, -1, -1,
+		f->fb->ns.fb, f->fb->nt.fb);
+      e_pr_str ((f->a.x + 14), f->e.y - by, "Change Dir", f->fb->nz.fb, 0, -1,
+		f->fb->ns.fb, f->fb->nt.fb);
+      if (b->sw == 1 && NUM_COLS_ON_SCREEN >= 34)
+	e_pr_str ((f->a.x + 28), f->e.y - by, "Read", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+      else if (b->sw == 2 && NUM_COLS_ON_SCREEN >= 35)
+	e_pr_str ((f->a.x + 28), f->e.y - by, "Write", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+      else if (b->sw == 4)
+	{
+	  if (NUM_COLS_ON_SCREEN >= 34)
+	    e_pr_str ((f->a.x + 28), f->e.y - by, "Save", f->fb->nz.fb, 0, -1,
+		      f->fb->ns.fb, f->fb->nt.fb);
+	}
+      else if (b->sw == 3 && NUM_COLS_ON_SCREEN >= 37)
+	e_pr_str ((f->a.x + 28), f->e.y - by, "Execute", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+      else if (b->sw == 5 && NUM_COLS_ON_SCREEN >= 33)
+	e_pr_str ((f->a.x + 28), f->e.y - by, "Add", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+      else if (b->sw == 0)
+	{
+	  if (NUM_COLS_ON_SCREEN >= 35)
+	    e_pr_str ((f->a.x + 28), f->e.y - by, "MKdir", f->fb->nz.fb, 1,
+		      -1, f->fb->ns.fb, f->fb->nt.fb);
+	  if (NUM_COLS_ON_SCREEN >= 49)
+	    e_pr_str ((f->a.x + 37), f->e.y - by, "Attributes", f->fb->nz.fb,
+		      0, -1, f->fb->ns.fb, f->fb->nt.fb);
+	}
     }
-    else if(b->sw == 3 && NUM_COLS_ON_SCREEN >= 37)
-      e_pr_str((f->a.x + 28), f->e.y - by, "Execute", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-    else if(b->sw == 5 && NUM_COLS_ON_SCREEN >= 33)
-      e_pr_str((f->a.x + 28), f->e.y - by, "Add", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-    else if(b->sw == 0)
+  if (b->sw == 0 && NUM_LINES_ON_SCREEN > 19)
     {
-      if(NUM_COLS_ON_SCREEN >= 35)
-        e_pr_str((f->a.x + 28), f->e.y - by, "MKdir", f->fb->nz.fb, 1, -1,
-                 f->fb->ns.fb, f->fb->nt.fb);
-      if(NUM_COLS_ON_SCREEN >= 49)
-        e_pr_str((f->a.x + 37), f->e.y - by, "Attributes", f->fb->nz.fb, 0, -1,
-                 f->fb->ns.fb, f->fb->nt.fb);
+      e_pr_str ((f->a.x + 4), f->e.y - 2, "Move", f->fb->nz.fb, 0, -1,
+		f->fb->ns.fb, f->fb->nt.fb);
+
+      if (NUM_COLS_ON_SCREEN >= 21)
+	e_pr_str ((f->a.x + 13), f->e.y - 2, "Remove", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+
+      if (NUM_COLS_ON_SCREEN >= 30)
+	e_pr_str ((f->a.x + 24), f->e.y - 2, "Link", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+
+      if (NUM_COLS_ON_SCREEN >= 39)
+	e_pr_str ((f->a.x + 33), f->e.y - 2, "COpy", f->fb->nz.fb, 1, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+
+      if (NUM_COLS_ON_SCREEN >= 48)
+	e_pr_str ((f->a.x + 42), f->e.y - 2, "Edit", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+
     }
-  }
-  if(b->sw == 0 && NUM_LINES_ON_SCREEN > 19)
-  {
-    e_pr_str((f->a.x + 4), f->e.y - 2, "Move", f->fb->nz.fb, 0, -1,
-             f->fb->ns.fb, f->fb->nt.fb);
-
-    if(NUM_COLS_ON_SCREEN >= 21)
-      e_pr_str((f->a.x + 13), f->e.y - 2, "Remove", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-
-    if(NUM_COLS_ON_SCREEN >= 30)
-      e_pr_str((f->a.x + 24), f->e.y - 2, "Link", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-
-    if(NUM_COLS_ON_SCREEN >= 39)
-      e_pr_str((f->a.x + 33), f->e.y - 2, "COpy", f->fb->nz.fb, 1, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-
-    if(NUM_COLS_ON_SCREEN >= 48)
-      e_pr_str((f->a.x + 42), f->e.y - 2, "Edit", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-
-  }
-  if(NUM_COLS_ON_SCREEN < 45)
+  if (NUM_COLS_ON_SCREEN < 45)
     bx3 = 0;
-  if(NUM_COLS_ON_SCREEN < 44)
+  if (NUM_COLS_ON_SCREEN < 44)
     bx2 = 0;
-  if(NUM_COLS_ON_SCREEN < 43)
+  if (NUM_COLS_ON_SCREEN < 43)
     bx1 = 0;
   b->xfd = (NUM_COLS_ON_SCREEN - bx1 - bx2 - bx3 - 6) / 2;
   b->xdd = NUM_COLS_ON_SCREEN - bx1 - bx2 - bx3 - b->xfd - 6;
   b->xda = 2 + bx1;
   b->xfa = 4 + bx1 + bx2 + b->xdd;
 
-  e_pr_str((f->a.x + b->xfa), f->a.y + 2, "Name:", f->fb->nt.fb, 0, 1,
-           f->fb->nsnt.fb, f->fb->nt.fb);
+  e_pr_str ((f->a.x + b->xfa), f->a.y + 2, "Name:", f->fb->nt.fb, 0, 1,
+	    f->fb->nsnt.fb, f->fb->nt.fb);
 /*    e_schr_nchar(b->rdfile, f->a.x+b->xfa, f->a.y+3, 0, b->xfd+1, f->fb->fr.fb);   */
-  e_schr_nchar_wsv(b->rdfile, f->a.x + b->xfa, f->a.y + 3, 0, b->xfd + 1,
-                   f->fb->fr.fb, f->fb->fz.fb);
-  e_pr_str((f->a.x + b->xfa), f->a.y + 5, "Files:", f->fb->nt.fb, 0, 1,
-           f->fb->nsnt.fb, f->fb->nt.fb);
+  e_schr_nchar_wsv (b->rdfile, f->a.x + b->xfa, f->a.y + 3, 0, b->xfd + 1,
+		    f->fb->fr.fb, f->fb->fz.fb);
+  e_pr_str ((f->a.x + b->xfa), f->a.y + 5, "Files:", f->fb->nt.fb, 0, 1,
+	    f->fb->nsnt.fb, f->fb->nt.fb);
 
-  e_pr_str((f->a.x + b->xda), f->a.y + 2, "Directory:", f->fb->nt.fb, 0, 1,
-           f->fb->nsnt.fb, f->fb->nt.fb);
+  e_pr_str ((f->a.x + b->xda), f->a.y + 2, "Directory:", f->fb->nt.fb, 0, 1,
+	    f->fb->nsnt.fb, f->fb->nt.fb);
 /*    e_schr_nchar(f->dirct, f->a.x+b->xda, f->a.y+3, 0, b->xdd+1, f->fb->fr.fb);   */
-  e_schr_nchar_wsv(f->dirct, f->a.x + b->xda, f->a.y + 3, 0, b->xdd + 1,
-                   f->fb->fr.fb, f->fb->fz.fb);
-  e_pr_str((f->a.x + b->xda), f->a.y + 5, "DirTree:", f->fb->nt.fb, 3, 1,
-           f->fb->nsnt.fb, f->fb->nt.fb);
+  e_schr_nchar_wsv (f->dirct, f->a.x + b->xda, f->a.y + 3, 0, b->xdd + 1,
+		    f->fb->fr.fb, f->fb->fz.fb);
+  e_pr_str ((f->a.x + b->xda), f->a.y + 5, "DirTree:", f->fb->nt.fb, 3, 1,
+	    f->fb->nsnt.fb, f->fb->nt.fb);
 
   b->fw->mxa = f->a.x;
   b->fw->mxe = f->e.x;
@@ -400,1242 +403,1298 @@ int WpeDrawFileManager(FENSTER * f)
   b->dw->ye = f->e.y - 2 - by;
 
   /* slider bars for file list */
-  e_mouse_bar(b->fw->xe, b->fw->ya, b->fw->ye - b->fw->ya, 0, b->fw->f->fb->em.fb);
-  e_mouse_bar(b->fw->xa, b->fw->ye, b->fw->xe - b->fw->xa, 1, b->fw->f->fb->em.fb);
+  e_mouse_bar (b->fw->xe, b->fw->ya, b->fw->ye - b->fw->ya, 0,
+	       b->fw->f->fb->em.fb);
+  e_mouse_bar (b->fw->xa, b->fw->ye, b->fw->xe - b->fw->xa, 1,
+	       b->fw->f->fb->em.fb);
   /* file list window */
-  e_pr_file_window(b->fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
+  e_pr_file_window (b->fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
 
   /* slide bars for directory window */
-  e_mouse_bar(b->dw->xe, b->dw->ya, b->dw->ye - b->dw->ya, 0, b->dw->f->fb->em.fb);
-  e_mouse_bar(b->dw->xa, b->dw->ye, b->dw->xe - b->dw->xa, 1, b->dw->f->fb->em.fb);
+  e_mouse_bar (b->dw->xe, b->dw->ya, b->dw->ye - b->dw->ya, 0,
+	       b->dw->f->fb->em.fb);
+  e_mouse_bar (b->dw->xa, b->dw->ye, b->dw->xe - b->dw->xa, 1,
+	       b->dw->f->fb->em.fb);
   /* directory window */
-  e_pr_file_window(b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
-  return(0);
+  e_pr_file_window (b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
+  return (0);
 }
 
 /* tries to find the required style file manager */
-int WpeCallFileManager(int sw, FENSTER * f)
+int
+WpeCallFileManager (int sw, FENSTER * f)
 {
-  int             i, ret;
-  FLBFFR         *b;
+  int i, ret;
+  FLBFFR *b;
 
-  for(i = f->ed->mxedt; i > 0; i--)
-    if(f->ed->f[i]->dtmd == DTMD_FILEMANAGER)     /* check only file manager windows */
-    {
-      b = (FLBFFR *)f->ed->f[i]->b;
-      /* open/new file manager and it is not in save mode */
-      if(sw == 0 && b->sw == sw && f->ed->f[i]->save != 1)
-        break;
-      /* wastebasket mode required, 
-         the window is "open/new" file manager and save mode turned on */
-      else if(sw == 6 && b->sw == 0 && f->ed->f[i]->save == 1)
-        break;
-      /* not open/new or wastebasket filemanager and it is the required style */
-      else if(sw != 0 && sw != 6 && b->sw == sw)
-        break;
-    }
-
-  if(i <= 0) /* we did not find the required style file-manager */
-  {
-    if(sw == 6) /* wastebasket mode */
-    {
-      char *tmp;
-
-      if ((tmp = WpeGetWastefile("")))
+  for (i = f->ed->mxedt; i > 0; i--)
+    if (f->ed->f[i]->dtmd == DTMD_FILEMANAGER)	/* check only file manager windows */
       {
-        ret = WpeCreateFileManager(sw, f->ed, tmp);
-        free(tmp);
-        return(ret);
+	b = (FLBFFR *) f->ed->f[i]->b;
+	/* open/new file manager and it is not in save mode */
+	if (sw == 0 && b->sw == sw && f->ed->f[i]->save != 1)
+	  break;
+	/* wastebasket mode required, 
+	   the window is "open/new" file manager and save mode turned on */
+	else if (sw == 6 && b->sw == 0 && f->ed->f[i]->save == 1)
+	  break;
+	/* not open/new or wastebasket filemanager and it is the required style */
+	else if (sw != 0 && sw != 6 && b->sw == sw)
+	  break;
       }
-      else
-      {
-        e_error(e_msg[ERR_NOWASTE], 0, f->ed->fb);
-        return 0;                /* Error -- no wastebasket */
-      }
+
+  if (i <= 0)			/* we did not find the required style file-manager */
+    {
+      if (sw == 6)		/* wastebasket mode */
+	{
+	  char *tmp;
+
+	  if ((tmp = WpeGetWastefile ("")))
+	    {
+	      ret = WpeCreateFileManager (sw, f->ed, tmp);
+	      free (tmp);
+	      return (ret);
+	    }
+	  else
+	    {
+	      e_error (e_msg[ERR_NOWASTE], 0, f->ed->fb);
+	      return 0;		/* Error -- no wastebasket */
+	    }
+	}
+      /* create the required style file manager */
+      return (WpeCreateFileManager (sw, f->ed, ""));
     }
-    /* create the required style file manager */
-    return(WpeCreateFileManager(sw, f->ed, ""));
-  }
   /* switch to the found file manager */
-  e_switch_window(f->ed->edt[i], f);
-  return(0);
+  e_switch_window (f->ed->edt[i], f);
+  return (0);
 }
 
 /* It will always create a new file manager */
-int WpeManagerFirst(FENSTER * f)
+int
+WpeManagerFirst (FENSTER * f)
 {
-  return(WpeCreateFileManager(0, f->ed, ""));
+  return (WpeCreateFileManager (0, f->ed, ""));
 }
 
 /* try to find an "open/new" style file manager or create one */
-int WpeManager(FENSTER * f)
+int
+WpeManager (FENSTER * f)
 {
-  return(WpeCallFileManager(0, f));
+  return (WpeCallFileManager (0, f));
 }
 
 /* try to find an "execute" style file manager or create one */
-int WpeExecuteManager(FENSTER * f)
+int
+WpeExecuteManager (FENSTER * f)
 {
-  return(WpeCallFileManager(3, f));
+  return (WpeCallFileManager (3, f));
 }
 
 /* try to find a "save as" style file manager or create one */
-int WpeSaveAsManager(FENSTER * f)
+int
+WpeSaveAsManager (FENSTER * f)
 {
-  return(WpeCreateFileManager(4, f->ed, ""));
+  return (WpeCreateFileManager (4, f->ed, ""));
 }
 
 
 /* File Manager Handler */
-int WpeHandleFileManager(ECNT * cn)
+int
+WpeHandleFileManager (ECNT * cn)
 {
-  FENSTER        *f = cn->f[cn->mxedt], *fe = NULL;
-  FLBFFR         *b = (FLBFFR *) f->b;
-  BUFFER         *be = NULL;
-  SCHIRM         *se = NULL;
-  int             c = AltC, i, j, t;
-  int             winnum = 0, nco, svmode = -1, fmode, len, start;
-  int             g[4], cold = AltN;
-  char            filen[128], *ftmp, *dtp = NULL, *ftp = NULL, *svdir = NULL;
-  char           *dirtmp = NULL;
-  view            *outp = NULL;
-  FILE           *fp;
-  struct stat     buf;
-  char            dtmd;
+  FENSTER *f = cn->f[cn->mxedt], *fe = NULL;
+  FLBFFR *b = (FLBFFR *) f->b;
+  BUFFER *be = NULL;
+  SCHIRM *se = NULL;
+  int c = AltC, i, j, t;
+  int winnum = 0, nco, svmode = -1, fmode, len, start;
+  int g[4], cold = AltN;
+  char filen[128], *ftmp, *dtp = NULL, *ftp = NULL, *svdir = NULL;
+  char *dirtmp = NULL;
+  view *outp = NULL;
+  FILE *fp;
+  struct stat buf;
+  char dtmd;
 
   /* check whether we really get a file-manager window here */
-  if(f->dtmd != DTMD_FILEMANAGER)
-    return(0);
+  if (f->dtmd != DTMD_FILEMANAGER)
+    return (0);
 
-  if(f->save == 1)
-  {
-    svmode = f->ed->flopt;
-    f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
-      FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
-  }
+  if (f->save == 1)
+    {
+      svmode = f->ed->flopt;
+      f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
+	FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
+    }
 
   /* if it is project management or saving mode 
      save the current directory to return to it */
-  if(f->save == 1 || b->sw == 5)
-  {
-    if((svdir = malloc(strlen(f->ed->dirct) + 1)) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-    strcpy(svdir, f->ed->dirct);
-  }
+  if (f->save == 1 || b->sw == 5)
+    {
+      if ((svdir = malloc (strlen (f->ed->dirct) + 1)) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+      strcpy (svdir, f->ed->dirct);
+    }
 
   nco = b->cd->anz - 1;
   /* when searching among files, search hidden ones as well */
   fmode = f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0;
   /* in execution mode show hidden dirs as well */
-  if(b->sw == 3)
+  if (b->sw == 3)
     fmode |= 2;
 
   /* searching for the last edited/touched file on the desktop */
-  for(i = cn->mxedt; i > 0; i--)
-  {
-    if (DTMD_ISTEXT(cn->f[i]->dtmd))
+  for (i = cn->mxedt; i > 0; i--)
     {
-      fe = cn->f[i];
-      be = fe->b;
-      se = fe->s;
-      winnum = cn->edt[i];
-      break;
+      if (DTMD_ISTEXT (cn->f[i]->dtmd))
+	{
+	  fe = cn->f[i];
+	  be = fe->b;
+	  se = fe->s;
+	  winnum = cn->edt[i];
+	  break;
+	}
     }
-  }
-  strcpy(f->fd.file, b->rdfile);
+  strcpy (f->fd.file, b->rdfile);
 
   /* go until quit */
-  while(c != WPE_ESC)
-  {
-    /* draw out dir tree and file list windows */
-    e_pr_file_window(b->fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
-    e_pr_file_window(b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
-
-    switch(c)
+  while (c != WPE_ESC)
     {
-      /* filename entry box activation */
-      case AltN:
-        cold = c;
-        fk_cursor(1);
-        /* get some answer from the name entry box, 
-           result file copied into b->rdfile, max 79 char + '\0' */
-        c = e_schr_lst_wsv(b->rdfile, f->a.x + b->xfa, f->a.y + 3, b->xfd + 1, 79,
-                           f->fb->fr.fb, f->fb->fz.fb, &f->ed->fdf, f);
+      /* draw out dir tree and file list windows */
+      e_pr_file_window (b->fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb,
+			f->fb->frft.fb);
+      e_pr_file_window (b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb,
+			f->fb->frft.fb);
 
-        /* determine the entered filename, going backward */
-        for(i = strlen(b->rdfile); i >= 0 && b->rdfile[i] != DIRC; i--)
-          ;
-        strcpy(f->fd.file, b->rdfile + 1 + i);
+      switch (c)
+	{
+	  /* filename entry box activation */
+	case AltN:
+	  cold = c;
+	  fk_cursor (1);
+	  /* get some answer from the name entry box, 
+	     result file copied into b->rdfile, max 79 char + '\0' */
+	  c =
+	    e_schr_lst_wsv (b->rdfile, f->a.x + b->xfa, f->a.y + 3,
+			    b->xfd + 1, 79, f->fb->fr.fb, f->fb->fz.fb,
+			    &f->ed->fdf, f);
 
-        /* there is some directory structure in the filename */
-        if(i >= 0)
-        {
-          if(i == 0)
-            i++;
-          b->rdfile[i] = '\0';
-          /* change the working directory */
-          free(f->dirct);
-          if((f->dirct = malloc(strlen(b->rdfile) + 1)) == NULL)
-            e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-          strcpy(f->dirct, b->rdfile);
+	  /* determine the entered filename, going backward */
+	  for (i = strlen (b->rdfile); i >= 0 && b->rdfile[i] != DIRC; i--)
+	    ;
+	  strcpy (f->fd.file, b->rdfile + 1 + i);
 
-          /* restore original filename */
-          strcpy(b->rdfile, f->fd.file);
-          c = AltC;
-        }
+	  /* there is some directory structure in the filename */
+	  if (i >= 0)
+	    {
+	      if (i == 0)
+		i++;
+	      b->rdfile[i] = '\0';
+	      /* change the working directory */
+	      free (f->dirct);
+	      if ((f->dirct = malloc (strlen (b->rdfile) + 1)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	      strcpy (f->dirct, b->rdfile);
+
+	      /* restore original filename */
+	      strcpy (b->rdfile, f->fd.file);
+	      c = AltC;
+	    }
 #if  MOUSE
-        /* if mouse was used (the reason it returned) get appropriate key interpretation */
-        if(c == -1)
-          c = WpeMngMouseInFileManager(f);
+	  /* if mouse was used (the reason it returned) get appropriate key interpretation */
+	  if (c == -1)
+	    c = WpeMngMouseInFileManager (f);
 #endif
-        if((c >= Alt1 && c <= Alt9) || (c >= 1024 && c <= 1049))
-        {
-          /* window changing, make the entry unhighlighted */
-          e_schr_nchar_wsv(b->rdfile, f->a.x + b->xfa, f->a.y + 3, 0, b->xfd + 1,
-                           f->fb->fr.fb, f->fb->fz.fb);
-          break;
-        }
-        if(c == CLE || c == CCLE) /* goto dir name window */
-          c = AltD;
-        else if(c == CDO || c == BDO || c == WPE_TAB) /* goto file list window */
-          c = AltF;
-        else if(c == WPE_BTAB) /* goto dir tree window */
-          c = AltT;
-        else if(    (   c == WPE_CR 
-                     || (b->sw == 0 && c == AltE)
-                     || (b->sw == 1 && c == AltR) 
-                     || (b->sw == 2 && c == AltW) 
-                     || (b->sw == 3 && c == AltE) 
-                     || (b->sw == 5 && c == AltA) 
-                     || (b->sw == 4 && (c == AltS || c == AltY)) ) 
-                 && (   strstr(b->rdfile, "*") 
-                     || strstr(b->rdfile, "?")
-                     || strstr(b->rdfile, "[") ) )
-        {
-          WpeMouseChangeShape(WpeWorkingShape);
-          /* free up existing structures */
-          freedf(b->df);
-          freedf(b->fw->df);
-          /* find files according to the new pattern */
-          b->df = e_find_files(b->rdfile, fmode);
-          /* setup the drawing in the dir tree window */
-          b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
-          b->fw->ia = b->fw->nf = 0;
-          b->fw->ja = b->fw->srcha;
-          /* jump to file list window */
-          c = AltF;
-          WpeMouseRestoreShape();
-        }
-        else
-        {
-          strcpy(filen, b->rdfile);   /* !!! alloc for filen ??? */
-          if(c == WPE_CR)
-          {
-            if(b->sw == 1)
-              c = AltR;
-            else if(b->sw == 2)
-              c = AltW;
-            else if(b->sw == 4)
-              c = AltS;
-            else if(b->sw == 5)
-              c = AltA;
-            else
-              c = AltE;
-          }
-        }
-        /* entry window is left, make the entry unhighlighted */
-        if(c != AltN)
-          e_schr_nchar_wsv(b->rdfile, f->a.x + b->xfa, f->a.y + 3, 0, b->xfd + 1,
-                           f->fb->fr.fb, f->fb->fz.fb);
-        fk_cursor(0);
-        break;
+	  if ((c >= Alt1 && c <= Alt9) || (c >= 1024 && c <= 1049))
+	    {
+	      /* window changing, make the entry unhighlighted */
+	      e_schr_nchar_wsv (b->rdfile, f->a.x + b->xfa, f->a.y + 3, 0,
+				b->xfd + 1, f->fb->fr.fb, f->fb->fz.fb);
+	      break;
+	    }
+	  if (c == CLE || c == CCLE)	/* goto dir name window */
+	    c = AltD;
+	  else if (c == CDO || c == BDO || c == WPE_TAB)	/* goto file list window */
+	    c = AltF;
+	  else if (c == WPE_BTAB)	/* goto dir tree window */
+	    c = AltT;
+	  else if ((c == WPE_CR
+		    || (b->sw == 0 && c == AltE)
+		    || (b->sw == 1 && c == AltR)
+		    || (b->sw == 2 && c == AltW)
+		    || (b->sw == 3 && c == AltE)
+		    || (b->sw == 5 && c == AltA)
+		    || (b->sw == 4 && (c == AltS || c == AltY)))
+		   && (strstr (b->rdfile, "*")
+		       || strstr (b->rdfile, "?") || strstr (b->rdfile, "[")))
+	    {
+	      WpeMouseChangeShape (WpeWorkingShape);
+	      /* free up existing structures */
+	      freedf (b->df);
+	      freedf (b->fw->df);
+	      /* find files according to the new pattern */
+	      b->df = e_find_files (b->rdfile, fmode);
+	      /* setup the drawing in the dir tree window */
+	      b->fw->df = WpeGraphicalFileList (b->df, f->ed->flopt >> 9, cn);
+	      b->fw->ia = b->fw->nf = 0;
+	      b->fw->ja = b->fw->srcha;
+	      /* jump to file list window */
+	      c = AltF;
+	      WpeMouseRestoreShape ();
+	    }
+	  else
+	    {
+	      strcpy (filen, b->rdfile);	/* !!! alloc for filen ??? */
+	      if (c == WPE_CR)
+		{
+		  if (b->sw == 1)
+		    c = AltR;
+		  else if (b->sw == 2)
+		    c = AltW;
+		  else if (b->sw == 4)
+		    c = AltS;
+		  else if (b->sw == 5)
+		    c = AltA;
+		  else
+		    c = AltE;
+		}
+	    }
+	  /* entry window is left, make the entry unhighlighted */
+	  if (c != AltN)
+	    e_schr_nchar_wsv (b->rdfile, f->a.x + b->xfa, f->a.y + 3, 0,
+			      b->xfd + 1, f->fb->fr.fb, f->fb->fz.fb);
+	  fk_cursor (0);
+	  break;
 
-      /* directory name entry box activation */
-      case AltD:
-        cold = c;
-        fk_cursor(1);
+	  /* directory name entry box activation */
+	case AltD:
+	  cold = c;
+	  fk_cursor (1);
 
-        /* get the directory name */
-        if ((dirtmp = malloc(WPE_PATHMAX)) == NULL)        /* dirct mat not have enough memory */
-          e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+	  /* get the directory name */
+	  if ((dirtmp = malloc (WPE_PATHMAX)) == NULL)	/* dirct mat not have enough memory */
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
-        if (strlen(f->dirct) >= WPE_PATHMAX)
-        {
-          strncpy(dirtmp, f->dirct, WPE_PATHMAX - 1);
-          dirtmp[WPE_PATHMAX - 1] = '\0';
-        }
-        else
-          strcpy(dirtmp, f->dirct);
+	  if (strlen (f->dirct) >= WPE_PATHMAX)
+	    {
+	      strncpy (dirtmp, f->dirct, WPE_PATHMAX - 1);
+	      dirtmp[WPE_PATHMAX - 1] = '\0';
+	    }
+	  else
+	    strcpy (dirtmp, f->dirct);
 
-        c = e_schr_lst_wsv(dirtmp, f->a.x + b->xda, f->a.y + 3, b->xdd + 1, WPE_PATHMAX,
-                           f->fb->fr.fb, f->fb->fz.fb, &f->ed->ddf, f);
-        free(f->dirct);
-        f->dirct = WpeStrdup(dirtmp);
-        free(dirtmp);
+	  c =
+	    e_schr_lst_wsv (dirtmp, f->a.x + b->xda, f->a.y + 3, b->xdd + 1,
+			    WPE_PATHMAX, f->fb->fr.fb, f->fb->fz.fb,
+			    &f->ed->ddf, f);
+	  free (f->dirct);
+	  f->dirct = WpeStrdup (dirtmp);
+	  free (dirtmp);
 
 #if  MOUSE
-        if(c == -1)
-          c = WpeMngMouseInFileManager(f);
+	  if (c == -1)
+	    c = WpeMngMouseInFileManager (f);
 #endif
-        if(c == CRI || c == CCRI) /* goto name entry windwow */
-          c = AltN;
-        else if(c == CDO || c == BDO || c == WPE_TAB) /* goto dir tree window */
-          c = AltT;
-        else if(c == WPE_BTAB) /* goto file list window */
-          c = AltF;
-        else if(c == WPE_CR) /* change dir */
-          c = AltC;
-        /* window left, make the entry unhighlighted */
-        if(c != AltD)
-          e_schr_nchar_wsv(f->dirct, f->a.x + b->xda, f->a.y + 3, 0, b->xdd + 1,
-                           f->fb->fr.fb, f->fb->fz.fb);
-        fk_cursor(0);
-        break;
+	  if (c == CRI || c == CCRI)	/* goto name entry windwow */
+	    c = AltN;
+	  else if (c == CDO || c == BDO || c == WPE_TAB)	/* goto dir tree window */
+	    c = AltT;
+	  else if (c == WPE_BTAB)	/* goto file list window */
+	    c = AltF;
+	  else if (c == WPE_CR)	/* change dir */
+	    c = AltC;
+	  /* window left, make the entry unhighlighted */
+	  if (c != AltD)
+	    e_schr_nchar_wsv (f->dirct, f->a.x + b->xda, f->a.y + 3, 0,
+			      b->xdd + 1, f->fb->fr.fb, f->fb->fz.fb);
+	  fk_cursor (0);
+	  break;
 
-      /* directory tree list window activation */
-      case AltT:
-        cold = c;
-        c = e_file_window(1, b->dw, f->fb->ft.fb, f->fb->fz.fb);
+	  /* directory tree list window activation */
+	case AltT:
+	  cold = c;
+	  c = e_file_window (1, b->dw, f->fb->ft.fb, f->fb->fz.fb);
 #if  MOUSE
-        if(c == MBKEY)         /* handle mouse actions in the window */
-          c = WpeMngMouseInFileManager(f);
-        else if(c < 0)
-          c = WpeMouseInFileDirList(c, 1, f);
+	  if (c == MBKEY)	/* handle mouse actions in the window */
+	    c = WpeMngMouseInFileManager (f);
+	  else if (c < 0)
+	    c = WpeMouseInFileDirList (c, 1, f);
 #endif
-        if(c == CCRI)
-          c = AltF;
-        else if(c == BUP)
-          c = AltD;
-        else if(c == WPE_TAB)
-          c = AltN;
-        else if(c == WPE_BTAB)
-          c = AltD;
-        else if(c == AltC || (c == WPE_CR && b->dw->nf != nco))
-        {
-          if ((dirtmp = WpeAssemblePath(f->dirct, b->cd, b->dd, b->dw->nf, f)))
-          {
-            free(f->dirct);
-            f->dirct = dirtmp;
-            e_schr_nchar_wsv(f->dirct, f->a.x + b->xda, f->a.y + 3, 0, b->xdd + 1,
-                             f->fb->fr.fb, f->fb->fz.fb);
-            f->ed->ddf = e_add_df(f->dirct, f->ed->ddf);
-            c = AltC;
-          }
-          /* there is only one case when it cannot assemble the path,
-             that it cannot access wastebasket, then quit the file manager */
-          else
-            c = WPE_ESC;
-        }
-        else if(c == WPE_CR)
-          c = AltT;
-        break;
+	  if (c == CCRI)
+	    c = AltF;
+	  else if (c == BUP)
+	    c = AltD;
+	  else if (c == WPE_TAB)
+	    c = AltN;
+	  else if (c == WPE_BTAB)
+	    c = AltD;
+	  else if (c == AltC || (c == WPE_CR && b->dw->nf != nco))
+	    {
+	      if ((dirtmp =
+		   WpeAssemblePath (f->dirct, b->cd, b->dd, b->dw->nf, f)))
+		{
+		  free (f->dirct);
+		  f->dirct = dirtmp;
+		  e_schr_nchar_wsv (f->dirct, f->a.x + b->xda, f->a.y + 3, 0,
+				    b->xdd + 1, f->fb->fr.fb, f->fb->fz.fb);
+		  f->ed->ddf = e_add_df (f->dirct, f->ed->ddf);
+		  c = AltC;
+		}
+	      /* there is only one case when it cannot assemble the path,
+	         that it cannot access wastebasket, then quit the file manager */
+	      else
+		c = WPE_ESC;
+	    }
+	  else if (c == WPE_CR)
+	    c = AltT;
+	  break;
 
-      /* file list window activation */
-      case AltF:
-        if(b->df->anz < 1)
-        {
-          c = cold;
-          break;
-        }
-        cold = c;
-        c = e_file_window(1, b->fw, f->fb->ft.fb, f->fb->fz.fb);
+	  /* file list window activation */
+	case AltF:
+	  if (b->df->anz < 1)
+	    {
+	      c = cold;
+	      break;
+	    }
+	  cold = c;
+	  c = e_file_window (1, b->fw, f->fb->ft.fb, f->fb->fz.fb);
 #if  MOUSE
-        if(c == MBKEY)
-          c = WpeMngMouseInFileManager(f);
-        else if(c < 0)
-          c = WpeMouseInFileDirList(c, 0, f);
+	  if (c == MBKEY)
+	    c = WpeMngMouseInFileManager (f);
+	  else if (c < 0)
+	    c = WpeMouseInFileDirList (c, 0, f);
 #endif
-        if(c == BUP)  /* goto file name entry window */
-          c = AltN;
-        else if(c == CCLE) /* goto dir tree window */
-          c = AltT;
-        else if(c == WPE_TAB) /* goto dir entry window */
-          c = AltD;
-        else if(c == WPE_BTAB) /* goto file name entry window */
-          c = AltN;
-        else if(c == WPE_CR)  /* action selected */
-        {
-          if(b->sw == 1)
-            c = AltR;
-          else if(b->sw == 2)
-            c = AltW;
-          else if(b->sw == 4)
-            c = AltS;
-          else if(b->sw == 5)
-            c = AltA;
-          else
-            c = AltE;
-        }
-        if(   (b->sw == 1 && c == AltR)  /* in case of action store the filename */
-           || (b->sw == 2 && c == AltW)
-           || (b->sw == 3 && c == AltE)
-           || (b->sw == 0 && c == AltE) 
-           || (b->sw == 4 && (c == AltS || c == AltY)) )
-        {
-          strcpy(filen, *(b->df->name + b->fw->nf));   /* !!! alloc for filen ??? */
-        }
-        break;
+	  if (c == BUP)		/* goto file name entry window */
+	    c = AltN;
+	  else if (c == CCLE)	/* goto dir tree window */
+	    c = AltT;
+	  else if (c == WPE_TAB)	/* goto dir entry window */
+	    c = AltD;
+	  else if (c == WPE_BTAB)	/* goto file name entry window */
+	    c = AltN;
+	  else if (c == WPE_CR)	/* action selected */
+	    {
+	      if (b->sw == 1)
+		c = AltR;
+	      else if (b->sw == 2)
+		c = AltW;
+	      else if (b->sw == 4)
+		c = AltS;
+	      else if (b->sw == 5)
+		c = AltA;
+	      else
+		c = AltE;
+	    }
+	  if ((b->sw == 1 && c == AltR)	/* in case of action store the filename */
+	      || (b->sw == 2 && c == AltW)
+	      || (b->sw == 3 && c == AltE)
+	      || (b->sw == 0 && c == AltE)
+	      || (b->sw == 4 && (c == AltS || c == AltY)))
+	    {
+	      strcpy (filen, *(b->df->name + b->fw->nf));	/* !!! alloc for filen ??? */
+	    }
+	  break;
 
-      /* change dir button activation */
-      case AltC:
-        c = cold;
-        /* if the current dir is equal to the "newly" entered dir, break */
-        if(!strcmp(f->ed->dirct, f->dirct))
-          break;
+	  /* change dir button activation */
+	case AltC:
+	  c = cold;
+	  /* if the current dir is equal to the "newly" entered dir, break */
+	  if (!strcmp (f->ed->dirct, f->dirct))
+	    break;
 
-        /* in wastebasket mode, we do not allow to go out of it through
-           a soft link */
-        if((b->sw == 0) && (f->save == 1))
-        {
-          if(lstat(f->dirct, &buf))
-          {
-            e_error(e_msg[ERR_ACCFILE], 0, f->ed->fb);
-            break;
-          }
-          if(S_ISLNK(buf.st_mode))
-          {
-            /* cannot go out through a softlink, restore dir name */
-            if((f->dirct = realloc(f->dirct, strlen(f->ed->dirct) + 1)) == NULL)
-              e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-            else
-              strcpy(f->dirct, f->ed->dirct);
-            break;
-          }
-        }
+	  /* in wastebasket mode, we do not allow to go out of it through
+	     a soft link */
+	  if ((b->sw == 0) && (f->save == 1))
+	    {
+	      if (lstat (f->dirct, &buf))
+		{
+		  e_error (e_msg[ERR_ACCFILE], 0, f->ed->fb);
+		  break;
+		}
+	      if (S_ISLNK (buf.st_mode))
+		{
+		  /* cannot go out through a softlink, restore dir name */
+		  if ((f->dirct =
+		       realloc (f->dirct, strlen (f->ed->dirct) + 1)) == NULL)
+		    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+		  else
+		    strcpy (f->dirct, f->ed->dirct);
+		  break;
+		}
+	    }
 
-        /* change to the desired dir with system error checking */
-        if(chdir(f->dirct))
-        {
-          e_error(e_msg[ERR_WORKDIRACCESS], 0, f->fb);
+	  /* change to the desired dir with system error checking */
+	  if (chdir (f->dirct))
+	    {
+	      e_error (e_msg[ERR_WORKDIRACCESS], 0, f->fb);
 
-          /* we cannot determine where we are, try the home */
-          if((dirtmp = getenv("HOME")) == NULL)
-            e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-          if(chdir(dirtmp))
-            e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-        }
+	      /* we cannot determine where we are, try the home */
+	      if ((dirtmp = getenv ("HOME")) == NULL)
+		e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+	      if (chdir (dirtmp))
+		e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+	    }
 
-        /* get current directory */
-        dirtmp = WpeGetCurrentDir(f->ed);
+	  /* get current directory */
+	  dirtmp = WpeGetCurrentDir (f->ed);
 
-        /* change the shape of the mouse */
-        WpeMouseChangeShape(WpeWorkingShape);
+	  /* change the shape of the mouse */
+	  WpeMouseChangeShape (WpeWorkingShape);
 
-        free(f->dirct);
-        f->dirct = dirtmp;
+	  free (f->dirct);
+	  f->dirct = dirtmp;
 
-        /* free up all relevant structures */
-        freedf(b->df);
-        freedf(b->fw->df);
-        freedf(b->cd);
-        freedf(b->dw->df);
-        freedf(b->dd);
+	  /* free up all relevant structures */
+	  freedf (b->df);
+	  freedf (b->fw->df);
+	  freedf (b->cd);
+	  freedf (b->dw->df);
+	  freedf (b->dd);
 
-        /* reset the current dir path in the control structure */
-        if((f->ed->dirct = realloc(f->ed->dirct, strlen(f->dirct) + 1)) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-        else
-          strcpy(f->ed->dirct, f->dirct);
+	  /* reset the current dir path in the control structure */
+	  if ((f->ed->dirct =
+	       realloc (f->ed->dirct, strlen (f->dirct) + 1)) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+	  else
+	    strcpy (f->ed->dirct, f->dirct);
 
-        /* setup current directory structure */
-        b->cd = WpeCreateWorkingDirTree(f->save, cn);
-        /* find all other directories in the current dir */
-        b->dd = e_find_dir(SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-        /* setup the drawing in the dir tree window */
-        b->dw->df = WpeGraphicalDirTree(b->cd, b->dd, cn);
+	  /* setup current directory structure */
+	  b->cd = WpeCreateWorkingDirTree (f->save, cn);
+	  /* find all other directories in the current dir */
+	  b->dd =
+	    e_find_dir (SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+	  /* setup the drawing in the dir tree window */
+	  b->dw->df = WpeGraphicalDirTree (b->cd, b->dd, cn);
 
-        nco = b->dw->nf = b->cd->anz - 1;
-        b->dw->ia = b->dw->ja = 0;
+	  nco = b->dw->nf = b->cd->anz - 1;
+	  b->dw->ia = b->dw->ja = 0;
 
-        /* finds all files matching the pattern */
-        b->df = e_find_files(b->rdfile, fmode);
-        /* setup the drawing in the file list window */
-        b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
-        b->fw->nf = b->fw->ia = 0;
-        b->fw->ja = 12;
+	  /* finds all files matching the pattern */
+	  b->df = e_find_files (b->rdfile, fmode);
+	  /* setup the drawing in the file list window */
+	  b->fw->df = WpeGraphicalFileList (b->df, f->ed->flopt >> 9, cn);
+	  b->fw->nf = b->fw->ia = 0;
+	  b->fw->ja = 12;
 
-        /* change the shape of the mouse back */
-        WpeMouseRestoreShape();
-        break;
+	  /* change the shape of the mouse back */
+	  WpeMouseRestoreShape ();
+	  break;
 
-      /* link file activation */
-      case AltL:
-      /* copy file activation */
-      case AltO:
-      /* move file activation */
-      case AltM:
-        /* moving/copying a file is valid only in mode 0 (open/new file) */
-        if(b->sw != 0)
-        {
-          c = cold;
-          break;
-        }
-        j = c;
+	  /* link file activation */
+	case AltL:
+	  /* copy file activation */
+	case AltO:
+	  /* move file activation */
+	case AltM:
+	  /* moving/copying a file is valid only in mode 0 (open/new file) */
+	  if (b->sw != 0)
+	    {
+	      c = cold;
+	      break;
+	    }
+	  j = c;
 
-        /* we are coming from files */
-        if(cold == AltF)
-        {
-          if((ftmp = malloc(129)) == NULL)
-            e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+	  /* we are coming from files */
+	  if (cold == AltF)
+	    {
+	      if ((ftmp = malloc (129)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
-          if(strlen(*(b->df->name + b->fw->nf)) > 128)
-          {
-            strncpy(ftmp, *(b->df->name + b->fw->nf), 128);
-            ftmp[128] = '\0';
-          }
-          else
-            strcpy(ftmp, *(b->df->name + b->fw->nf));
+	      if (strlen (*(b->df->name + b->fw->nf)) > 128)
+		{
+		  strncpy (ftmp, *(b->df->name + b->fw->nf), 128);
+		  ftmp[128] = '\0';
+		}
+	      else
+		strcpy (ftmp, *(b->df->name + b->fw->nf));
 
-          /* make the file name editable */
-          c = e_schreib_leiste(ftmp, b->fw->xa, b->fw->ya + b->fw->nf - b->fw->ia,
-                               b->fw->xe - b->fw->xa, 128, f->fb->fr.fb, f->fb->fz.fb);
-          if(c == WPE_CR)
-          {
-            if(j == AltM)
-              e_rename(*(b->df->name + b->fw->nf), ftmp, f); /* move */
-            else if(j == AltL)
-              WpeLinkFile(*(b->df->name + b->fw->nf), ftmp, /* link */
-                          f->ed->flopt & FM_TRY_HARDLINK, f);
-            else if(j == AltO)
-              e_copy(*(b->df->name + b->fw->nf), ftmp, f); /* copy */
+	      /* make the file name editable */
+	      c =
+		e_schreib_leiste (ftmp, b->fw->xa,
+				  b->fw->ya + b->fw->nf - b->fw->ia,
+				  b->fw->xe - b->fw->xa, 128, f->fb->fr.fb,
+				  f->fb->fz.fb);
+	      if (c == WPE_CR)
+		{
+		  if (j == AltM)
+		    e_rename (*(b->df->name + b->fw->nf), ftmp, f);	/* move */
+		  else if (j == AltL)
+		    WpeLinkFile (*(b->df->name + b->fw->nf), ftmp,	/* link */
+				 f->ed->flopt & FM_TRY_HARDLINK, f);
+		  else if (j == AltO)
+		    e_copy (*(b->df->name + b->fw->nf), ftmp, f);	/* copy */
 
-            /* after copying/moving/linking, free up the old structures */
-            freedf(b->df);
-            freedf(b->fw->df);
+		  /* after copying/moving/linking, free up the old structures */
+		  freedf (b->df);
+		  freedf (b->fw->df);
 
-            /* generate the new file list */
-            b->df = e_find_files(b->rdfile, fmode);
-            /* setup the drawing of it */
-            b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
-            b->fw->ia = b->fw->nf = 0;
-            b->fw->ja = b->fw->srcha;
-          }
-          free(ftmp);
-        }
-        /* we are coming from dirs */
-        else if(cold == AltT && b->dw->nf >= b->cd->anz)
-        {
-          if((ftmp = malloc(129)) == NULL)
-            e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+		  /* generate the new file list */
+		  b->df = e_find_files (b->rdfile, fmode);
+		  /* setup the drawing of it */
+		  b->fw->df =
+		    WpeGraphicalFileList (b->df, f->ed->flopt >> 9, cn);
+		  b->fw->ia = b->fw->nf = 0;
+		  b->fw->ja = b->fw->srcha;
+		}
+	      free (ftmp);
+	    }
+	  /* we are coming from dirs */
+	  else if (cold == AltT && b->dw->nf >= b->cd->anz)
+	    {
+	      if ((ftmp = malloc (129)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
-          /* selected dir */
-          t = b->dw->nf - b->cd->anz;
+	      /* selected dir */
+	      t = b->dw->nf - b->cd->anz;
 
-          if(strlen(*(b->dd->name + t)) > 128)
-          {
-            strncpy(ftmp, *(b->dd->name + t), 128);
-            ftmp[128] = '\0';
-          }
-          else
-            strcpy(ftmp, *(b->dd->name + t));
+	      if (strlen (*(b->dd->name + t)) > 128)
+		{
+		  strncpy (ftmp, *(b->dd->name + t), 128);
+		  ftmp[128] = '\0';
+		}
+	      else
+		strcpy (ftmp, *(b->dd->name + t));
 
 
-          /* separate the dir name from other drawings in the line */
-          for(i = 0; *(b->dw->df->name[b->dw->nf] + i) &&
-              (*(b->dw->df->name[b->dw->nf] + i) <= 32 ||
-               *(b->dw->df->name[b->dw->nf] + i) >= 127); i++)
-            ;
+	      /* separate the dir name from other drawings in the line */
+	      for (i = 0; *(b->dw->df->name[b->dw->nf] + i) &&
+		   (*(b->dw->df->name[b->dw->nf] + i) <= 32 ||
+		    *(b->dw->df->name[b->dw->nf] + i) >= 127); i++)
+		;
 
-          if(!WpeIsXwin())
-            i += 3;
-          b->dw->ja = i;
-          e_pr_file_window(b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
-          /* make the name editable */
-          c = e_schreib_leiste(ftmp, b->dw->xa, b->dw->ya + b->dw->nf - b->dw->ia, 
-                               b->dw->xe - b->dw->xa, 128, f->fb->fr.fb, f->fb->fz.fb);
-          if(c == WPE_CR)
-          {
-            if(j == AltM)
-              e_rename(*(b->dd->name + t), ftmp, f); /* move */
-            else if(j == AltL)
-              e_link(*(b->dd->name + t), ftmp, f); /* link */
-            else if(j == AltO)
-              e_copy(*(b->dd->name + t), ftmp, f); /* copy */
+	      if (!WpeIsXwin ())
+		i += 3;
+	      b->dw->ja = i;
+	      e_pr_file_window (b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb,
+				f->fb->frft.fb);
+	      /* make the name editable */
+	      c =
+		e_schreib_leiste (ftmp, b->dw->xa,
+				  b->dw->ya + b->dw->nf - b->dw->ia,
+				  b->dw->xe - b->dw->xa, 128, f->fb->fr.fb,
+				  f->fb->fz.fb);
+	      if (c == WPE_CR)
+		{
+		  if (j == AltM)
+		    e_rename (*(b->dd->name + t), ftmp, f);	/* move */
+		  else if (j == AltL)
+		    e_link (*(b->dd->name + t), ftmp, f);	/* link */
+		  else if (j == AltO)
+		    e_copy (*(b->dd->name + t), ftmp, f);	/* copy */
 
-            /* free up structures */
-            freedf(b->cd);
-            freedf(b->dw->df);
-            freedf(b->dd);
+		  /* free up structures */
+		  freedf (b->cd);
+		  freedf (b->dw->df);
+		  freedf (b->dd);
 
-            /* determine current directory */
-            b->cd = WpeCreateWorkingDirTree(f->save, cn);
-            /* find all other directories in the current */
-            b->dd = e_find_dir(SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-            /* setup drawing */
-            b->dw->df = WpeGraphicalDirTree(b->cd, b->dd, cn);
-            nco = b->dw->nf = b->cd->anz - 1;
-            b->dw->ia = b->dw->ja = 0;
-          }
-          free(ftmp);
-        }
-        c = cold;
-        cold = AltN; /* go back to name entry */
-        break;
+		  /* determine current directory */
+		  b->cd = WpeCreateWorkingDirTree (f->save, cn);
+		  /* find all other directories in the current */
+		  b->dd =
+		    e_find_dir (SUDIR,
+				f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+		  /* setup drawing */
+		  b->dw->df = WpeGraphicalDirTree (b->cd, b->dd, cn);
+		  nco = b->dw->nf = b->cd->anz - 1;
+		  b->dw->ia = b->dw->ja = 0;
+		}
+	      free (ftmp);
+	    }
+	  c = cold;
+	  cold = AltN;		/* go back to name entry */
+	  break;
 
-      /* remove button activation */
-      case ENTF:
-        if(b->sw != 0)
-        {
-          c = cold;
-          break;
-        }
-      /* remove button activation */
-      case AltR:
-        if(b->sw == 0)
-        {
-          /* coming from file list */
-          if(cold == AltF)
-          {
-            WpeRemove(*(b->df->name + b->fw->nf), f); /* remove the file */
+	  /* remove button activation */
+	case ENTF:
+	  if (b->sw != 0)
+	    {
+	      c = cold;
+	      break;
+	    }
+	  /* remove button activation */
+	case AltR:
+	  if (b->sw == 0)
+	    {
+	      /* coming from file list */
+	      if (cold == AltF)
+		{
+		  WpeRemove (*(b->df->name + b->fw->nf), f);	/* remove the file */
 
-            /* free up structures */
-            freedf(b->df);
-            freedf(b->fw->df);
+		  /* free up structures */
+		  freedf (b->df);
+		  freedf (b->fw->df);
 
-            /* find files according to the pattern */
-            b->df = e_find_files(b->rdfile, fmode);
+		  /* find files according to the pattern */
+		  b->df = e_find_files (b->rdfile, fmode);
 
-            /* setup drawing */
-            b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
-            b->fw->ia = b->fw->nf = 0;
-            b->fw->ja = b->fw->srcha;
-          }
-          /* coming from the dir tree list and the selected dir is a subdir of
-             the current directory */
-          else if(cold == AltT && b->dw->nf >= b->cd->anz)
-          {
-            t = b->dw->nf - b->cd->anz;
-            WpeRemove(*(b->dd->name + t), f);  /* remove the dir */
+		  /* setup drawing */
+		  b->fw->df =
+		    WpeGraphicalFileList (b->df, f->ed->flopt >> 9, cn);
+		  b->fw->ia = b->fw->nf = 0;
+		  b->fw->ja = b->fw->srcha;
+		}
+	      /* coming from the dir tree list and the selected dir is a subdir of
+	         the current directory */
+	      else if (cold == AltT && b->dw->nf >= b->cd->anz)
+		{
+		  t = b->dw->nf - b->cd->anz;
+		  WpeRemove (*(b->dd->name + t), f);	/* remove the dir */
 
-            /* free up structures */
-            freedf(b->cd);
-            freedf(b->dw->df);
-            freedf(b->dd);
+		  /* free up structures */
+		  freedf (b->cd);
+		  freedf (b->dw->df);
+		  freedf (b->dd);
 
-            /* determine current directory */
-            b->cd = WpeCreateWorkingDirTree(f->save, cn);
-            /* find all other directories in the current */
-            b->dd = e_find_dir(SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-            /* setup drawing */
-            b->dw->df = WpeGraphicalDirTree(b->cd, b->dd, cn);
-            nco = b->dw->nf = b->cd->anz - 1;
-            b->dw->ia = b->dw->ja = 0;
-          }
-          c = cold;
-          cold = AltN; /* go back to name entry */
-          break;
-        }
+		  /* determine current directory */
+		  b->cd = WpeCreateWorkingDirTree (f->save, cn);
+		  /* find all other directories in the current */
+		  b->dd =
+		    e_find_dir (SUDIR,
+				f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+		  /* setup drawing */
+		  b->dw->df = WpeGraphicalDirTree (b->cd, b->dd, cn);
+		  nco = b->dw->nf = b->cd->anz - 1;
+		  b->dw->ia = b->dw->ja = 0;
+		}
+	      c = cold;
+	      cold = AltN;	/* go back to name entry */
+	      break;
+	    }
 
-      /* edit/execute button activation */
-      case AltE:
-        if(   (c == AltE && b->sw != 0 && b->sw != 3) 
-           || (c == AltR && b->sw != 1) )
-        {
-          c = cold;
-          break;
-        }
-        if(b->sw == 3) /* file-manager in execution mode */
-        {
-          if(cold == AltF)
-            strcpy(filen, *(b->df->name + b->fw->nf));     /* !!! alloc filen ??? */
-          if(!WpeIsXwin())
-          {
-            outp = e_open_view(0, 0, MAXSCOL - 1, MAXSLNS - 1, f->fb->ws, 1);
-            fk_locate(0, 0);
-            fk_cursor(1);
+	  /* edit/execute button activation */
+	case AltE:
+	  if ((c == AltE && b->sw != 0 && b->sw != 3)
+	      || (c == AltR && b->sw != 1))
+	    {
+	      c = cold;
+	      break;
+	    }
+	  if (b->sw == 3)	/* file-manager in execution mode */
+	    {
+	      if (cold == AltF)
+		strcpy (filen, *(b->df->name + b->fw->nf));	/* !!! alloc filen ??? */
+	      if (!WpeIsXwin ())
+		{
+		  outp =
+		    e_open_view (0, 0, MAXSCOL - 1, MAXSLNS - 1, f->fb->ws,
+				 1);
+		  fk_locate (0, 0);
+		  fk_cursor (1);
 #if  MOUSE
-            g[0] = 2;
-            fk_mouse(g);
+		  g[0] = 2;
+		  fk_mouse (g);
 #endif
-            (*e_u_sys_ini)();
-            printf(e_msg[ERR_EXEC], filen);
-            fflush(stdout);
-          }
-          if ((*e_u_system)(filen))
-          {
-            if(!WpeIsXwin())
-              (*e_u_sys_end)();
-            e_error(e_msg[ERR_COMMAND], 0, f->fb);
-          }
-          else if(!WpeIsXwin())
-          {
-            printf("%s",e_msg[ERR_HITCR]);
-            fflush(stderr);
-            fflush(stdout);
-            fk_getch();
-          }
-          if(!WpeIsXwin())
-          {
-            (*e_u_sys_end)();
-            e_close_view(outp, 1);
-            fk_cursor(0);
+		  (*e_u_sys_ini) ();
+		  printf (e_msg[ERR_EXEC], filen);
+		  fflush (stdout);
+		}
+	      if ((*e_u_system) (filen))
+		{
+		  if (!WpeIsXwin ())
+		    (*e_u_sys_end) ();
+		  e_error (e_msg[ERR_COMMAND], 0, f->fb);
+		}
+	      else if (!WpeIsXwin ())
+		{
+		  printf ("%s", e_msg[ERR_HITCR]);
+		  fflush (stderr);
+		  fflush (stdout);
+		  fk_getch ();
+		}
+	      if (!WpeIsXwin ())
+		{
+		  (*e_u_sys_end) ();
+		  e_close_view (outp, 1);
+		  fk_cursor (0);
 #if MOUSE
-            g[0] = 1;
-            fk_mouse(g);
+		  g[0] = 1;
+		  fk_mouse (g);
 #endif
-          }
-          c = cold;
-          break;
-        }
-        else
-        {
-          /* if there is only a pattern get back to file selection */
-          if(strstr(filen, "*") || strstr(filen, "?"))
-          {
-            c = AltF;
-            break;
-          }
-          /* there is no open ??? file */
-          if(b->sw == 0 || !fe)
-          {
-            /* close on open request */
-            if(f->ed->flopt & FM_CLOSE_WINDOW)
-            {
-              e_close_window(f);
-            }
-            /* editing the file */
-            e_edit(cn, filen);
-          }
-          else
-          {
-            /* try to open the file, no success return */
-            if((fp = fopen(filen, "rb")) == NULL)
-            {
-              e_error(e_msg[ERR_ACCFILE], 0, f->fb);
-              c = cold;
-              break;
-            }
-            if(access(filen, W_OK) != 0)
-              f->ins = 8;
-            e_close_window(f);
-            e_switch_window(winnum, fe);
-            fe = cn->f[cn->mxedt];
-            be = fe->b;
-            se = fe->s;
-            f = cn->f[cn->mxedt];
-            if(be->b.x != 0)
-            {
-              e_new_line(be->b.y + 1, be);
-              if(*(be->bf[be->b.y].s + be->bf[be->b.y].len) != '\0')
-                (be->bf[be->b.y].len)++;
-              for(i = be->b.x; i <= be->bf[be->b.y].len; i++)
-                *(be->bf[be->b.y + 1].s + i - be->b.x) = *(be->bf[be->b.y].s + i);
-              *(be->bf[be->b.y].s + be->b.x) = '\0';
-              be->bf[be->b.y].len = be->b.x;
-              be->bf[be->b.y + 1].len = e_str_len(be->bf[be->b.y + 1].s);
-              be->bf[be->b.y + 1].nrc = strlen((const char *)be->bf[be->b.y + 1].s);
-            }
-            se->mark_begin.x = be->b.x;
-            start = se->mark_begin.y = be->b.y;
-            dtmd = fe->dtmd;
-            se->mark_end = e_readin(be->b.x, be->b.y, fp, be, &dtmd);
-            fclose(fp);
+		}
+	      c = cold;
+	      break;
+	    }
+	  else
+	    {
+	      /* if there is only a pattern get back to file selection */
+	      if (strstr (filen, "*") || strstr (filen, "?"))
+		{
+		  c = AltF;
+		  break;
+		}
+	      /* there is no open ??? file */
+	      if (b->sw == 0 || !fe)
+		{
+		  /* close on open request */
+		  if (f->ed->flopt & FM_CLOSE_WINDOW)
+		    {
+		      e_close_window (f);
+		    }
+		  /* editing the file */
+		  e_edit (cn, filen);
+		}
+	      else
+		{
+		  /* try to open the file, no success return */
+		  if ((fp = fopen (filen, "rb")) == NULL)
+		    {
+		      e_error (e_msg[ERR_ACCFILE], 0, f->fb);
+		      c = cold;
+		      break;
+		    }
+		  if (access (filen, W_OK) != 0)
+		    f->ins = 8;
+		  e_close_window (f);
+		  e_switch_window (winnum, fe);
+		  fe = cn->f[cn->mxedt];
+		  be = fe->b;
+		  se = fe->s;
+		  f = cn->f[cn->mxedt];
+		  if (be->b.x != 0)
+		    {
+		      e_new_line (be->b.y + 1, be);
+		      if (*(be->bf[be->b.y].s + be->bf[be->b.y].len) != '\0')
+			(be->bf[be->b.y].len)++;
+		      for (i = be->b.x; i <= be->bf[be->b.y].len; i++)
+			*(be->bf[be->b.y + 1].s + i - be->b.x) =
+			  *(be->bf[be->b.y].s + i);
+		      *(be->bf[be->b.y].s + be->b.x) = '\0';
+		      be->bf[be->b.y].len = be->b.x;
+		      be->bf[be->b.y + 1].len =
+			e_str_len (be->bf[be->b.y + 1].s);
+		      be->bf[be->b.y + 1].nrc =
+			strlen ((const char *) be->bf[be->b.y + 1].s);
+		    }
+		  se->mark_begin.x = be->b.x;
+		  start = se->mark_begin.y = be->b.y;
+		  dtmd = fe->dtmd;
+		  se->mark_end = e_readin (be->b.x, be->b.y, fp, be, &dtmd);
+		  fclose (fp);
 
-            if(se->mark_begin.x > 0)
-              start++;
-            len = se->mark_end.y - start;
-            e_brk_recalc(f, start, len);
+		  if (se->mark_begin.x > 0)
+		    start++;
+		  len = se->mark_end.y - start;
+		  e_brk_recalc (f, start, len);
 
-            e_schirm(fe, 1);
-          }
+		  e_schirm (fe, 1);
+		}
 
-          /* if there was no error */
-          dirtmp = WpeGetCurrentDir(cn);
-          free(cn->dirct);
-          cn->dirct = dirtmp;
+	      /* if there was no error */
+	      dirtmp = WpeGetCurrentDir (cn);
+	      free (cn->dirct);
+	      cn->dirct = dirtmp;
 
-          if (svmode >= 0)
-            cn->flopt = svmode;
+	      if (svmode >= 0)
+		cn->flopt = svmode;
 
-          if (svdir != NULL)
-          {
-            /* go back to the saved directory */
-            if (chdir(svdir))
-            {
-              e_error(e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
+	      if (svdir != NULL)
+		{
+		  /* go back to the saved directory */
+		  if (chdir (svdir))
+		    {
+		      e_error (e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
 
-              /* we cannot determine where we are, try the home */
-              if((dirtmp = getenv("HOME")) == NULL)
-                e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-              if(chdir(dirtmp))
-                e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-            }
+		      /* we cannot determine where we are, try the home */
+		      if ((dirtmp = getenv ("HOME")) == NULL)
+			e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		      if (chdir (dirtmp))
+			e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		    }
 
-            /* determine current dir */
-            dirtmp = WpeGetCurrentDir(cn);
+		  /* determine current dir */
+		  dirtmp = WpeGetCurrentDir (cn);
 
-            free(cn->dirct);
-            cn->dirct = dirtmp;
+		  free (cn->dirct);
+		  cn->dirct = dirtmp;
 
-            free(svdir);
-            svdir = NULL;
-          }
+		  free (svdir);
+		  svdir = NULL;
+		}
 
-          return(0);
-        }
+	      return (0);
+	    }
 
-      case AltW: /* write activation */
-      case AltS: /* save activation */
-        if(   (c == AltW && b->sw != 2) 
-           || (c == AltS && b->sw != 4)
-           || !fe
-           || fe->ins == 8 )
-        {
-          c = cold;
-          break;
-        }
-        /* only file pattern, return */
-        if(strstr(filen, "*") || strstr(filen, "?"))
-        {
-          c = AltF;
-          break;
-        }
-        /* check whether the file exist */
-        if(!access(filen, F_OK))
-        {
-          if((ftmp = malloc(strlen(filen) + 42)) == NULL)
-            e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+	case AltW:		/* write activation */
+	case AltS:		/* save activation */
+	  if ((c == AltW && b->sw != 2)
+	      || (c == AltS && b->sw != 4) || !fe || fe->ins == 8)
+	    {
+	      c = cold;
+	      break;
+	    }
+	  /* only file pattern, return */
+	  if (strstr (filen, "*") || strstr (filen, "?"))
+	    {
+	      c = AltF;
+	      break;
+	    }
+	  /* check whether the file exist */
+	  if (!access (filen, F_OK))
+	    {
+	      if ((ftmp = malloc (strlen (filen) + 42)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
-          sprintf(ftmp, "File %s exist\nDo you want to overwrite it ?", filen);
-          i = e_message(1, ftmp, f);
-          free(ftmp);
+	      sprintf (ftmp, "File %s exist\nDo you want to overwrite it ?",
+		       filen);
+	      i = e_message (1, ftmp, f);
+	      free (ftmp);
 
-          if(i == WPE_ESC)
-          {
-            c = WPE_ESC;
-            break;
-          }
-          else if(i == 'N')
-          {
-            c = AltF;
-            break;
-          }
-        }
-        if(b->sw != 4)
-        {
-          dtp = fe->dirct;
-          ftp = fe->datnam;
-        }
-        else /* save as mode, current dir and window header will/may change */
-        {
-          free(fe->dirct);
-          free(fe->datnam);
-        }
+	      if (i == WPE_ESC)
+		{
+		  c = WPE_ESC;
+		  break;
+		}
+	      else if (i == 'N')
+		{
+		  c = AltF;
+		  break;
+		}
+	    }
+	  if (b->sw != 4)
+	    {
+	      dtp = fe->dirct;
+	      ftp = fe->datnam;
+	    }
+	  else			/* save as mode, current dir and window header will/may change */
+	    {
+	      free (fe->dirct);
+	      free (fe->datnam);
+	    }
 
-        WpeFilenameToPathFile(filen, &fe->dirct, &fe->datnam);
-        if(b->sw == 4) /* save as mode */
-          e_save(fe);
-        else
-        {
-          e_write(se->mark_begin.x, se->mark_begin.y, se->mark_end.x, se->mark_end.y, fe, WPE_BACKUP);
-          free(fe->dirct);  /* restore current dir window header */
-          free(fe->datnam);
-          fe->dirct = dtp;
-          fe->datnam = ftp;
-        }
+	  WpeFilenameToPathFile (filen, &fe->dirct, &fe->datnam);
+	  if (b->sw == 4)	/* save as mode */
+	    e_save (fe);
+	  else
+	    {
+	      e_write (se->mark_begin.x, se->mark_begin.y, se->mark_end.x,
+		       se->mark_end.y, fe, WPE_BACKUP);
+	      free (fe->dirct);	/* restore current dir window header */
+	      free (fe->datnam);
+	      fe->dirct = dtp;
+	      fe->datnam = ftp;
+	    }
 
-        if(b->sw == 4 && (f->ed->edopt & ED_SYNTAX_HIGHLIGHT))
-        {
-          if(fe->c_sw)
-            free(fe->c_sw);
-          if(WpeIsProg())
-            e_add_synt_tl(fe->datnam, fe);
-          if(fe->c_st)
-          {
-            if(fe->c_sw)
-              free(fe->c_sw);
-            fe->c_sw = e_sc_txt(NULL, fe->b);
-          }
-          e_rep_win_tree(f->ed);
-        }
-        if(svmode >= 0)
-          f->ed->flopt = svmode;
+	  if (b->sw == 4 && (f->ed->edopt & ED_SYNTAX_HIGHLIGHT))
+	    {
+	      if (fe->c_sw)
+		free (fe->c_sw);
+	      if (WpeIsProg ())
+		e_add_synt_tl (fe->datnam, fe);
+	      if (fe->c_st)
+		{
+		  if (fe->c_sw)
+		    free (fe->c_sw);
+		  fe->c_sw = e_sc_txt (NULL, fe->b);
+		}
+	      e_rep_win_tree (f->ed);
+	    }
+	  if (svmode >= 0)
+	    f->ed->flopt = svmode;
 
-        if(svdir != NULL)
-        {
-          /* go back to the saved directory */
-          if(chdir(svdir))
-          {
-            e_error(e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
+	  if (svdir != NULL)
+	    {
+	      /* go back to the saved directory */
+	      if (chdir (svdir))
+		{
+		  e_error (e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
 
-            /* we cannot determine where we are, try the home */
-            if((dirtmp = getenv("HOME")) == NULL)
-              e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-            if(chdir(dirtmp))
-              e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-          }
+		  /* we cannot determine where we are, try the home */
+		  if ((dirtmp = getenv ("HOME")) == NULL)
+		    e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		  if (chdir (dirtmp))
+		    e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		}
 
-          /* determine current dir */
-          dirtmp = WpeGetCurrentDir(cn);
+	      /* determine current dir */
+	      dirtmp = WpeGetCurrentDir (cn);
 
-          free(cn->dirct);
-          cn->dirct = dirtmp;
+	      free (cn->dirct);
+	      cn->dirct = dirtmp;
 
-          free(svdir);
-          svdir = NULL;
-        }
+	      free (svdir);
+	      svdir = NULL;
+	    }
 
-        e_close_window(f);
-        return(0);
+	  e_close_window (f);
+	  return (0);
 
-      /* make dir button activation */
-      case EINFG:
-      case AltK:
-        if(b->sw != 0)
-        {
-          c = cold;
-          break;
-        }
-        /* create new directory */
-        if(WpeMakeNewDir(f) != 0)
-        {
-          c = cold;
-          break;
-        }
+	  /* make dir button activation */
+	case EINFG:
+	case AltK:
+	  if (b->sw != 0)
+	    {
+	      c = cold;
+	      break;
+	    }
+	  /* create new directory */
+	  if (WpeMakeNewDir (f) != 0)
+	    {
+	      c = cold;
+	      break;
+	    }
 
-        /* free up old structures */
-        freedf(b->dd);
-        freedf(b->dw->df);
+	  /* free up old structures */
+	  freedf (b->dd);
+	  freedf (b->dw->df);
 
-        /* create new directory structure */
-        b->dd = e_find_dir(SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-        b->dw->df = WpeGraphicalDirTree(b->cd, b->dd, cn);
-        /* go to the line where the new dir is */
-        for(i = 0; i < b->dd->anz && strcmp(b->dd->name[i], "new.dir"); i++)
-          ;
-        /* set the slidebar variables */
-        if((b->dw->nf = b->cd->anz + i) >= b->dw->df->anz)
-          b->dw->nf = b->cd->anz - 1;
-        if(b->dw->nf - b->dw->ia >= b->dw->ye - b->dw->ya)
-          b->dw->ia = b->dw->nf + b->dw->ya - b->dw->ye + 1;
-        else if(b->dw->nf - b->dw->ia < 0)
-          b->dw->ia = b->dw->nf;
-        cold = AltT;
-        /* let the user modify the newly created dir */
-        c = AltM;
-        break;
+	  /* create new directory structure */
+	  b->dd =
+	    e_find_dir (SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+	  b->dw->df = WpeGraphicalDirTree (b->cd, b->dd, cn);
+	  /* go to the line where the new dir is */
+	  for (i = 0; i < b->dd->anz && strcmp (b->dd->name[i], "new.dir");
+	       i++)
+	    ;
+	  /* set the slidebar variables */
+	  if ((b->dw->nf = b->cd->anz + i) >= b->dw->df->anz)
+	    b->dw->nf = b->cd->anz - 1;
+	  if (b->dw->nf - b->dw->ia >= b->dw->ye - b->dw->ya)
+	    b->dw->ia = b->dw->nf + b->dw->ya - b->dw->ye + 1;
+	  else if (b->dw->nf - b->dw->ia < 0)
+	    b->dw->ia = b->dw->nf;
+	  cold = AltT;
+	  /* let the user modify the newly created dir */
+	  c = AltM;
+	  break;
 
-      /* attribute/add file button activation */
-      case AltA:
-        /* not valid mode */
-        if(b->sw != 0 && b->sw != 5)
-        {
-          c = cold;
-          break;
-        }
-        /* attribute button */
-        if(b->sw == 0)
-        {
-          if(cold == AltF) /* coming from file list */
-          {
-            strcpy(filen, *(b->df->name + b->fw->nf));  /* alloc for filen ??? */
-            /* change the file attributes */
-            WpeFileDirAttributes(filen, f);
+	  /* attribute/add file button activation */
+	case AltA:
+	  /* not valid mode */
+	  if (b->sw != 0 && b->sw != 5)
+	    {
+	      c = cold;
+	      break;
+	    }
+	  /* attribute button */
+	  if (b->sw == 0)
+	    {
+	      if (cold == AltF)	/* coming from file list */
+		{
+		  strcpy (filen, *(b->df->name + b->fw->nf));	/* alloc for filen ??? */
+		  /* change the file attributes */
+		  WpeFileDirAttributes (filen, f);
 
-            /* free up old file list structures */
-            freedf(b->df);
-            freedf(b->fw->df);
+		  /* free up old file list structures */
+		  freedf (b->df);
+		  freedf (b->fw->df);
 
-            /* create new file list */
-            b->df = e_find_files(b->rdfile, fmode);
-            /* setup drawing */
-            b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
-          }
-          else if(cold == AltT && b->dw->nf >= b->cd->anz) /* coming from dir tree */
-          {
-            t = b->dw->nf - b->cd->anz;
+		  /* create new file list */
+		  b->df = e_find_files (b->rdfile, fmode);
+		  /* setup drawing */
+		  b->fw->df =
+		    WpeGraphicalFileList (b->df, f->ed->flopt >> 9, cn);
+		}
+	      else if (cold == AltT && b->dw->nf >= b->cd->anz)	/* coming from dir tree */
+		{
+		  t = b->dw->nf - b->cd->anz;
 
-            if((ftmp = malloc(strlen(*(b->dd->name + t)) + 1)) == NULL)
-              e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+		  if ((ftmp =
+		       malloc (strlen (*(b->dd->name + t)) + 1)) == NULL)
+		    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
-            strcpy(ftmp, *(b->dd->name + t));
-            /* change the dir attributes */
-            WpeFileDirAttributes(ftmp, f);
+		  strcpy (ftmp, *(b->dd->name + t));
+		  /* change the dir attributes */
+		  WpeFileDirAttributes (ftmp, f);
 
-            free(ftmp);
+		  free (ftmp);
 
-            /* free up old file list structures */
-            freedf(b->dd);
-            freedf(b->dw->df);
-            /* create new dir list */
-            b->dd = e_find_dir(SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-            /* setup drawing */
-            b->dw->df = WpeGraphicalDirTree(b->cd, b->dd, cn);
-          }
-          c = cold;
-        }
-        else if(b->sw == 5) /* it is in project management */
-        {
-          FLWND *fw = (FLWND *)cn->f[cn->mxedt - 1]->b;
-          if (cold != AltN)
-            strcpy(filen, *(b->df->name + b->fw->nf));
-          dirtmp = cn->f[cn->mxedt - 1]->dirct;
-          ftmp = malloc(strlen(f->dirct) + strlen(filen) + 2);
-          len = strlen(dirtmp);
-          if (strncmp(dirtmp, f->dirct, len) == 0)
-          {
-           /* Make path relative to project directory */
-           sprintf(ftmp, "%s%s", f->dirct + len, filen);
-          }
-          else
-          {
-           /* Full path */
-           sprintf(ftmp, "%s%s", f->dirct, filen);
-          }
-          fw->df->anz++;
-          fw->df->name = realloc(fw->df->name, fw->df->anz * sizeof(char *));
-          for(i = fw->df->anz - 1; i > fw->nf; i--)
-            fw->df->name[i] = fw->df->name[i - 1];
-          fw->df->name[i] = ftmp;
+		  /* free up old file list structures */
+		  freedf (b->dd);
+		  freedf (b->dw->df);
+		  /* create new dir list */
+		  b->dd =
+		    e_find_dir (SUDIR,
+				f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+		  /* setup drawing */
+		  b->dw->df = WpeGraphicalDirTree (b->cd, b->dd, cn);
+		}
+	      c = cold;
+	    }
+	  else if (b->sw == 5)	/* it is in project management */
+	    {
+	      FLWND *fw = (FLWND *) cn->f[cn->mxedt - 1]->b;
+	      if (cold != AltN)
+		strcpy (filen, *(b->df->name + b->fw->nf));
+	      dirtmp = cn->f[cn->mxedt - 1]->dirct;
+	      ftmp = malloc (strlen (f->dirct) + strlen (filen) + 2);
+	      len = strlen (dirtmp);
+	      if (strncmp (dirtmp, f->dirct, len) == 0)
+		{
+		  /* Make path relative to project directory */
+		  sprintf (ftmp, "%s%s", f->dirct + len, filen);
+		}
+	      else
+		{
+		  /* Full path */
+		  sprintf (ftmp, "%s%s", f->dirct, filen);
+		}
+	      fw->df->anz++;
+	      fw->df->name =
+		realloc (fw->df->name, fw->df->anz * sizeof (char *));
+	      for (i = fw->df->anz - 1; i > fw->nf; i--)
+		fw->df->name[i] = fw->df->name[i - 1];
+	      fw->df->name[i] = ftmp;
 /* Don't bother notifying the user for each file added to project
    sprintf(ftmp, "File added to Project:\n%s",
    fw->df->name[i]);
    e_message(0, ftmp, f); */
-          fw->nf++;
-          if(fw->nf - fw->ia >= fw->ye - fw->ya)
-            fw->ia = fw->nf + fw->ya - fw->ye + 1;
-          c = AltN;
-        }
-        break;
+	      fw->nf++;
+	      if (fw->nf - fw->ia >= fw->ye - fw->ya)
+		fw->ia = fw->nf + fw->ya - fw->ye + 1;
+	      c = AltN;
+	    }
+	  break;
 
-      /* like save */
-      case F2:
-        c = AltS;
-        break;
-      /* leave file manager */
-      case AltBl:
-        c = WPE_ESC;
+	  /* like save */
+	case F2:
+	  c = AltS;
+	  break;
+	  /* leave file manager */
+	case AltBl:
+	  c = WPE_ESC;
 
-      default:
-        /* not project management */
-        if(b->sw != 5)
-        {
-          if(svmode >= 0)
-          {
-            /* restore options */
-            f->ed->flopt = svmode;
-          }
+	default:
+	  /* not project management */
+	  if (b->sw != 5)
+	    {
+	      if (svmode >= 0)
+		{
+		  /* restore options */
+		  f->ed->flopt = svmode;
+		}
 
-          if(svdir != NULL)
-          {
-            /* go back to the saved directory */
-            if(chdir(svdir))
-            {
-              e_error(e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
+	      if (svdir != NULL)
+		{
+		  /* go back to the saved directory */
+		  if (chdir (svdir))
+		    {
+		      e_error (e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
 
-              /* we cannot determine where we are, try the home */
-              if((dirtmp = getenv("HOME")) == NULL)
-                e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-              if(chdir(dirtmp))
-                e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-            }
+		      /* we cannot determine where we are, try the home */
+		      if ((dirtmp = getenv ("HOME")) == NULL)
+			e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		      if (chdir (dirtmp))
+			e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		    }
 
-            /* determine current dir */
-            dirtmp = WpeGetCurrentDir(f->ed);
-            free(f->ed->dirct);
-            f->ed->dirct = dirtmp;
-          }
+		  /* determine current dir */
+		  dirtmp = WpeGetCurrentDir (f->ed);
+		  free (f->ed->dirct);
+		  f->ed->dirct = dirtmp;
+		}
 
 
-          /* the key dispatcher returns zero when something has happened
-             and this means that the file-manager lost focus, just return */
+	      /* the key dispatcher returns zero when something has happened
+	         and this means that the file-manager lost focus, just return */
 #ifdef PROG
-          if(!e_tst_dfkt(f, c) || (WpeIsProg() && !e_prog_switch(f, c)))
+	      if (!e_tst_dfkt (f, c)
+		  || (WpeIsProg () && !e_prog_switch (f, c)))
 #else
-          if(!e_tst_dfkt(f, c))
+	      if (!e_tst_dfkt (f, c))
 #endif
-          {
-            if(svdir != NULL)
-            {
-              free(svdir);
-              svdir = NULL;
-            }
+		{
+		  if (svdir != NULL)
+		    {
+		      free (svdir);
+		      svdir = NULL;
+		    }
 
-            return(0);
-          }
-          /* file manager is still active */
-          if(svmode >= 0)
-            f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
-              FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
-        }
-        else if(   c == WPE_ESC
-                || (!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
-                || (f->ed->edopt & ED_CUA_STYLE && c == CF4))
-        {
-          if(svdir != NULL)
-          {
-            /* go back to the saved directory */
-            if(chdir(svdir))
-            {
-              e_error(e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
+		  return (0);
+		}
+	      /* file manager is still active */
+	      if (svmode >= 0)
+		f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
+		  FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
+	    }
+	  else if (c == WPE_ESC
+		   || (!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
+		   || (f->ed->edopt & ED_CUA_STYLE && c == CF4))
+	    {
+	      if (svdir != NULL)
+		{
+		  /* go back to the saved directory */
+		  if (chdir (svdir))
+		    {
+		      e_error (e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
 
-              /* we cannot determine where we are, try the home */
-              if((dirtmp = getenv("HOME")) == NULL)
-                e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-              if(chdir(dirtmp))
-                e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-            }
+		      /* we cannot determine where we are, try the home */
+		      if ((dirtmp = getenv ("HOME")) == NULL)
+			e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		      if (chdir (dirtmp))
+			e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		    }
 
-            /* determine current dir */
-            dirtmp = WpeGetCurrentDir(cn);
+		  /* determine current dir */
+		  dirtmp = WpeGetCurrentDir (cn);
 
-            free(cn->dirct);
-            cn->dirct = dirtmp;
+		  free (cn->dirct);
+		  cn->dirct = dirtmp;
 
-            free(svdir);
-            svdir = NULL;
-          }
+		  free (svdir);
+		  svdir = NULL;
+		}
 
-          /* close file manager */
-          e_close_window(f);
+	      /* close file manager */
+	      e_close_window (f);
 
-          /* restore options */
-          if(svmode >= 0)
-            cn->flopt = svmode;
+	      /* restore options */
+	      if (svmode >= 0)
+		cn->flopt = svmode;
 
-          return(WPE_ESC);
-        }
-        c = cold;
-        break;
+	      return (WPE_ESC);
+	    }
+	  c = cold;
+	  break;
+	}
     }
-  }
 
   /* change to saved directory and lets hope it works */
-  if(svdir != NULL)
-  {
-    /* go back to the saved directory */
-    if(chdir(svdir))
+  if (svdir != NULL)
     {
-      e_error(e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
+      /* go back to the saved directory */
+      if (chdir (svdir))
+	{
+	  e_error (e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
 
-      /* we cannot determine where we are, try the home */
-      if((dirtmp = getenv("HOME")) == NULL)
-        e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-      if(chdir(dirtmp))
-        e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+	  /* we cannot determine where we are, try the home */
+	  if ((dirtmp = getenv ("HOME")) == NULL)
+	    e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+	  if (chdir (dirtmp))
+	    e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+	}
+
+      /* determine current dir */
+      dirtmp = WpeGetCurrentDir (cn);
+
+      free (cn->dirct);
+      cn->dirct = dirtmp;
+
+      free (svdir);
+      svdir = NULL;
     }
 
-    /* determine current dir */
-    dirtmp = WpeGetCurrentDir(cn);
-
-    free(cn->dirct);
-    cn->dirct = dirtmp;
-
-    free(svdir);
-    svdir = NULL;
-  }
-
   /* restore options */
-  if(svmode >= 0)
+  if (svmode >= 0)
     cn->flopt = svmode;
 
   /* if in save mode or project management */
-  if(f->save == 1 || b->sw == 5)
-  {
-    e_close_window(f);
-    return(WPE_ESC);
-  }
+  if (f->save == 1 || b->sw == 5)
+    {
+      e_close_window (f);
+      return (WPE_ESC);
+    }
   else
-  {
-    e_close_window(f);
-    return(0);
-  }
+    {
+      e_close_window (f);
+      return (0);
+    }
 }
 
 
-int WpeGrepFile(char *file, char *string, int sw)
+int
+WpeGrepFile (char *file, char *string, int sw)
 {
-  FILE           *fp;
-  char            str[256];
-  int             ret, nn;
+  FILE *fp;
+  char str[256];
+  int ret, nn;
 
-  if((fp = fopen(file, "r")) == NULL)
-    return(0);
+  if ((fp = fopen (file, "r")) == NULL)
+    return (0);
 
-  nn = strlen(string);
-  while(fgets(str, 256, fp))
-  {
-    if((sw & 32) == 0)
+  nn = strlen (string);
+  while (fgets (str, 256, fp))
     {
-      if((sw & 128) != 0)
-        ret = e_strstr(0, strlen(str), (unsigned char *)str, (unsigned char *)string);
+      if ((sw & 32) == 0)
+	{
+	  if ((sw & 128) != 0)
+	    ret =
+	      e_strstr (0, strlen (str), (unsigned char *) str,
+			(unsigned char *) string);
+	  else
+	    ret =
+	      e_ustrstr (0, strlen (str), (unsigned char *) str,
+			 (unsigned char *) string);
+	}
       else
-        ret = e_ustrstr(0, strlen(str), (unsigned char *)str, (unsigned char *)string);
+	{
+	  if ((sw & 128) != 0)
+	    ret =
+	      e_rstrstr (0, strlen (str), (unsigned char *) str,
+			 (unsigned char *) string, &nn);
+	  else
+	    ret =
+	      e_urstrstr (0, strlen (str), (unsigned char *) str,
+			  (unsigned char *) string, &nn);
+	}
+      if (ret >= 0
+	  && (!(sw & 64)
+	      || (isalnum (str[ret + nn]) == 0
+		  && (ret == 0 || isalnum (str[ret - 1]) == 0))))
+	{
+	  fclose (fp);
+	  return (1);
+	}
     }
-    else
-    {
-      if((sw & 128) != 0)
-        ret = e_rstrstr(0, strlen(str), (unsigned char *)str, (unsigned char *)string, &nn);
-      else
-        ret = e_urstrstr(0, strlen(str), (unsigned char *)str, (unsigned char *)string, &nn);
-    }
-    if(   ret >= 0 
-       && (   !(sw & 64) 
-           || (   isalnum(str[ret + nn]) == 0
-               && (ret == 0 || isalnum(str[ret - 1]) == 0))))
-    {
-      fclose(fp);
-      return(1);
-    }
-  }
-  fclose(fp);
-  return(0);
+  fclose (fp);
+  return (0);
 }
 
-int WpeMakeNewDir(FENSTER *f)
+int
+WpeMakeNewDir (FENSTER * f)
 {
-  char           *dirct;
-  int             msk, mode, ret;
-  struct stat     buf;
+  char *dirct;
+  int msk, mode, ret;
+  struct stat buf;
 
-  umask(msk = umask(077));
+  umask (msk = umask (077));
   mode = 0777 & ~msk;
 
-  if((dirct = malloc(strlen(f->dirct) + 9)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  if ((dirct = malloc (strlen (f->dirct) + 9)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-  if(f->dirct[strlen(f->dirct) - 1] != DIRC)
-    sprintf(dirct, "%s/new.dir", f->dirct);
+  if (f->dirct[strlen (f->dirct) - 1] != DIRC)
+    sprintf (dirct, "%s/new.dir", f->dirct);
   else
-    sprintf(dirct, "%snew.dir", f->dirct);
+    sprintf (dirct, "%snew.dir", f->dirct);
 
   /* check existence and status (whether it is directory) */
-  if(stat(dirct, &buf))
-  {
-    if((ret = mkdir(dirct, mode)) != 0)
-      e_error(e_msg[ERR_NONEWDIR], 0, f->ed->fb);
-  }
-  else
-  {
-    /* check whether the existing file is a directory */
-    if(!(buf.st_mode & S_IFDIR))
+  if (stat (dirct, &buf))
     {
-      e_error(e_msg[ERR_NEWDIREXIST], 0, f->ed->fb);
-      ret = 1;
+      if ((ret = mkdir (dirct, mode)) != 0)
+	e_error (e_msg[ERR_NONEWDIR], 0, f->ed->fb);
     }
-    else
-      ret = 0;
-  }
+  else
+    {
+      /* check whether the existing file is a directory */
+      if (!(buf.st_mode & S_IFDIR))
+	{
+	  e_error (e_msg[ERR_NEWDIREXIST], 0, f->ed->fb);
+	  ret = 1;
+	}
+      else
+	ret = 0;
+    }
 
-  free(dirct);
-  return(ret);
+  free (dirct);
+  return (ret);
 }
 
-int WpeFileDirAttributes(char *filen, FENSTER * f)
+int
+WpeFileDirAttributes (char *filen, FENSTER * f)
 {
-  struct stat     buf[1];
-  int             mode, ret;
-  W_OPTSTR       *o = e_init_opt_kst(f);
+  struct stat buf[1];
+  int mode, ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
 
   /* if cannot access or error */
-  if(stat(filen, buf))
-  {
-    e_error(e_msg[ERR_ACCFILE], 0, f->ed->fb);
-    return 1;
-  }
+  if (stat (filen, buf))
+    {
+      e_error (e_msg[ERR_ACCFILE], 0, f->ed->fb);
+      return 1;
+    }
   mode = buf->st_mode;
-  if(o == NULL)
-    return(1);
+  if (o == NULL)
+    return (1);
   o->xa = 14;
   o->ya = 4;
   o->xe = 62;
@@ -1643,37 +1702,36 @@ int WpeFileDirAttributes(char *filen, FENSTER * f)
   o->bgsw = AltO;
   o->name = "Attributes";
   o->crsw = AltO;
-  e_add_txtstr(3, 2, "User:", o);
-  e_add_txtstr(33, 2, "Other:", o);
-  e_add_txtstr(18, 2, "Group:", o);
-  e_add_sswstr(4, 3, 0, AltR, mode & 256 ? 1 : 0, "Read   ", o);
-  e_add_sswstr(4, 4, 0, AltW, mode & 128 ? 1 : 0, "Write  ", o);
-  e_add_sswstr(4, 5, 1, AltX, mode & 64 ? 1 : 0, "EXecute", o);
-  e_add_sswstr(19, 3, 2, AltA, mode & 32 ? 1 : 0, "ReAd   ", o);
-  e_add_sswstr(19, 4, 2, AltI, mode & 16 ? 1 : 0, "WrIte  ", o);
-  e_add_sswstr(19, 5, 0, AltE, mode & 8 ? 1 : 0, "Execute", o);
-  e_add_sswstr(34, 3, 3, AltD, mode & 4 ? 1 : 0, "ReaD   ", o);
-  e_add_sswstr(34, 4, 3, AltT, mode & 2 ? 1 : 0, "WriTe  ", o);
-  e_add_sswstr(34, 5, 4, AltU, mode & 1, "ExecUte", o);
-  e_add_bttstr(12, 7, 1, AltO, " Ok ", NULL, o);
-  e_add_bttstr(29, 7, -1, WPE_ESC, "Cancel", NULL, o);
-  ret = e_opt_kst(o);
-  if(ret != WPE_ESC)
-  {
-    mode = (o->sstr[0]->num << 8) + (o->sstr[1]->num << 7) +
-      (o->sstr[2]->num << 6) + (o->sstr[3]->num << 5) +
-      (o->sstr[4]->num << 4) + (o->sstr[5]->num << 3) +
-      (o->sstr[6]->num << 2) + (o->sstr[7]->num << 1) +
-      o->sstr[8]->num;
-    if(chmod(filen, mode))
+  e_add_txtstr (3, 2, "User:", o);
+  e_add_txtstr (33, 2, "Other:", o);
+  e_add_txtstr (18, 2, "Group:", o);
+  e_add_sswstr (4, 3, 0, AltR, mode & 256 ? 1 : 0, "Read   ", o);
+  e_add_sswstr (4, 4, 0, AltW, mode & 128 ? 1 : 0, "Write  ", o);
+  e_add_sswstr (4, 5, 1, AltX, mode & 64 ? 1 : 0, "EXecute", o);
+  e_add_sswstr (19, 3, 2, AltA, mode & 32 ? 1 : 0, "ReAd   ", o);
+  e_add_sswstr (19, 4, 2, AltI, mode & 16 ? 1 : 0, "WrIte  ", o);
+  e_add_sswstr (19, 5, 0, AltE, mode & 8 ? 1 : 0, "Execute", o);
+  e_add_sswstr (34, 3, 3, AltD, mode & 4 ? 1 : 0, "ReaD   ", o);
+  e_add_sswstr (34, 4, 3, AltT, mode & 2 ? 1 : 0, "WriTe  ", o);
+  e_add_sswstr (34, 5, 4, AltU, mode & 1, "ExecUte", o);
+  e_add_bttstr (12, 7, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (29, 7, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
     {
-      e_error(e_msg[ERR_CHGPERM], 0, f->ed->fb);
-      freeostr(o);
-      return(1);
+      mode = (o->sstr[0]->num << 8) + (o->sstr[1]->num << 7) +
+	(o->sstr[2]->num << 6) + (o->sstr[3]->num << 5) +
+	(o->sstr[4]->num << 4) + (o->sstr[5]->num << 3) +
+	(o->sstr[6]->num << 2) + (o->sstr[7]->num << 1) + o->sstr[8]->num;
+      if (chmod (filen, mode))
+	{
+	  e_error (e_msg[ERR_CHGPERM], 0, f->ed->fb);
+	  freeostr (o);
+	  return (1);
+	}
     }
-  }
-  freeostr(o);
-  return(0);
+  freeostr (o);
+  return (0);
 }
 
 /* determines the current working directory,
@@ -1682,7 +1740,8 @@ int WpeFileDirAttributes(char *filen, FENSTER * f)
                          if it is impossible, give it up and exit with "system error"
                        - otherwise exit with "system error"
  */
-char *WpeGetCurrentDir(ECNT *cn)
+char *
+WpeGetCurrentDir (ECNT * cn)
 {
   int allocate_size;
   char *current_dir = NULL, *check_dir, *dirtmp;
@@ -1690,238 +1749,243 @@ char *WpeGetCurrentDir(ECNT *cn)
 
   home = 0;
   allocate_size = 256;
-  if ((current_dir = (char *)malloc(allocate_size + 1)) == NULL)
-  {
-   e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-   return NULL;
-  }
+  if ((current_dir = (char *) malloc (allocate_size + 1)) == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+      return NULL;
+    }
 
   do
-  {
-    /* allocate space for the directory name */
-    if ((current_dir = (char *)realloc(current_dir, allocate_size + 1)) == NULL)
     {
-     e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-     return NULL;
+      /* allocate space for the directory name */
+      if ((current_dir =
+	   (char *) realloc (current_dir, allocate_size + 1)) == NULL)
+	{
+	  e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	  return NULL;
+	}
+
+      check_dir = getcwd (current_dir, allocate_size);
+      if (check_dir == NULL)
+	{
+	  switch (errno)
+	    {
+	    case EACCES:	/* directory cannot be read */
+	      if (home == 0)
+		{
+		  e_error (e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
+
+		  /* we cannot determine where we are, try the home */
+		  if ((dirtmp = getenv ("HOME")) == NULL)
+		    e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+		  if (chdir (dirtmp))
+		    e_error (e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
+
+		  home = 1;
+		}
+	      else
+		e_error (e_msg[ERR_SYSTEM], 1, cn->fb);	/* will not return */
+	      break;
+	    case EINVAL:	/* size is equal to 0 */
+	      allocate_size = 256;	/* impossible !!! */
+	      break;
+	    case ERANGE:	/* not enough space for the pathname */
+	      allocate_size <<= 1;
+	      break;
+	    default:		/* System error */
+	      e_error (e_msg[ERR_SYSTEM], 1, cn->fb);	/* will not return */
+	      break;
+	    }
+	}
     }
+  while (check_dir == NULL);
 
-    check_dir = getcwd(current_dir, allocate_size);
-    if(check_dir == NULL)
-    {
-      switch(errno)
-      {
-        case EACCES:  /* directory cannot be read */
-          if (home == 0)
-          {
-            e_error(e_msg[ERR_WORKDIRACCESS], 0, cn->fb);
-
-            /* we cannot determine where we are, try the home */
-            if ((dirtmp = getenv("HOME")) == NULL)
-              e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-            if (chdir(dirtmp))
-              e_error(e_msg[ERR_HOMEDIRACCESS], 1, cn->fb);
-
-            home = 1;
-          }
-          else
-            e_error(e_msg[ERR_SYSTEM], 1, cn->fb); /* will not return */
-          break;
-        case EINVAL:  /* size is equal to 0 */
-          allocate_size = 256; /* impossible !!! */
-          break;
-        case ERANGE:  /* not enough space for the pathname */
-          allocate_size <<= 1;
-          break;
-        default:      /* System error */
-          e_error(e_msg[ERR_SYSTEM], 1, cn->fb); /* will not return */
-          break;
-      }
-    }
-  } while (check_dir == NULL);
-
-  if (current_dir[strlen(current_dir) - 1] != DIRC)
-   strcat(current_dir, DIRS);
-  return(current_dir);
+  if (current_dir[strlen (current_dir) - 1] != DIRC)
+    strcat (current_dir, DIRS);
+  return (current_dir);
 }
 
 /* It always returns the assembled file path, except
    when it is in wastebasket mode and there is an error, return NULL */
-char *WpeAssemblePath(char *pth, struct dirfile *cd, struct dirfile *dd, int n, 
-                      FENSTER *f)
+char *
+WpeAssemblePath (char *pth, struct dirfile *cd, struct dirfile *dd, int n,
+		 FENSTER * f)
 {
-  int             i = 0, k = 0, j = 0, t;
-  char           *adir= NULL;  /* assembled directory */
-  int             totall = 0;
+  int i = 0, k = 0, j = 0, t;
+  char *adir = NULL;		/* assembled directory */
+  int totall = 0;
 
-  UNUSED(pth);
+  UNUSED (pth);
 
 #ifdef UNIX
-  if (!strcmp(cd->name[0], "Wastebasket"))
-  {
-    if ((adir = WpeGetWastefile("")))
+  if (!strcmp (cd->name[0], "Wastebasket"))
     {
-      totall = strlen(adir) + 16;
-      if ((adir = realloc(adir, totall)) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, f->fb);
+      if ((adir = WpeGetWastefile ("")))
+	{
+	  totall = strlen (adir) + 16;
+	  if ((adir = realloc (adir, totall)) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
 
-      strcat(adir, DIRS);
-      i = strlen(adir);
-      k++;
+	  strcat (adir, DIRS);
+	  i = strlen (adir);
+	  k++;
+	}
+      else
+	{
+	  /* Error failed to find wastebasket */
+	  e_error (e_msg[ERR_NOWASTE], 0, f->ed->fb);
+	  return NULL;
+	}
     }
-    else
-    {
-      /* Error failed to find wastebasket */
-      e_error(e_msg[ERR_NOWASTE], 0, f->ed->fb);
-      return NULL;
-    }
-  }
 #endif
-  for(; k <= n && k < cd->anz; i++, j++)
-  {
-    if(i >= totall-1)
+  for (; k <= n && k < cd->anz; i++, j++)
     {
-      totall += 16;
-      if((adir = realloc(adir, totall)) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-    }
-    *(adir + i) = *(*(cd->name + k) + j);
+      if (i >= totall - 1)
+	{
+	  totall += 16;
+	  if ((adir = realloc (adir, totall)) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+	}
+      *(adir + i) = *(*(cd->name + k) + j);
 
-    if(*(adir + i) == '\0' || *(adir + i) == DIRC)
-    {
-      *(adir + i) = DIRC;
-      k++;
-      j = -1;
+      if (*(adir + i) == '\0' || *(adir + i) == DIRC)
+	{
+	  *(adir + i) = DIRC;
+	  k++;
+	  j = -1;
+	}
     }
-  }
-  if(n >= k)
-  {
-    t = n - cd->anz;
-    j = 0;
+  if (n >= k)
+    {
+      t = n - cd->anz;
+      j = 0;
 
-    do
-    {
-      if(i >= totall-2)
-      {
-        totall += 16;
-        if((adir = realloc(adir, totall)) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-      }
-      *(adir + i) = *(*(dd->name + t) + j);
-      i++;
-      j++;
-    }
-    while(*(adir + i - 1) != '\0');
+      do
+	{
+	  if (i >= totall - 2)
+	    {
+	      totall += 16;
+	      if ((adir = realloc (adir, totall)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+	    }
+	  *(adir + i) = *(*(dd->name + t) + j);
+	  i++;
+	  j++;
+	}
+      while (*(adir + i - 1) != '\0');
 
 /*
     for(j = 0; (*(pth + i) = *(*(dd->name + t) + j)) != '\0'; i++, j++)
       ;
 */
 
-  }
-  if(n == 0 || n >= k)
+    }
+  if (n == 0 || n >= k)
     i++;
   *(adir + i - 1) = '\0';
-  return(adir);
+  return (adir);
 }
 
 
 /* create tree structure up to working directory */
-struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
+struct dirfile *
+WpeCreateWorkingDirTree (int sw, ECNT * cn)
 {
   struct dirfile *df;
-  char           *buf;
-  char           *tmp, *tmp2;
-  char          **dftmp;
-  int             buflen = 256;
-  int             maxd = 10;    /* inital number of directory levels */
-  int             i, j, k;
+  char *buf;
+  char *tmp, *tmp2;
+  char **dftmp;
+  int buflen = 256;
+  int maxd = 10;		/* inital number of directory levels */
+  int i, j, k;
 
-  buf = WpeGetCurrentDir(cn);
+  buf = WpeGetCurrentDir (cn);
 
-  buflen = strlen(buf);
-  if((tmp = malloc(buflen+1)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  buflen = strlen (buf);
+  if ((tmp = malloc (buflen + 1)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* initialise directory list */
-  if(   ((df = malloc(sizeof(struct dirfile))) == NULL)
-     || ((df->name = malloc(sizeof(char *) * maxd)) == NULL) )
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if (((df = malloc (sizeof (struct dirfile))) == NULL)
+      || ((df->name = malloc (sizeof (char *) * maxd)) == NULL))
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
   df->anz = 0;
 
-  if(sw == 1)                        /* file-manager open to wastebasket */
-  {
-    /* instead of saving the real wastebasket dir into the structure
-       the "Wastebasket" name will appear */
-    if((tmp2 = WpeGetWastefile("")) == NULL)
+  if (sw == 1)			/* file-manager open to wastebasket */
     {
-      e_error(e_msg[ERR_NOWASTE], 0, cn->fb);    /* more error check ??? */
+      /* instead of saving the real wastebasket dir into the structure
+         the "Wastebasket" name will appear */
+      if ((tmp2 = WpeGetWastefile ("")) == NULL)
+	{
+	  e_error (e_msg[ERR_NOWASTE], 0, cn->fb);	/* more error check ??? */
+	  i = 0;
+	}
+      else
+	{
+	  i = strlen (tmp2);
+	  /* increase the level in the dir tree */
+	  df->anz = 1;
+	  /* save the name into first level */
+	  if ((*(df->name) = malloc (12 * sizeof (char))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	  strcpy (*(df->name), "Wastebasket");
+
+	  if (!strncmp (tmp2, buf, i) && buf[i])
+	    {
+	      free (tmp2);
+	      i++;
+	    }
+	  else
+	    {
+	      free (tmp2);
+	      free (buf);
+	      free (tmp);
+	      return (df);
+	    }
+	}
+    }
+  else
+    {
       i = 0;
     }
-    else
+
+
+  for (j = 0; i <= buflen; i++, j++)
     {
-      i = strlen(tmp2);
-      /* increase the level in the dir tree */
-      df->anz = 1;
-      /* save the name into first level */
-      if((*(df->name) = malloc(12 * sizeof(char))) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-      strcpy(*(df->name), "Wastebasket");
+      tmp[j] = buf[i];
+      /* if directory separator or end of string */
+      if (tmp[j] == DIRC || tmp[j] == '\0')
+	{
+	  if (buf[i] == '\0' && j == 0)
+	    return (df);
+	  if (df->anz == 0)	/* for the very first time save the '/' sign */
+	    j++;
+	  tmp[j] = '\0';
 
-      if(!strncmp(tmp2, buf, i) && buf[i])
-      {
-        free(tmp2);
-        i++;
-      }
-      else
-      {
-        free(tmp2);
-        free(buf);
-        free(tmp);
-        return(df);
-      }
+	  /* if we need more space for the directories */
+	  if (df->anz >= maxd)
+	    {
+	      maxd += 10;
+	      dftmp = df->name;
+	      if ((df->name = malloc (sizeof (char *) * maxd)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	      for (k = 0; k < maxd - 10; k++)
+		*(df->name + k) = *(dftmp + k);
+	      free (dftmp);
+	    }
+	  /* save the current directory */
+	  if ((*(df->name + df->anz) =
+	       malloc ((strlen (tmp) + 1) * sizeof (char))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	  strcpy (*(df->name + df->anz), tmp);
+	  df->anz++;
+	  j = -1;
+	}
     }
-  }
-  else
-  {
-    i = 0;
-  }
-
-
-  for(j = 0; i <= buflen; i++, j++)
-  {
-    tmp[j] = buf[i];
-    /* if directory separator or end of string */
-    if(tmp[j] == DIRC || tmp[j] == '\0')
-    {
-      if(buf[i] == '\0' && j == 0)
-        return(df);
-      if(df->anz == 0)  /* for the very first time save the '/' sign */
-        j++;
-      tmp[j] = '\0';
-
-      /* if we need more space for the directories */
-      if(df->anz >= maxd)
-      {
-        maxd += 10;
-        dftmp = df->name;
-        if((df->name = malloc(sizeof(char *) * maxd)) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-        for(k = 0; k < maxd - 10; k++)
-          *(df->name + k) = *(dftmp + k);
-        free(dftmp);
-      }
-      /* save the current directory */
-      if((*(df->name + df->anz) = malloc((strlen(tmp) + 1) * sizeof(char))) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-      strcpy(*(df->name + df->anz), tmp);
-      df->anz++;
-      j = -1;
-    }
-  }
-  free(buf);
-  free(tmp);
-  return(df);
+  free (buf);
+  free (tmp);
+  return (df);
 }
 
 /* This function creates a wastebasket directory if needed, then returns a
@@ -1931,928 +1995,954 @@ struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn)
    error checking on wastebasket path creation.  The modified version does --
    it also returns NULL on an error in the chdir function or mkdir
    function. */
-char  *WpeGetWastefile(char *file)
+char *
+WpeGetWastefile (char *file)
 {
-  static char    *wastebasket = NULL;
-  int             i, lw;
-  char           *tmp;             /* storage for wastebasket path */
-  char           *tmp2;
+  static char *wastebasket = NULL;
+  int i, lw;
+  char *tmp;			/* storage for wastebasket path */
+  char *tmp2;
 
-  if(!wastebasket)  /* setup and test access to wastebasket directory */
-  {
-    if((tmp2 = getenv("HOME")) == NULL)
-      return NULL;
-
-    lw = strlen(tmp2) + 1 + strlen(WASTEBASKET) + 1;
-    /*    HOME          /     WASTEBASKET       \0    */
-    if((tmp = (char *)malloc(lw)) == NULL)
-      return NULL;
-
-    sprintf(tmp, "%s/%s", tmp2, WASTEBASKET);
-
-    /* if wastebasket dir does not exist, create it with error checking */
-    if(access(tmp, F_OK))
+  if (!wastebasket)		/* setup and test access to wastebasket directory */
     {
-      if(mkdir(tmp, 0700))
-      {
-        free(tmp);
-        return NULL;
-      }
+      if ((tmp2 = getenv ("HOME")) == NULL)
+	return NULL;
+
+      lw = strlen (tmp2) + 1 + strlen (WASTEBASKET) + 1;
+      /*    HOME          /     WASTEBASKET       \0    */
+      if ((tmp = (char *) malloc (lw)) == NULL)
+	return NULL;
+
+      sprintf (tmp, "%s/%s", tmp2, WASTEBASKET);
+
+      /* if wastebasket dir does not exist, create it with error checking */
+      if (access (tmp, F_OK))
+	{
+	  if (mkdir (tmp, 0700))
+	    {
+	      free (tmp);
+	      return NULL;
+	    }
+	}
+      /* check for wastebasket's permissions */
+      if (access (tmp, R_OK | W_OK | X_OK))
+	{
+	  free (tmp);
+	  return NULL;
+	}
+      wastebasket = tmp;
     }
-    /* check for wastebasket's permissions */
-    if(access(tmp, R_OK | W_OK | X_OK))
-    {
-      free(tmp);
-      return NULL;
-    }
-    wastebasket = tmp;
-  }
 
   /* verify that wastebasket directory still exists before proceeding */
-  if(access(wastebasket, F_OK | R_OK | W_OK | X_OK))
-  {
-    /* try to recreate it */
-    if(mkdir(wastebasket, 0700))
-      return NULL;
-  }
+  if (access (wastebasket, F_OK | R_OK | W_OK | X_OK))
+    {
+      /* try to recreate it */
+      if (mkdir (wastebasket, 0700))
+	return NULL;
+    }
 
   /* return wastebasket directory path if no filename in 'file' */
-  if(file[0] == '\0')
-  {
-    if((tmp2 = malloc(strlen(wastebasket)+1)) == NULL)
-      return NULL;
-    strcpy(tmp2, wastebasket);
-    return(tmp2);
-  }
+  if (file[0] == '\0')
+    {
+      if ((tmp2 = malloc (strlen (wastebasket) + 1)) == NULL)
+	return NULL;
+      strcpy (tmp2, wastebasket);
+      return (tmp2);
+    }
 
   /* else get filename from end of 'file' string, 
      append to wastebasket sting */
-  for(i = strlen(file) - 1; i >= 0 && file[i] != DIRC; i--)
+  for (i = strlen (file) - 1; i >= 0 && file[i] != DIRC; i--)
     ;
-  if((tmp2 = malloc(strlen(wastebasket) + strlen(file + 1 + i) + 2)) == NULL)
+  if ((tmp2 =
+       malloc (strlen (wastebasket) + strlen (file + 1 + i) + 2)) == NULL)
     return NULL;
 
-  sprintf(tmp2, "%s/%s", wastebasket, file + 1 + i);
-  return(tmp2);
+  sprintf (tmp2, "%s/%s", wastebasket, file + 1 + i);
+  return (tmp2);
 }
 
-struct dirfile *WpeGraphicalFileList(struct dirfile *df, int sw, ECNT *cn)
+struct dirfile *
+WpeGraphicalFileList (struct dirfile *df, int sw, ECNT * cn)
 {
- struct dirfile *edf;
- char          **name, **ename, *stmp, str[256];
- int             ntmp, n, i, *num;
+  struct dirfile *edf;
+  char **name, **ename, *stmp, str[256];
+  int ntmp, n, i, *num;
 
- /* allocate the same structure as the argument */
- if ((edf = malloc(sizeof(struct dirfile))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  /* allocate the same structure as the argument */
+  if ((edf = malloc (sizeof (struct dirfile))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
- edf->anz = df->anz;
- edf->name = NULL;
+  edf->anz = df->anz;
+  edf->name = NULL;
 
 /* OSF and AIX fix, for malloc(0) they return NULL */
- if (df->anz)
- {
-  if ((edf->name = malloc(df->anz * sizeof(char *))) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-
-  if ((num = malloc(df->anz * sizeof(int))) == NULL)
-   e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-
-  for (i = 0; i < df->anz; i++)
-  {
-   e_file_info(*(df->name + i), str, num + i, sw);
-   if ((*(edf->name + i) = malloc(strlen(str) + 1)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-   strcpy(*(edf->name + i), str);
-  }
-
-  /* sort by time or size mode */
-  if (sw & 3)
-  {
-   if ((ename = malloc(df->anz * sizeof(char *))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-
-   if ((name = malloc(df->anz * sizeof(char *))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-
-   for (i = 0; i < df->anz; i++)
-   {
-    for (ntmp = num[i], n = i; n > 0 && ntmp > num[n - 1]; n--)
+  if (df->anz)
     {
-     *(ename + n) = *(ename + n - 1);
-     *(name + n) = *(name + n - 1);
-     num[n] = num[n - 1];
+      if ((edf->name = malloc (df->anz * sizeof (char *))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+
+      if ((num = malloc (df->anz * sizeof (int))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+
+      for (i = 0; i < df->anz; i++)
+	{
+	  e_file_info (*(df->name + i), str, num + i, sw);
+	  if ((*(edf->name + i) = malloc (strlen (str) + 1)) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	  strcpy (*(edf->name + i), str);
+	}
+
+      /* sort by time or size mode */
+      if (sw & 3)
+	{
+	  if ((ename = malloc (df->anz * sizeof (char *))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+
+	  if ((name = malloc (df->anz * sizeof (char *))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+
+	  for (i = 0; i < df->anz; i++)
+	    {
+	      for (ntmp = num[i], n = i; n > 0 && ntmp > num[n - 1]; n--)
+		{
+		  *(ename + n) = *(ename + n - 1);
+		  *(name + n) = *(name + n - 1);
+		  num[n] = num[n - 1];
+		}
+	      *(ename + n) = *(edf->name + i);
+	      *(name + n) = *(df->name + i);
+	      num[n] = ntmp;
+	    }
+	  free (edf->name);
+	  free (df->name);
+	  edf->name = ename;
+	  df->name = name;
+	}
+
+      free (num);
+
+      /* reverse order */
+      if (sw & 4)
+	{
+	  for (i = 0; i < (df->anz) / 2; i++)
+	    {
+	      stmp = edf->name[i];
+	      edf->name[i] = edf->name[edf->anz - i - 1];
+	      edf->name[edf->anz - i - 1] = stmp;
+	      stmp = df->name[i];
+	      df->name[i] = df->name[df->anz - i - 1];
+	      df->name[df->anz - i - 1] = stmp;
+	    }
+	}
     }
-    *(ename + n) = *(edf->name + i);
-    *(name + n) = *(df->name + i);
-    num[n] = ntmp;
-   }
-   free(edf->name);
-   free(df->name);
-   edf->name = ename;
-   df->name = name;
-  }
 
-  free(num);
-
-  /* reverse order */
-  if (sw & 4)
-  {
-   for (i = 0; i < (df->anz) / 2; i++)
-   {
-    stmp = edf->name[i];
-    edf->name[i] = edf->name[edf->anz - i - 1];
-    edf->name[edf->anz - i - 1] = stmp;
-    stmp = df->name[i];
-    df->name[i] = df->name[df->anz - i - 1];
-    df->name[df->anz - i - 1] = stmp;
-   }
-  }
- }
-
- return(edf);
+  return (edf);
 }
 
-struct dirfile *WpeGraphicalDirTree(struct dirfile *cd, struct dirfile *dd, ECNT *cn)
+struct dirfile *
+WpeGraphicalDirTree (struct dirfile *cd, struct dirfile *dd, ECNT * cn)
 {
-  extern char    *ctree[5];
+  extern char *ctree[5];
   struct dirfile *edf;
-  char            str[256];
-  int             i = 0, j;
+  char str[256];
+  int i = 0, j;
 
-  if((edf = malloc(sizeof(struct dirfile))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((edf = malloc (sizeof (struct dirfile))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
   /* for the OSF and AIX this should never be zero, we are always somewhere */
-  if(cd->anz + dd->anz > 0)
-  {
-    if((edf->name = malloc((cd->anz + dd->anz) * sizeof(char *))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-
-    for(i = 0; i < cd->anz; i++)
+  if (cd->anz + dd->anz > 0)
     {
-      if(!i)
-      {
-        if(*cd->name[0] == DIRC && *(cd->name[0] + 1) == '\0')
-          strcpy(str, "Root");
-        else
-          strcpy(str, *(cd->name + i));
-      }
-      else
-      {
-        for(str[0] = '\0', j = 0; j < i - 1; j++)
-          strcat(str, "  ");
-        if(i == cd->anz - 1 && dd->anz < 1)
-          strcat(str, ctree[1]);
-        else if(i == cd->anz - 1)
-          strcat(str, ctree[2]);
-        else
-          strcat(str, ctree[0]);
-        strcat(str, *(cd->name + i));
-      }
-      if((*(edf->name + i) = malloc((strlen(str) + 1) * sizeof(char))) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-      strcpy(*(edf->name + i), str);
-    }
+      if ((edf->name =
+	   malloc ((cd->anz + dd->anz) * sizeof (char *))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
 
-    for(; i < cd->anz + dd->anz; i++)
-    {
-      for(str[0] = '\0', j = 0; j < cd->anz - 2; j++)
-        strcat(str, "  ");
-      strcat(str, " ");
-      if(i == cd->anz + dd->anz - 1)
-        strcat(str, ctree[4]);
-      else
-        strcat(str, ctree[3]);
-      {
-        int             tttt = i - cd->anz;
-        strcat(str, *(dd->name + tttt));
-      }
-      if((*(edf->name + i) = malloc((strlen(str) + 1) * sizeof(char))) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-      strcpy(*(edf->name + i), str);
+      for (i = 0; i < cd->anz; i++)
+	{
+	  if (!i)
+	    {
+	      if (*cd->name[0] == DIRC && *(cd->name[0] + 1) == '\0')
+		strcpy (str, "Root");
+	      else
+		strcpy (str, *(cd->name + i));
+	    }
+	  else
+	    {
+	      for (str[0] = '\0', j = 0; j < i - 1; j++)
+		strcat (str, "  ");
+	      if (i == cd->anz - 1 && dd->anz < 1)
+		strcat (str, ctree[1]);
+	      else if (i == cd->anz - 1)
+		strcat (str, ctree[2]);
+	      else
+		strcat (str, ctree[0]);
+	      strcat (str, *(cd->name + i));
+	    }
+	  if ((*(edf->name + i) =
+	       malloc ((strlen (str) + 1) * sizeof (char))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	  strcpy (*(edf->name + i), str);
+	}
+
+      for (; i < cd->anz + dd->anz; i++)
+	{
+	  for (str[0] = '\0', j = 0; j < cd->anz - 2; j++)
+	    strcat (str, "  ");
+	  strcat (str, " ");
+	  if (i == cd->anz + dd->anz - 1)
+	    strcat (str, ctree[4]);
+	  else
+	    strcat (str, ctree[3]);
+	  {
+	    int tttt = i - cd->anz;
+	    strcat (str, *(dd->name + tttt));
+	  }
+	  if ((*(edf->name + i) =
+	       malloc ((strlen (str) + 1) * sizeof (char))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+	  strcpy (*(edf->name + i), str);
+	}
     }
-  }
 
   edf->anz = i;
-  return(edf);
+  return (edf);
 }
 
-int WpeDelWastebasket(FENSTER *f)
+int
+WpeDelWastebasket (FENSTER * f)
 {
-  char            *tmp;
-  int             ret, mode = f->ed->flopt;
+  char *tmp;
+  int ret, mode = f->ed->flopt;
 
-  WpeMouseChangeShape(WpeWorkingShape);
+  WpeMouseChangeShape (WpeWorkingShape);
   f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
-                 FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
-  if ((tmp = WpeGetWastefile("")))
-  {
-    ret = WpeRemoveDir(tmp, "*", f, 0);
-    free(tmp);
+    FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
+  if ((tmp = WpeGetWastefile ("")))
+    {
+      ret = WpeRemoveDir (tmp, "*", f, 0);
+      free (tmp);
 
-    /* Unfortunately there is this racing condition, so
-       this is necessary to get back the deleted wastebasket. */
-    if ((tmp = WpeGetWastefile("")))
-    {
-      free(tmp);
-      ret = 0;
+      /* Unfortunately there is this racing condition, so
+         this is necessary to get back the deleted wastebasket. */
+      if ((tmp = WpeGetWastefile ("")))
+	{
+	  free (tmp);
+	  ret = 0;
+	}
+      else
+	{
+	  e_error (e_msg[ERR_NOWASTE], 0, f->ed->fb);
+	  ret = 1;
+	}
     }
-    else
-    {
-      e_error(e_msg[ERR_NOWASTE], 0, f->ed->fb);
-      ret = 1;
-    }
-  }
   else
-  {
-    /* Error failed to find wastebasket */
-    e_error(e_msg[ERR_NOWASTE], 0, f->ed->fb);
-    ret = 1;
-  }
-  f->ed->flopt = mode;
-  WpeMouseRestoreShape();
-  return(ret);
-}
-
-int WpeShowWastebasket(FENSTER *f)
-{
-  return(WpeCallFileManager(6, f));
-}
-
-int WpeQuitWastebasket(FENSTER * f)
-{
-  char            *tmp;
-  int             ret = 0, mode = f->ed->flopt;
-
-  if(mode & FM_PROMPT_DELETE)
-    f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
-                   FM_REMOVE_PROMPT | FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
-  else if(mode & FM_DELETE_AT_EXIT)
-    f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
-                   FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
-
-  if((mode & FM_PROMPT_DELETE) || (mode & FM_DELETE_AT_EXIT))
-  {
-    WpeMouseChangeShape(WpeWorkingShape);
-    if ((tmp = WpeGetWastefile("")))
-    {
-      ret = WpeRemoveDir(tmp, "*", f, 0);
-      free(tmp);
-    }
-    else
     {
       /* Error failed to find wastebasket */
-      e_error(e_msg[ERR_NOWASTE], 0, f->ed->fb);
-      ret = 0;
+      e_error (e_msg[ERR_NOWASTE], 0, f->ed->fb);
+      ret = 1;
     }
-    WpeMouseRestoreShape();
-  }
+  f->ed->flopt = mode;
+  WpeMouseRestoreShape ();
+  return (ret);
+}
+
+int
+WpeShowWastebasket (FENSTER * f)
+{
+  return (WpeCallFileManager (6, f));
+}
+
+int
+WpeQuitWastebasket (FENSTER * f)
+{
+  char *tmp;
+  int ret = 0, mode = f->ed->flopt;
+
+  if (mode & FM_PROMPT_DELETE)
+    f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
+      FM_REMOVE_PROMPT | FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
+  else if (mode & FM_DELETE_AT_EXIT)
+    f->ed->flopt = FM_SHOW_HIDDEN_FILES | FM_SHOW_HIDDEN_DIRS |
+      FM_MOVE_OVERWRITE | FM_REKURSIVE_ACTIONS;
+
+  if ((mode & FM_PROMPT_DELETE) || (mode & FM_DELETE_AT_EXIT))
+    {
+      WpeMouseChangeShape (WpeWorkingShape);
+      if ((tmp = WpeGetWastefile ("")))
+	{
+	  ret = WpeRemoveDir (tmp, "*", f, 0);
+	  free (tmp);
+	}
+      else
+	{
+	  /* Error failed to find wastebasket */
+	  e_error (e_msg[ERR_NOWASTE], 0, f->ed->fb);
+	  ret = 0;
+	}
+      WpeMouseRestoreShape ();
+    }
 
   f->ed->flopt = mode;
-  return(ret);
+  return (ret);
 }
 
 
-int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec)
+int
+WpeRemoveDir (char *dirct, char *file, FENSTER * f, int rec)
 {
-  view            *pic = NULL;
-  char           *tmp;
-  int             i, ret, svmode = f->ed->flopt;
+  view *pic = NULL;
+  char *tmp;
+  int i, ret, svmode = f->ed->flopt;
   struct dirfile *dd;
 
-  if(rec > MAXREC)
-    return(0);
+  if (rec > MAXREC)
+    return (0);
 
   /* only copy it to the wastebasket */
-  if(f->ed->flopt & FM_REMOVE_INTO_WB)
-  {
-    if ((tmp = WpeGetWastefile(dirct)))
+  if (f->ed->flopt & FM_REMOVE_INTO_WB)
     {
-      i = strlen(tmp);
-      /* we should not use the fact, that the wasbasket is always something
-         meaningful !!! */
-      if(strncmp(tmp, dirct, i))
-      {
-        ret = WpeRenameCopyDir(dirct, file, tmp, f, 0, 0);
-        free(tmp);
-        return(ret);
-      }
-      free(tmp);
+      if ((tmp = WpeGetWastefile (dirct)))
+	{
+	  i = strlen (tmp);
+	  /* we should not use the fact, that the wasbasket is always something
+	     meaningful !!! */
+	  if (strncmp (tmp, dirct, i))
+	    {
+	      ret = WpeRenameCopyDir (dirct, file, tmp, f, 0, 0);
+	      free (tmp);
+	      return (ret);
+	    }
+	  free (tmp);
+	}
+      else
+	{
+	  e_error (e_msg[ERR_NOWASTE], 0, f->ed->fb);
+	  return 1;
+	}
     }
-    else
-    {
-      e_error(e_msg[ERR_NOWASTE], 0, f->ed->fb);
-      return 1;
-    }
-  }
 
-  if((tmp = malloc(strlen(dirct) + strlen(file)+2)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  if ((tmp = malloc (strlen (dirct) + strlen (file) + 2)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
   /* search for files in the directory */
-  sprintf(tmp, "%s%c%s", dirct, DIRC, file);
-  dd = e_find_files(tmp, f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0);
+  sprintf (tmp, "%s%c%s", dirct, DIRC, file);
+  dd = e_find_files (tmp, f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0);
 
   /* it is called for the first time and the user should be asked about
      the deletion */
-  if(!rec && (f->ed->flopt & FM_REMOVE_PROMPT) && dd->anz > 0)
-  {
-    if((ret = WpeDirDelOptions(f)) < 0)
+  if (!rec && (f->ed->flopt & FM_REMOVE_PROMPT) && dd->anz > 0)
     {
-      freedf(dd);
-      free(tmp);
-      return(ret == WPE_ESC ? 1 : 0);
+      if ((ret = WpeDirDelOptions (f)) < 0)
+	{
+	  freedf (dd);
+	  free (tmp);
+	  return (ret == WPE_ESC ? 1 : 0);
+	}
+      if (ret)
+	f->ed->flopt |= FM_REMOVE_PROMPT;
+      else
+	f->ed->flopt &= ~FM_REMOVE_PROMPT;
+      rec = -1;
     }
-    if(ret)
-      f->ed->flopt |= FM_REMOVE_PROMPT;
-    else
-      f->ed->flopt &= ~FM_REMOVE_PROMPT;
-    rec = -1;
-  }
-  free(tmp);
+  free (tmp);
 
   /* cleans up the files in the directory */
-  for(i = 0; i < dd->anz; i++)
-  {
-    if((tmp = malloc(strlen(dirct) + strlen(dd->name[i])+15)) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-    sprintf(tmp, "Remove File:\n%s%c%s", dirct, DIRC, dd->name[i]);
-    if(f->ed->flopt & FM_REMOVE_PROMPT)
+  for (i = 0; i < dd->anz; i++)
     {
-      ret = e_message(1, tmp, f);
+      if ((tmp = malloc (strlen (dirct) + strlen (dd->name[i]) + 15)) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+      sprintf (tmp, "Remove File:\n%s%c%s", dirct, DIRC, dd->name[i]);
+      if (f->ed->flopt & FM_REMOVE_PROMPT)
+	{
+	  ret = e_message (1, tmp, f);
+	}
+      else
+	ret = 'Y';
+      if (ret == WPE_ESC)
+	{
+	  freedf (dd);
+	  free (tmp);
+	  f->ed->flopt = svmode;
+	  return (1);
+	}
+      else if (ret == 'Y')
+	{
+	  /* this should definitely fit in */
+	  sprintf (tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
+
+	  /* put message out */
+	  if (e_mess_win ("Remove", tmp, &pic, f))
+	    {
+	      free (tmp);
+	      break;
+	    }
+
+	  if (pic)
+	    {
+	      e_close_view (pic, 1);
+	      pic = NULL;
+	    }
+
+	  /* try to remove it */
+	  if (remove (tmp))
+	    {
+	      e_error (e_msg[ERR_DELFILE], 0, f->ed->fb);
+	      freedf (dd);
+	      free (tmp);
+	      f->ed->flopt = svmode;
+	      return (1);
+	    }
+	}
+      free (tmp);
     }
-    else
-      ret = 'Y';
-    if(ret == WPE_ESC)
-    {
-      freedf(dd);
-      free(tmp);
-      f->ed->flopt = svmode;
-      return(1);
-    }
-    else if(ret == 'Y')
-    {
-      /* this should definitely fit in */
-      sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
 
-      /* put message out */
-      if(e_mess_win("Remove", tmp, &pic, f))
-      {
-        free(tmp);
-        break;
-      }
-
-      if(pic)
-      {
-        e_close_view(pic, 1);
-        pic = NULL;
-      }
-
-      /* try to remove it */
-      if(remove(tmp))
-      {
-        e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
-        freedf(dd);
-        free(tmp);
-        f->ed->flopt = svmode;
-        return(1);
-      }
-    }
-    free(tmp);
-  }
-
-  if(pic)
-    e_close_view(pic, 1);
-  freedf(dd);
+  if (pic)
+    e_close_view (pic, 1);
+  freedf (dd);
 
   /* if recursive action is specified clean up the 
      subdirectories as well */
-  if(f->ed->flopt & FM_REKURSIVE_ACTIONS)
-  {
-    if((tmp = malloc(strlen(dirct) + strlen(SUDIR)+2)) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-    /* search for subdirectories */
-    sprintf(tmp, "%s%c%s", dirct, DIRC, SUDIR);
-    dd = e_find_dir(tmp, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-
-    /* should the user be asked about deletion ? */
-    if(!rec && (f->ed->flopt & FM_REMOVE_PROMPT) && dd->anz > 0)
+  if (f->ed->flopt & FM_REKURSIVE_ACTIONS)
     {
-      if((ret = WpeDirDelOptions(f)) < 0)
-      {
-        freedf(dd);
-        free(tmp);
-        return(ret == WPE_ESC ? 1 : 0);
-      }
-      if(ret)
-        f->ed->flopt |= FM_REMOVE_PROMPT;
-      else
-        f->ed->flopt &= ~FM_REMOVE_PROMPT;
+      if ((tmp = malloc (strlen (dirct) + strlen (SUDIR) + 2)) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+      /* search for subdirectories */
+      sprintf (tmp, "%s%c%s", dirct, DIRC, SUDIR);
+      dd = e_find_dir (tmp, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+
+      /* should the user be asked about deletion ? */
+      if (!rec && (f->ed->flopt & FM_REMOVE_PROMPT) && dd->anz > 0)
+	{
+	  if ((ret = WpeDirDelOptions (f)) < 0)
+	    {
+	      freedf (dd);
+	      free (tmp);
+	      return (ret == WPE_ESC ? 1 : 0);
+	    }
+	  if (ret)
+	    f->ed->flopt |= FM_REMOVE_PROMPT;
+	  else
+	    f->ed->flopt &= ~FM_REMOVE_PROMPT;
+	}
+      else if (rec < 0)
+	rec = 0;
+
+      free (tmp);
+
+      /* call recursively itself to delete the subdirectories */
+      for (rec++, i = 0; i < dd->anz; i++)
+	{
+	  if ((tmp =
+	       malloc (strlen (dirct) + strlen (dd->name[i]) + 2)) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+	  sprintf (tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
+	  if (WpeRemoveDir (tmp, file, f, rec))
+	    {
+	      freedf (dd);
+	      free (tmp);
+	      f->ed->flopt = svmode;
+	      return (1);
+	    }
+	  free (tmp);
+	}
+      freedf (dd);
     }
-    else if(rec < 0)
-      rec = 0;
-
-    free(tmp);
-
-    /* call recursively itself to delete the subdirectories */
-    for(rec++, i = 0; i < dd->anz; i++)
-    {
-      if((tmp = malloc(strlen(dirct) + strlen(dd->name[i])+2)) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-      sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
-      if(WpeRemoveDir(tmp, file, f, rec))
-      {
-        freedf(dd);
-        free(tmp);
-        f->ed->flopt = svmode;
-        return(1);
-      }
-      free(tmp);
-    }
-    freedf(dd);
-  }
 
   f->ed->flopt = svmode;
 
   /* remove finally the directory itself */
-  if(rmdir(dirct))
-  {
-    e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
-    return(1);
-  }
+  if (rmdir (dirct))
+    {
+      e_error (e_msg[ERR_DELFILE], 0, f->ed->fb);
+      return (1);
+    }
   else
-    return(0);
+    return (0);
 }
 
-int WpeRemove(char *file, FENSTER * f)
+int
+WpeRemove (char *file, FENSTER * f)
 {
-  struct stat     buf;
-  struct stat     lbuf;
-  char           *tmp2;
-  int             ret;
+  struct stat buf;
+  struct stat lbuf;
+  char *tmp2;
+  int ret;
 
-  if(lstat(file, &lbuf))
-  {
-    e_error(e_msg[ERR_ACCFILE], 0, f->ed->fb);
-    return 1;
-  }
+  if (lstat (file, &lbuf))
+    {
+      e_error (e_msg[ERR_ACCFILE], 0, f->ed->fb);
+      return 1;
+    }
 
-  WpeMouseChangeShape(WpeWorkingShape);
+  WpeMouseChangeShape (WpeWorkingShape);
 
   /* this is important, first we check whether it is a file,
      this check works even when it is a pointer, if it is not
      a file, then it can be an "invalid" symbolic link, check for that */
-  if(((stat(file, &buf) == 0) && S_ISREG(buf.st_mode)) || S_ISLNK(lbuf.st_mode))
-  {
-    if((f->ed->flopt & FM_REMOVE_INTO_WB))
+  if (((stat (file, &buf) == 0) && S_ISREG (buf.st_mode))
+      || S_ISLNK (lbuf.st_mode))
     {
-      if ((tmp2 = WpeGetWastefile(file)))
-      {
-        ret = strlen(tmp2);
-        if(strncmp(tmp2, file, ret))
-        {
-          e_rename(file, tmp2, f);
-        }
-        free(tmp2);
-        ret = 0;
-      }
+      if ((f->ed->flopt & FM_REMOVE_INTO_WB))
+	{
+	  if ((tmp2 = WpeGetWastefile (file)))
+	    {
+	      ret = strlen (tmp2);
+	      if (strncmp (tmp2, file, ret))
+		{
+		  e_rename (file, tmp2, f);
+		}
+	      free (tmp2);
+	      ret = 0;
+	    }
+	  else
+	    {
+	      e_error (e_msg[ERR_NOWASTE], 0, f->ed->fb);
+	      ret = 1;
+	    }
+	}
       else
-      {
-        e_error(e_msg[ERR_NOWASTE], 0, f->ed->fb);
-        ret = 1;
-      }
-    }
-    else
-    {
-      if(f->ed->flopt & FM_REMOVE_PROMPT)
-      {
-        if((tmp2 = malloc(strlen(file) + 14)) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+	{
+	  if (f->ed->flopt & FM_REMOVE_PROMPT)
+	    {
+	      if ((tmp2 = malloc (strlen (file) + 14)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-        sprintf(tmp2, "Remove File:\n%s", file);
-        ret = e_message(1, tmp2, f);
-        free(tmp2);
-      }
-      else
-        ret = 'Y';
+	      sprintf (tmp2, "Remove File:\n%s", file);
+	      ret = e_message (1, tmp2, f);
+	      free (tmp2);
+	    }
+	  else
+	    ret = 'Y';
 
-      if(ret == 'Y')
-      {
-        if(remove(file))
-        {
-          e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
-          ret = 1;
-        }
-        else
-          ret = 0;
-      }
-      else
-        ret = 0;
+	  if (ret == 'Y')
+	    {
+	      if (remove (file))
+		{
+		  e_error (e_msg[ERR_DELFILE], 0, f->ed->fb);
+		  ret = 1;
+		}
+	      else
+		ret = 0;
+	    }
+	  else
+	    ret = 0;
+	}
     }
-  }
   else
-  {
-    ret = WpeRemoveDir(file, f->fd.file, f, 0);
-  }
+    {
+      ret = WpeRemoveDir (file, f->fd.file, f, 0);
+    }
 
-  WpeMouseRestoreShape();
-  return(ret);
+  WpeMouseRestoreShape ();
+  return (ret);
 }
 
 /* sw = 0  -> renames the directory
    sw = 1  -> copies the directory
    sw = 2  -> links directory */
-int WpeRenameCopyDir(char *dirct, char *file, char *newname, FENSTER *f,
-                     int rec, int sw)
+int
+WpeRenameCopyDir (char *dirct, char *file, char *newname, FENSTER * f,
+		  int rec, int sw)
 {
-  char            *tmp, *ntmp, *mtmp;
-  int             i, ret, mode;
+  char *tmp, *ntmp, *mtmp;
+  int i, ret, mode;
   struct dirfile *dd;
-  struct stat     buf;
-  view            *pic = NULL;
+  struct stat buf;
+  view *pic = NULL;
 
-  if(rec > MAXREC)
-    return(0);
+  if (rec > MAXREC)
+    return (0);
 
   /* check whether the dir already exist */
-  ret = access(newname, F_OK);
+  ret = access (newname, F_OK);
   /* rename mode and dir does not exist */
   if (sw == 0 && ret && file[0] == '*' && file[1] == '\0')
-  {
-    if ((ret = rename(dirct, newname)))
-      e_error(e_msg[ERR_RENFILE], 0, f->ed->fb);
-    return(ret);
-  }
+    {
+      if ((ret = rename (dirct, newname)))
+	e_error (e_msg[ERR_RENFILE], 0, f->ed->fb);
+      return (ret);
+    }
 
   /* directory does not exist */
   if (ret != 0)
-  {
-    /* get the permissions */
-    if (stat(dirct, &buf))
     {
-      e_error(e_msg[ERR_ACCFILE], 0, f->ed->fb);
-      return(1);
+      /* get the permissions */
+      if (stat (dirct, &buf))
+	{
+	  e_error (e_msg[ERR_ACCFILE], 0, f->ed->fb);
+	  return (1);
+	}
+      /* with that permission create the new dir */
+      if (mkdir (newname, buf.st_mode))
+	{
+	  e_error (e_msg[ERR_NONEWDIR], 0, f->ed->fb);
+	  return (1);
+	}
     }
-    /* with that permission create the new dir */
-    if(mkdir(newname, buf.st_mode))
+
+  if (f->ed->flopt & FM_REKURSIVE_ACTIONS)
     {
-      e_error(e_msg[ERR_NONEWDIR], 0, f->ed->fb);
-      return(1);
+      if ((tmp = malloc (strlen (dirct) + 2 + strlen (SUDIR))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+      sprintf (tmp, "%s%c%s", dirct, DIRC, SUDIR);
+      dd = e_find_dir (tmp, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+      free (tmp);
+
+      for (rec++, i = 0; i < dd->anz; i++)
+	{
+
+	  if ((tmp =
+	       malloc (strlen (dirct) + 2 + strlen (dd->name[i]))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+	  if ((ntmp =
+	       malloc (strlen (newname) + 2 + strlen (dd->name[i]))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+	  sprintf (tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
+	  sprintf (ntmp, "%s%c%s", newname, DIRC, dd->name[i]);
+
+	  if (WpeRenameCopyDir (tmp, file, ntmp, f, rec, sw))
+	    {
+	      free (tmp);
+	      free (ntmp);
+	      freedf (dd);
+	      return (1);
+	    }
+	  free (tmp);
+	  free (ntmp);
+	}
+      freedf (dd);
     }
-  }
 
-  if(f->ed->flopt & FM_REKURSIVE_ACTIONS)
-  {
-    if((tmp = malloc(strlen(dirct) + 2 + strlen(SUDIR))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-    sprintf(tmp, "%s%c%s", dirct, DIRC, SUDIR);
-    dd = e_find_dir(tmp, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-    free(tmp);
-
-    for(rec++, i = 0; i < dd->anz; i++)
-    {
-
-      if((tmp = malloc(strlen(dirct) + 2 + strlen(dd->name[i]))) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-      if((ntmp = malloc(strlen(newname) + 2 + strlen(dd->name[i]))) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-      sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
-      sprintf(ntmp, "%s%c%s", newname, DIRC, dd->name[i]);
-
-      if(WpeRenameCopyDir(tmp, file, ntmp, f, rec, sw))
-      {
-        free(tmp);
-        free(ntmp);
-        freedf(dd);
-        return(1);
-      }
-      free(tmp);
-      free(ntmp);
-    }
-    freedf(dd);
-  }
-
-  if((tmp = malloc(strlen(dirct) + 2 + strlen(file))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-  sprintf(tmp, "%s%c%s", dirct, DIRC, file);
-  dd = e_find_files(tmp, f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0);
-  free(tmp);
+  if ((tmp = malloc (strlen (dirct) + 2 + strlen (file))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  sprintf (tmp, "%s%c%s", dirct, DIRC, file);
+  dd = e_find_files (tmp, f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0);
+  free (tmp);
 
   mode = f->ed->flopt;
   f->ed->flopt &= ~FM_REMOVE_PROMPT;
 
-  for(i = 0; i < dd->anz; i++)
-  {
-    if((ntmp = malloc(strlen(newname) + 2 + strlen(dd->name[i]))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-    sprintf(ntmp, "%s%c%s", newname, DIRC, dd->name[i]);
-    ret = 'Y';
-
-    if(access(ntmp, F_OK) == 0)
+  for (i = 0; i < dd->anz; i++)
     {
-      if(f->ed->flopt & FM_MOVE_PROMPT)
-      {
-        if((tmp = malloc(strlen(ntmp) + 31)) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+      if ((ntmp =
+	   malloc (strlen (newname) + 2 + strlen (dd->name[i]))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-        sprintf(tmp, "File %s exist !\nOverwrite File ?", ntmp);
-        if(pic)
-        {
-          e_close_view(pic, 1);
-          pic = NULL;
-        }
-        ret = e_message(1, tmp, f);
-        free(tmp);
+      sprintf (ntmp, "%s%c%s", newname, DIRC, dd->name[i]);
+      ret = 'Y';
 
-        if(ret == 'Y')
-        {
-          if(WpeRemove(ntmp, f))
-          {
-            free(ntmp);
-            freedf(dd);
-            return(1);
-          }
-        }
-        else if(ret == WPE_ESC)
-        {
-          free(ntmp);
-          freedf(dd);
-          return(1);
-        }
-      }
-      else if(f->ed->flopt & FM_MOVE_OVERWRITE)
-      {
-        if(WpeRemove(ntmp, f))
-        {
-          free(ntmp);
-          freedf(dd);
-          return(1);
-        }
-      }
+      if (access (ntmp, F_OK) == 0)
+	{
+	  if (f->ed->flopt & FM_MOVE_PROMPT)
+	    {
+	      if ((tmp = malloc (strlen (ntmp) + 31)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+	      sprintf (tmp, "File %s exist !\nOverwrite File ?", ntmp);
+	      if (pic)
+		{
+		  e_close_view (pic, 1);
+		  pic = NULL;
+		}
+	      ret = e_message (1, tmp, f);
+	      free (tmp);
+
+	      if (ret == 'Y')
+		{
+		  if (WpeRemove (ntmp, f))
+		    {
+		      free (ntmp);
+		      freedf (dd);
+		      return (1);
+		    }
+		}
+	      else if (ret == WPE_ESC)
+		{
+		  free (ntmp);
+		  freedf (dd);
+		  return (1);
+		}
+	    }
+	  else if (f->ed->flopt & FM_MOVE_OVERWRITE)
+	    {
+	      if (WpeRemove (ntmp, f))
+		{
+		  free (ntmp);
+		  freedf (dd);
+		  return (1);
+		}
+	    }
+	}
+
+      if ((tmp = malloc (strlen (dirct) + 2 + strlen (dd->name[i]))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+      sprintf (tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
+
+      if (ret == 'Y')
+	{
+	  if ((mtmp = malloc (strlen (tmp) + 2 + strlen (ntmp))) == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+	  sprintf (mtmp, "%s %s", tmp, ntmp);
+	  if (e_mess_win (!sw ? "Rename" : "Copy", mtmp, &pic, f))
+	    {
+	      free (tmp);
+	      free (ntmp);
+	      free (mtmp);
+	      break;
+	    }
+	  free (mtmp);
+
+	  if (sw == 0)
+	    {
+	      if ((ret = rename (tmp, ntmp)))
+		{
+		  e_error (e_msg[ERR_RENFILE], 0, f->ed->fb);
+		  free (tmp);
+		  free (ntmp);
+		  freedf (dd);
+		  return (1);
+		}
+	    }
+	  else if (sw == 1)
+	    {
+	      if (WpeCopyFileCont (tmp, ntmp, f))
+		{
+		  free (tmp);
+		  free (ntmp);
+		  freedf (dd);
+		  return (1);
+		}
+	    }
+	  else if (sw == 2)
+	    {
+	      if (WpeLinkFile (tmp, ntmp, f->ed->flopt & FM_TRY_HARDLINK, f))
+		{
+		  free (tmp);
+		  free (ntmp);
+		  freedf (dd);
+		  return (1);
+		}
+	    }
+	}
+
+      free (tmp);
+      free (ntmp);
     }
 
-    if((tmp = malloc(strlen(dirct) + 2 + strlen(dd->name[i]))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-    sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
-
-    if(ret == 'Y')
-    {
-      if((mtmp = malloc(strlen(tmp) + 2 + strlen(ntmp))) == NULL)
-        e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-      sprintf(mtmp, "%s %s", tmp, ntmp);
-      if(e_mess_win(!sw ? "Rename" : "Copy", mtmp, &pic, f))
-      {
-        free(tmp);
-        free(ntmp);
-        free(mtmp);
-        break;
-      }
-      free(mtmp);
-
-      if (sw == 0)
-      {
-        if ((ret = rename(tmp, ntmp)))
-        {
-          e_error(e_msg[ERR_RENFILE], 0, f->ed->fb);
-          free(tmp);
-          free(ntmp);
-          freedf(dd);
-          return(1);
-        }
-      }
-      else if (sw == 1)
-      {
-        if (WpeCopyFileCont(tmp, ntmp, f))
-        {
-          free(tmp);
-          free(ntmp);
-          freedf(dd);
-          return(1);
-        }
-      }
-      else if(sw == 2)
-      {
-        if(WpeLinkFile(tmp, ntmp, f->ed->flopt & FM_TRY_HARDLINK, f))
-        {
-          free(tmp);
-          free(ntmp);
-          freedf(dd);
-          return(1);
-        }
-      }
-    }
-
-    free(tmp);
-    free(ntmp);
-  }
-
-  if(pic)
-    e_close_view(pic, 1);
+  if (pic)
+    e_close_view (pic, 1);
 
   f->ed->flopt = mode;
 
-  if(sw == 0)
-  {
-    if(rmdir(dirct))
-      e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
-  }
+  if (sw == 0)
+    {
+      if (rmdir (dirct))
+	e_error (e_msg[ERR_DELFILE], 0, f->ed->fb);
+    }
 
-  freedf(dd);
-  return(0);
+  freedf (dd);
+  return (0);
 }
 
 
-int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw)
+int
+WpeRenameCopy (char *file, char *newname, FENSTER * f, int sw)
 {
- struct stat     buf;
- struct stat     lbuf;
- char           *tmp, *tmpl;
- int             ln = -1, ret = 'Y';
- int             allocate_size, retl = 0;
+  struct stat buf;
+  struct stat lbuf;
+  char *tmp, *tmpl;
+  int ln = -1, ret = 'Y';
+  int allocate_size, retl = 0;
 
- WpeMouseChangeShape(WpeWorkingShape);
+  WpeMouseChangeShape (WpeWorkingShape);
 
- /* in copy mode check whether it is a link */
- if (sw == 0)
- {
-  if (lstat(file, &lbuf))
-  {
-   e_error(e_msg[ERR_ACCFILE], 0, f->ed->fb);
-   return 1;
-  }
-
-  if (S_ISLNK(lbuf.st_mode))
-   ln = 1;
- }
-
- if ((stat(file, &buf) == 0) && S_ISDIR(buf.st_mode) && ln < 0)
-  retl = WpeRenameCopyDir(file, f->fd.file, newname, f, 0, sw);
- else
- {
-  /* check whether file exist */
-  if (access(newname, F_OK) == 0)
-  {
-   if (f->ed->flopt & FM_MOVE_OVERWRITE)
-   {
-    if (WpeRemove(newname, f))
+  /* in copy mode check whether it is a link */
+  if (sw == 0)
     {
-     WpeMouseRestoreShape();
-     return(1);
+      if (lstat (file, &lbuf))
+	{
+	  e_error (e_msg[ERR_ACCFILE], 0, f->ed->fb);
+	  return 1;
+	}
+
+      if (S_ISLNK (lbuf.st_mode))
+	ln = 1;
     }
-   }
-   else if (f->ed->flopt & FM_MOVE_PROMPT)
-   {
-    if ((tmp = malloc(strlen(newname) + 26)) == NULL)
-     e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-    sprintf(tmp, "File %s exist\nRemove File ?", newname);
-    ret = e_message(1, tmp, f);
-    free(tmp);
-    if (ret == 'Y')
-    {
-     if (WpeRemove(newname, f))
-     {
-      WpeMouseRestoreShape();
-      return(1);
-     }
-    }
-   }
-  }
 
-  if (ret == 'Y')
-  {
-   if (sw == 1)
-   {
-    retl = WpeCopyFileCont(file, newname, f);
-   }
-   else if (sw == 2)
-   {
-    retl = WpeLinkFile(file, newname, f->ed->flopt & FM_TRY_HARDLINK, f);
-   }
-   else if (sw == 0 && ln < 0) /* rename mode, no softlink */
-   {
-    if ((retl = rename(file, newname)) == -1)
+  if ((stat (file, &buf) == 0) && S_ISDIR (buf.st_mode) && ln < 0)
+    retl = WpeRenameCopyDir (file, f->fd.file, newname, f, 0, sw);
+  else
     {
-     if (errno == EXDEV)
-     {
-      if ((retl = WpeCopyFileCont(file, newname, f)) == 0)
-      {
-       if ((retl = remove(file)))
-        e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
-      }
-     }
-     else
-     {
-      e_error(e_msg[ERR_RENFILE], 0, f->ed->fb);
-      retl = 1;
-     }
-    }
-   }
-   else if (sw == 0)
-   {
-    allocate_size = 2;
-    tmp = NULL;
-    do
-    {
-     if (tmp)
-      free(tmp);
-     allocate_size += 4;
-     if ((tmp = malloc(allocate_size)) == NULL) {
-        e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-     }
+      /* check whether file exist */
+      if (access (newname, F_OK) == 0)
+	{
+	  if (f->ed->flopt & FM_MOVE_OVERWRITE)
+	    {
+	      if (WpeRemove (newname, f))
+		{
+		  WpeMouseRestoreShape ();
+		  return (1);
+		}
+	    }
+	  else if (f->ed->flopt & FM_MOVE_PROMPT)
+	    {
+	      if ((tmp = malloc (strlen (newname) + 26)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+	      sprintf (tmp, "File %s exist\nRemove File ?", newname);
+	      ret = e_message (1, tmp, f);
+	      free (tmp);
+	      if (ret == 'Y')
+		{
+		  if (WpeRemove (newname, f))
+		    {
+		      WpeMouseRestoreShape ();
+		      return (1);
+		    }
+		}
+	    }
+	}
 
-      ln = readlink(file, tmp, allocate_size-1);
-    } while (!(ln < allocate_size-1));
-    tmp[ln] = '\0';
+      if (ret == 'Y')
+	{
+	  if (sw == 1)
+	    {
+	      retl = WpeCopyFileCont (file, newname, f);
+	    }
+	  else if (sw == 2)
+	    {
+	      retl =
+		WpeLinkFile (file, newname, f->ed->flopt & FM_TRY_HARDLINK,
+			     f);
+	    }
+	  else if (sw == 0 && ln < 0)	/* rename mode, no softlink */
+	    {
+	      if ((retl = rename (file, newname)) == -1)
+		{
+		  if (errno == EXDEV)
+		    {
+		      if ((retl = WpeCopyFileCont (file, newname, f)) == 0)
+			{
+			  if ((retl = remove (file)))
+			    e_error (e_msg[ERR_DELFILE], 0, f->ed->fb);
+			}
+		    }
+		  else
+		    {
+		      e_error (e_msg[ERR_RENFILE], 0, f->ed->fb);
+		      retl = 1;
+		    }
+		}
+	    }
+	  else if (sw == 0)
+	    {
+	      allocate_size = 2;
+	      tmp = NULL;
+	      do
+		{
+		  if (tmp)
+		    free (tmp);
+		  allocate_size += 4;
+		  if ((tmp = malloc (allocate_size)) == NULL)
+		    {
+		      e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+		    }
 
-    for (; ln >= 0 && tmp[ln] != DIRC; ln--)
-     ;
-    if (ln < 0)
-    {
-     if ((tmpl = malloc(strlen(f->dirct) + 2 + strlen(tmp))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+		  ln = readlink (file, tmp, allocate_size - 1);
+		}
+	      while (!(ln < allocate_size - 1));
+	      tmp[ln] = '\0';
 
-     sprintf(tmpl, "%s%c%s", f->dirct, DIRC, tmp);
-     retl = WpeRenameLink(file, newname, tmpl, f);
-     free(tmpl);
+	      for (; ln >= 0 && tmp[ln] != DIRC; ln--)
+		;
+	      if (ln < 0)
+		{
+		  if ((tmpl =
+		       malloc (strlen (f->dirct) + 2 + strlen (tmp))) == NULL)
+		    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+		  sprintf (tmpl, "%s%c%s", f->dirct, DIRC, tmp);
+		  retl = WpeRenameLink (file, newname, tmpl, f);
+		  free (tmpl);
+		}
+	      else
+		{
+		  retl = WpeRenameLink (file, newname, tmp, f);
+		}
+	    }
+	}
     }
-    else
-    {
-     retl = WpeRenameLink(file, newname, tmp, f);
-    }
-   }
-  }
- }
- WpeMouseRestoreShape();
- return(retl);
+  WpeMouseRestoreShape ();
+  return (retl);
 }
 
-int WpeCopyFileCont(char *oldfile, char *newfile, FENSTER *f)
+int
+WpeCopyFileCont (char *oldfile, char *newfile, FENSTER * f)
 {
-  struct stat     buf;
-  size_t          ret;
-  char           *buffer;
-  FILE           *fpo, *fpn;
+  struct stat buf;
+  size_t ret;
+  char *buffer;
+  FILE *fpo, *fpn;
 
   /* get the status of the file */
-  if(stat(oldfile, &buf))
-  {
-    e_error(e_msg[ERR_ACCFILE], 0, f->ed->fb);
-    return(1);
-  }
+  if (stat (oldfile, &buf))
+    {
+      e_error (e_msg[ERR_ACCFILE], 0, f->ed->fb);
+      return (1);
+    }
 
   /* open files for copying */
-  if((fpo = fopen(oldfile, "rb")) == NULL)
-  {
-    e_error(e_msg[ERR_OREADFILE], 0, f->ed->fb);
-    return(1);
-  }
-  if((fpn = fopen(newfile, "wb")) == NULL)
-  {
-    e_error(e_msg[ERR_OWRITEFILE], 0, f->ed->fb);
-    return(1);
-  }
+  if ((fpo = fopen (oldfile, "rb")) == NULL)
+    {
+      e_error (e_msg[ERR_OREADFILE], 0, f->ed->fb);
+      return (1);
+    }
+  if ((fpn = fopen (newfile, "wb")) == NULL)
+    {
+      e_error (e_msg[ERR_OWRITEFILE], 0, f->ed->fb);
+      return (1);
+    }
 
   /* allocate buffer for copying */
-  if((buffer = malloc(E_C_BUFFERSIZE)) == NULL)
-  {
-    e_error(e_msg[ERR_ALLOC_CBUF], 0, f->ed->fb);
-    return(1);
-  }
+  if ((buffer = malloc (E_C_BUFFERSIZE)) == NULL)
+    {
+      e_error (e_msg[ERR_ALLOC_CBUF], 0, f->ed->fb);
+      return (1);
+    }
 
   /* copy until end of file */
   do
-  {
-    ret = fread(buffer, 1, E_C_BUFFERSIZE, fpo);
-    /* we should be able to write the same amount of info */
-    if (fwrite(buffer, 1, ret, fpn) != ret)
     {
-      fclose(fpo);
-      fclose(fpn);
-      free(buffer);
-      e_error(e_msg[ERR_INCONSCOPY], 0, f->ed->fb);
-      return(1);
+      ret = fread (buffer, 1, E_C_BUFFERSIZE, fpo);
+      /* we should be able to write the same amount of info */
+      if (fwrite (buffer, 1, ret, fpn) != ret)
+	{
+	  fclose (fpo);
+	  fclose (fpn);
+	  free (buffer);
+	  e_error (e_msg[ERR_INCONSCOPY], 0, f->ed->fb);
+	  return (1);
+	}
     }
-  } while(!feof(fpo));
+  while (!feof (fpo));
 
-  fclose(fpo);
-  fclose(fpn);
-  free(buffer);
+  fclose (fpo);
+  fclose (fpn);
+  free (buffer);
 
   /* Well, we just created the file, so theoretically this 
      should succeed. Of course this is a racing condition !!! */
-  if(chmod(newfile, buf.st_mode))
-    e_error(e_msg[ERR_CHGPERM], 0, f->ed->fb);
-  return(0);
+  if (chmod (newfile, buf.st_mode))
+    e_error (e_msg[ERR_CHGPERM], 0, f->ed->fb);
+  return (0);
 }
 
 #ifdef HAVE_SYMLINK
@@ -2862,75 +2952,82 @@ int WpeCopyFileCont(char *oldfile, char *newfile, FENSTER *f)
    When hard linking does not work, it tries to do
    symbolic linking
 */
-int WpeLinkFile(char *fl, char *ln, int sw, FENSTER *f)
+int
+WpeLinkFile (char *fl, char *ln, int sw, FENSTER * f)
 {
   int ret;
 
-  if(sw || link(fl, ln))
-  {
-    ret = symlink(fl, ln);
-    if (ret)
+  if (sw || link (fl, ln))
     {
-      e_error(e_msg[ERR_LINKFILE], 0, f->ed->fb);
+      ret = symlink (fl, ln);
+      if (ret)
+	{
+	  e_error (e_msg[ERR_LINKFILE], 0, f->ed->fb);
+	}
+      return (ret);
     }
-    return(ret);
-  }
-  return(0);
+  return (0);
 }
 
-int WpeRenameLink(char *old, char *ln, char *fl, FENSTER *f)
+int
+WpeRenameLink (char *old, char *ln, char *fl, FENSTER * f)
 {
   int ret;
 
-  ret = symlink(fl, ln);
-  if(ret)
-  {
-    e_error(e_msg[ERR_LINKFILE], 0, f->ed->fb);
-    return(1);
-  }
+  ret = symlink (fl, ln);
+  if (ret)
+    {
+      e_error (e_msg[ERR_LINKFILE], 0, f->ed->fb);
+      return (1);
+    }
   else
-  {
-    if(remove(old))
     {
-      e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
-      return(1);
+      if (remove (old))
+	{
+	  e_error (e_msg[ERR_DELFILE], 0, f->ed->fb);
+	  return (1);
+	}
+      else
+	return (0);
     }
-    else
-      return(0);
-  }
 }
-#endif	// #ifdef HAVE_SYMLINK
+#endif // #ifdef HAVE_SYMLINK
 
-int e_rename(char *file, char *newname, FENSTER * f)
+int
+e_rename (char *file, char *newname, FENSTER * f)
 {
-  return(WpeRenameCopy(file, newname, f, 0));
+  return (WpeRenameCopy (file, newname, f, 0));
 }
 
-int e_rename_dir(char *dirct, char *file, char *newname, FENSTER * f, int rec)
+int
+e_rename_dir (char *dirct, char *file, char *newname, FENSTER * f, int rec)
 {
-  return(WpeRenameCopyDir(dirct, file, newname, f, rec, 0));
-}
-
-
-int e_link(char *file, char *newname, FENSTER *f)
-{
-  return(WpeRenameCopy(file, newname, f, 2));
+  return (WpeRenameCopyDir (dirct, file, newname, f, rec, 0));
 }
 
 
-int e_copy(char *file, char *newname, FENSTER * f)
+int
+e_link (char *file, char *newname, FENSTER * f)
 {
-  return(WpeRenameCopy(file, newname, f, 1));
+  return (WpeRenameCopy (file, newname, f, 2));
 }
 
 
-int WpeFileManagerOptions(FENSTER * f)
+int
+e_copy (char *file, char *newname, FENSTER * f)
 {
-  int             ret;
-  W_OPTSTR       *o = e_init_opt_kst(f);
+  return (WpeRenameCopy (file, newname, f, 1));
+}
 
-  if(o == NULL)
-    return(1);
+
+int
+WpeFileManagerOptions (FENSTER * f)
+{
+  int ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
+
+  if (o == NULL)
+    return (1);
 
   o->xa = 8;
   o->ya = 1;
@@ -2939,80 +3036,85 @@ int WpeFileManagerOptions(FENSTER * f)
   o->bgsw = AltO;
   o->name = "File-Manager-Options";
   o->crsw = AltO;
-  e_add_txtstr(4, 2, "Directories:", o);
-  e_add_txtstr(35, 13, "Wastebasket:", o);
-  e_add_txtstr(4, 7, "Move/Copy:", o);
-  e_add_txtstr(35, 8, "Remove:", o);
-  e_add_txtstr(35, 2, "Sort Files by:", o);
-  e_add_txtstr(4, 12, "Links on Files:", o);
-  e_add_txtstr(4, 16, "On Open:", o);
+  e_add_txtstr (4, 2, "Directories:", o);
+  e_add_txtstr (35, 13, "Wastebasket:", o);
+  e_add_txtstr (4, 7, "Move/Copy:", o);
+  e_add_txtstr (35, 8, "Remove:", o);
+  e_add_txtstr (35, 2, "Sort Files by:", o);
+  e_add_txtstr (4, 12, "Links on Files:", o);
+  e_add_txtstr (4, 16, "On Open:", o);
 
-  e_add_sswstr(5, 3, 12, AltF, 
-               f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0, 
-               "Show Hidden Files      ", o);
-  e_add_sswstr(5, 4, 12, AltD, 
-               f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0, 
-               "Show Hidden Directories", o);
-  e_add_sswstr(5, 5, 2, AltK, 
-               f->ed->flopt & FM_REKURSIVE_ACTIONS ? 1 : 0, 
-               "ReKursive Actions      ", o);
-  e_add_sswstr(5, 17, 0, AltC, 
-               f->ed->flopt & FM_CLOSE_WINDOW ? 1 : 0, 
-               "Close File Manager     ", o);
+  e_add_sswstr (5, 3, 12, AltF,
+		f->ed->flopt & FM_SHOW_HIDDEN_FILES ? 1 : 0,
+		"Show Hidden Files      ", o);
+  e_add_sswstr (5, 4, 12, AltD,
+		f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0,
+		"Show Hidden Directories", o);
+  e_add_sswstr (5, 5, 2, AltK,
+		f->ed->flopt & FM_REKURSIVE_ACTIONS ? 1 : 0,
+		"ReKursive Actions      ", o);
+  e_add_sswstr (5, 17, 0, AltC,
+		f->ed->flopt & FM_CLOSE_WINDOW ? 1 : 0,
+		"Close File Manager     ", o);
 
-  e_add_sswstr(36, 6, 0, AltR, 
-               f->ed->flopt & FM_REVERSE_ORDER ? 1 : 0, 
-               "Reverse Order    ", o);
+  e_add_sswstr (36, 6, 0, AltR,
+		f->ed->flopt & FM_REVERSE_ORDER ? 1 : 0,
+		"Reverse Order    ", o);
 
-  e_add_pswstr(0, 36, 14, 0, AltP, 0, "Prompt for Delete", o);
-  e_add_pswstr(0, 36, 15, 10, AltE, 0, "Delete at Exit   ", o);
-  e_add_pswstr(0, 36, 16, 8, AltL, f->ed->flopt & FM_PROMPT_DELETE ? 0 :
-               (f->ed->flopt & FM_DELETE_AT_EXIT ? 1 : 2), "Don't DeLete     ", o);
-  e_add_pswstr(1, 36, 3, 0, AltN, 0, "Name             ", o);
-  e_add_pswstr(1, 36, 4, 1, AltI, 0, "TIme             ", o);
-  e_add_pswstr(1, 36, 5, 0, AltB, f->ed->flopt & FM_SORT_NAME ? 1 :
-               (f->ed->flopt & FM_SORT_TIME ? 2 : 0), "Bytes            ", o);
-  e_add_pswstr(2, 5, 8, 12, AltQ, 0, "Prompt for eQual Files ", o);
-  e_add_pswstr(2, 5, 9, 1, AltV, 0, "OVerwrite equal Files  ", o);
-  e_add_pswstr(2, 5, 10, 4, AltT, f->ed->flopt & FM_MOVE_PROMPT ? 0 :
-               (f->ed->flopt & FM_MOVE_OVERWRITE ? 1 : 2), "Don'T overwrite        ", o);
-  e_add_pswstr(3, 5, 13, 4, AltH, 0, "Try Hardlink           ", o);
-  e_add_pswstr(3, 5, 14, 7, AltS, 
-               f->ed->flopt & FM_TRY_HARDLINK ? 1 : 0,
-               "Always Symbolic Link   ", o);
-  e_add_pswstr(4, 36, 9, 5, AltW, 0, "into Wastebasket ", o);
-  e_add_pswstr(4, 36, 10, 0, AltA, 0, "Absolute (Prompt)", o);
-  e_add_pswstr(4, 36, 11, 6, AltM, f->ed->flopt & FM_REMOVE_INTO_WB ? 0 :
-               (f->ed->flopt & FM_REMOVE_PROMPT ? 1 : 2), "No ProMpt        ", o);
-  e_add_bttstr(16, 19, 1, AltO, " Ok ", NULL, o);
-  e_add_bttstr(38, 19, -1, WPE_ESC, "Cancel", NULL, o);
+  e_add_pswstr (0, 36, 14, 0, AltP, 0, "Prompt for Delete", o);
+  e_add_pswstr (0, 36, 15, 10, AltE, 0, "Delete at Exit   ", o);
+  e_add_pswstr (0, 36, 16, 8, AltL, f->ed->flopt & FM_PROMPT_DELETE ? 0 :
+		(f->ed->flopt & FM_DELETE_AT_EXIT ? 1 : 2),
+		"Don't DeLete     ", o);
+  e_add_pswstr (1, 36, 3, 0, AltN, 0, "Name             ", o);
+  e_add_pswstr (1, 36, 4, 1, AltI, 0, "TIme             ", o);
+  e_add_pswstr (1, 36, 5, 0, AltB, f->ed->flopt & FM_SORT_NAME ? 1 :
+		(f->ed->flopt & FM_SORT_TIME ? 2 : 0), "Bytes            ",
+		o);
+  e_add_pswstr (2, 5, 8, 12, AltQ, 0, "Prompt for eQual Files ", o);
+  e_add_pswstr (2, 5, 9, 1, AltV, 0, "OVerwrite equal Files  ", o);
+  e_add_pswstr (2, 5, 10, 4, AltT, f->ed->flopt & FM_MOVE_PROMPT ? 0 :
+		(f->ed->flopt & FM_MOVE_OVERWRITE ? 1 : 2),
+		"Don'T overwrite        ", o);
+  e_add_pswstr (3, 5, 13, 4, AltH, 0, "Try Hardlink           ", o);
+  e_add_pswstr (3, 5, 14, 7, AltS,
+		f->ed->flopt & FM_TRY_HARDLINK ? 1 : 0,
+		"Always Symbolic Link   ", o);
+  e_add_pswstr (4, 36, 9, 5, AltW, 0, "into Wastebasket ", o);
+  e_add_pswstr (4, 36, 10, 0, AltA, 0, "Absolute (Prompt)", o);
+  e_add_pswstr (4, 36, 11, 6, AltM, f->ed->flopt & FM_REMOVE_INTO_WB ? 0 :
+		(f->ed->flopt & FM_REMOVE_PROMPT ? 1 : 2),
+		"No ProMpt        ", o);
+  e_add_bttstr (16, 19, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (38, 19, -1, WPE_ESC, "Cancel", NULL, o);
 
-  ret = e_opt_kst(o);
-  if(ret != WPE_ESC)
-  {
-    f->ed->flopt = o->sstr[0]->num +
-      (o->sstr[1]->num << 1) +
-      (o->sstr[2]->num ? FM_REKURSIVE_ACTIONS : 0) +
-      (o->sstr[3]->num ? FM_CLOSE_WINDOW : 0) +
-      (o->sstr[4]->num ? FM_REVERSE_ORDER : 0) +
-      (o->pstr[0]->num ? (o->pstr[0]->num == 1 ? 4 : 0) : 8) +
-      (o->pstr[2]->num ? (o->pstr[2]->num == 1 ? 16 : 0) : 32) +
-      (o->pstr[4]->num ? (o->pstr[4]->num == 1 ? 128 : 0) : 64) +
-      (o->pstr[1]->num ? (o->pstr[1]->num == 1 ? 01000 : 02000) : 0) +
-      (o->pstr[3]->num ? FM_TRY_HARDLINK : 0);
-  }
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      f->ed->flopt = o->sstr[0]->num +
+	(o->sstr[1]->num << 1) +
+	(o->sstr[2]->num ? FM_REKURSIVE_ACTIONS : 0) +
+	(o->sstr[3]->num ? FM_CLOSE_WINDOW : 0) +
+	(o->sstr[4]->num ? FM_REVERSE_ORDER : 0) +
+	(o->pstr[0]->num ? (o->pstr[0]->num == 1 ? 4 : 0) : 8) +
+	(o->pstr[2]->num ? (o->pstr[2]->num == 1 ? 16 : 0) : 32) +
+	(o->pstr[4]->num ? (o->pstr[4]->num == 1 ? 128 : 0) : 64) +
+	(o->pstr[1]->num ? (o->pstr[1]->num == 1 ? 01000 : 02000) : 0) +
+	(o->pstr[3]->num ? FM_TRY_HARDLINK : 0);
+    }
 
-  freeostr(o);
-  return(0);
+  freeostr (o);
+  return (0);
 }
 
-int WpeDirDelOptions(FENSTER * f)
+int
+WpeDirDelOptions (FENSTER * f)
 {
-  int             ret;
-  W_OPTSTR       *o = e_init_opt_kst(f);
+  int ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
 
-  if(o == NULL)
-    return(1);
+  if (o == NULL)
+    return (1);
 
   o->xa = 19;
   o->ya = 11;
@@ -3021,276 +3123,285 @@ int WpeDirDelOptions(FENSTER * f)
   o->bgsw = AltO;
   o->name = "Message";
   o->crsw = AltO;
-  e_add_txtstr(4, 2, "Delete Directory:", o);
-  e_add_pswstr(0, 5, 3, 0, AltD, 0, "Delete without Prompt", o);
-  e_add_pswstr(0, 5, 4, 0, AltP, 1, "Prompt for Files     ", o);
-  e_add_bttstr(7, 6, 1, AltO, " Ok ", NULL, o);
-  e_add_bttstr(22, 6, -1, WPE_ESC, "Cancel", NULL, o);
+  e_add_txtstr (4, 2, "Delete Directory:", o);
+  e_add_pswstr (0, 5, 3, 0, AltD, 0, "Delete without Prompt", o);
+  e_add_pswstr (0, 5, 4, 0, AltP, 1, "Prompt for Files     ", o);
+  e_add_bttstr (7, 6, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (22, 6, -1, WPE_ESC, "Cancel", NULL, o);
 
-  ret = e_opt_kst(o);
+  ret = e_opt_kst (o);
 
   ret = (ret == WPE_ESC) ? -1 : o->pstr[0]->num;
 
-  freeostr(o);
-  return(ret);
+  freeostr (o);
+  return (ret);
 }
 
-int WpeShell(FENSTER * f)
+int
+WpeShell (FENSTER * f)
 {
-  view            *outp = NULL;
-  int             g[4];
+  view *outp = NULL;
+  int g[4];
 
-  if (!WpeIsXwin())
-  {
-    outp = e_open_view(0, 0, MAXSCOL - 1, MAXSLNS - 1, f->fb->ws, 1);
-    fk_locate(0, 0);
-    fk_cursor(1);
+  if (!WpeIsXwin ())
+    {
+      outp = e_open_view (0, 0, MAXSCOL - 1, MAXSLNS - 1, f->fb->ws, 1);
+      fk_locate (0, 0);
+      fk_cursor (1);
 #if  MOUSE
-    g[0] = 2;
-    fk_mouse(g);
+      g[0] = 2;
+      fk_mouse (g);
 #endif
-    (*e_u_s_sys_ini) ();
-  }
+      (*e_u_s_sys_ini) ();
+    }
   (*e_u_system) (user_shell);
-  if(!WpeIsXwin())
-  {
-    (*e_u_s_sys_end) ();
-    e_close_view(outp, 1);
-    fk_cursor(0);
+  if (!WpeIsXwin ())
+    {
+      (*e_u_s_sys_end) ();
+      e_close_view (outp, 1);
+      fk_cursor (0);
 #if  MOUSE
-    g[0] = 1;
-    fk_mouse(g);
+      g[0] = 1;
+      fk_mouse (g);
 #endif
-  }
-  return(0);
+    }
+  return (0);
 }
 
 /*   print file */
 #ifndef NOPRINTER
-int WpePrintFile(FENSTER *f)
+int
+WpePrintFile (FENSTER * f)
 {
- char           *str, *dp;
- int             c, sins = f->ins;
+  char *str, *dp;
+  int c, sins = f->ins;
 
- for (c = f->ed->mxedt; c > 0 && !DTMD_ISTEXT(f->ed->f[c]->dtmd); c--)
-  ;
- if (c <= 0)
-   return(0);
- f = f->ed->f[c];
+  for (c = f->ed->mxedt; c > 0 && !DTMD_ISTEXT (f->ed->f[c]->dtmd); c--)
+    ;
+  if (c <= 0)
+    return (0);
+  f = f->ed->f[c];
 
- if (strcmp(f->ed->print_cmd, "") == 0)
- {
-  return(e_error(e_msg[ERR_NOPRINT], 0, f->fb));
- }
- if ((str = malloc(strlen(f->datnam) + 32 )) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  if (strcmp (f->ed->print_cmd, "") == 0)
+    {
+      return (e_error (e_msg[ERR_NOPRINT], 0, f->fb));
+    }
+  if ((str = malloc (strlen (f->datnam) + 32)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
- sprintf(str, "File: %s\nDo you want to print it?", f->datnam);
- c = e_message(1, str, f);
- free(str);
- if (c != 'Y')
-  return(0);
+  sprintf (str, "File: %s\nDo you want to print it?", f->datnam);
+  c = e_message (1, str, f);
+  free (str);
+  if (c != 'Y')
+    return (0);
 
- dp = f->dirct;
- f->dirct = e_tmp_dir;
- f->ins = 0;
+  dp = f->dirct;
+  f->dirct = e_tmp_dir;
+  f->ins = 0;
 
- e_save(f);
+  e_save (f);
 
- f->dirct = dp;
- f->ins = sins;
+  f->dirct = dp;
+  f->ins = sins;
 
- if ((str = malloc(strlen(e_tmp_dir) + 7 +
-                   strlen(f->ed->print_cmd) + strlen(f->datnam) )) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  if ((str = malloc (strlen (e_tmp_dir) + 7 +
+		     strlen (f->ed->print_cmd) + strlen (f->datnam))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
- sprintf(str, "cd %s; %s %s", e_tmp_dir, f->ed->print_cmd, f->datnam);
- if (system(str))
-  e_error(e_msg[ERR_NOTINSTALL], 0, f->fb);
+  sprintf (str, "cd %s; %s %s", e_tmp_dir, f->ed->print_cmd, f->datnam);
+  if (system (str))
+    e_error (e_msg[ERR_NOTINSTALL], 0, f->fb);
 
- sprintf(str, "%s/%s", e_tmp_dir, f->datnam);
- if (remove(str))
-  e_error(e_msg[ERR_DELFILE], 0, f->ed->fb);
+  sprintf (str, "%s/%s", e_tmp_dir, f->datnam);
+  if (remove (str))
+    e_error (e_msg[ERR_DELFILE], 0, f->ed->fb);
 
- free(str);
- return(0);
+  free (str);
+  return (0);
 }
 #else
-int WpePrintFile(FENSTER * f)
+int
+WpePrintFile (FENSTER * f)
 {
-  return(e_error(e_msg[ERR_NOPRINT], 0, f->fb));
+  return (e_error (e_msg[ERR_NOPRINT], 0, f->fb));
 }
 #endif
 
-struct dirfile *WpeSearchFiles(FENSTER *f, char *dirct, char *file, char *string,
-                               struct dirfile *df, int sw)
+struct dirfile *
+WpeSearchFiles (FENSTER * f, char *dirct, char *file, char *string,
+		struct dirfile *df, int sw)
 {
   struct dirfile *dd;
-  char          **tname, *tp, *tmp, *tmp2;
-  int             i;
-  static int      rec = 0;
+  char **tname, *tp, *tmp, *tmp2;
+  int i;
+  static int rec = 0;
 
-  if(rec > MAXREC)
-    return(df);
+  if (rec > MAXREC)
+    return (df);
 
   /* if not absolute path is given */
-  if(*dirct != DIRC)
-  {
-    tmp2 = WpeGetCurrentDir(f->ed);
+  if (*dirct != DIRC)
+    {
+      tmp2 = WpeGetCurrentDir (f->ed);
 
-    tmp = realloc(tmp2, strlen(tmp2) + strlen(dirct) + 4);
-    if(tmp == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+      tmp = realloc (tmp2, strlen (tmp2) + strlen (dirct) + 4);
+      if (tmp == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-    tmp2 = tmp;
-    if(tmp2[strlen(tmp2) - 1] != DIRC)
-      sprintf(tmp2 + strlen(tmp2), "%c%s%c", DIRC, dirct, DIRC);
-    else
-      sprintf(tmp2 + strlen(tmp2), "%s%c", dirct, DIRC);
-  }
+      tmp2 = tmp;
+      if (tmp2[strlen (tmp2) - 1] != DIRC)
+	sprintf (tmp2 + strlen (tmp2), "%c%s%c", DIRC, dirct, DIRC);
+      else
+	sprintf (tmp2 + strlen (tmp2), "%s%c", dirct, DIRC);
+    }
   else
-  {
-    if((tmp2 = malloc(strlen(dirct) + 2)) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+    {
+      if ((tmp2 = malloc (strlen (dirct) + 2)) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-    if(dirct[strlen(dirct) - 1] != DIRC)
-      sprintf(tmp2, "%s%c", dirct, DIRC);
-    else
-      sprintf(tmp2, "%s", dirct);
-  }
+      if (dirct[strlen (dirct) - 1] != DIRC)
+	sprintf (tmp2, "%s%c", dirct, DIRC);
+      else
+	sprintf (tmp2, "%s", dirct);
+    }
 
   /* assemble total path, dir + filename */
-  if((tmp = malloc(strlen(tmp2) + strlen(file) + 2)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-  sprintf(tmp, "%s%s", tmp2, file);
+  if ((tmp = malloc (strlen (tmp2) + strlen (file) + 2)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  sprintf (tmp, "%s%s", tmp2, file);
 
   /* initialise structure, only once */
-  if(df == NULL)
-  {
-    if((df = malloc(sizeof(struct dirfile))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  if (df == NULL)
+    {
+      if ((df = malloc (sizeof (struct dirfile))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-    df->anz = 0;
-    if((df->name = malloc(sizeof(char *))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-  }
+      df->anz = 0;
+      if ((df->name = malloc (sizeof (char *))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+    }
 
   /* search all matching file */
-  dd = e_find_files(tmp, 0);
+  dd = e_find_files (tmp, 0);
 
   /* if we found something */
-  if(dd && dd->anz > 0)
-  {
-
-    /* file find */
-    if(!(sw & 1024))
+  if (dd && dd->anz > 0)
     {
-      for(i = 0; i < dd->anz; i++)
-      {
-        if((tp = malloc(strlen(tmp2) + strlen(dd->name[i]) + 2)) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-        sprintf(tp, "%s%s", tmp2, dd->name[i]);
+      /* file find */
+      if (!(sw & 1024))
+	{
+	  for (i = 0; i < dd->anz; i++)
+	    {
+	      if ((tp =
+		   malloc (strlen (tmp2) + strlen (dd->name[i]) + 2)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-        df->anz++;
+	      sprintf (tp, "%s%s", tmp2, dd->name[i]);
 
-        if((tname = realloc(df->name, df->anz * sizeof(char *))) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+	      df->anz++;
 
-        df->name = tname;
-        df->name[df->anz - 1] = tp;
-      }
+	      if ((tname =
+		   realloc (df->name, df->anz * sizeof (char *))) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+	      df->name = tname;
+	      df->name[df->anz - 1] = tp;
+	    }
+	}
+      /* file grep */
+      else
+	{
+	  for (i = 0; i < dd->anz; i++)
+	    {
+	      if ((tp =
+		   malloc (strlen (tmp2) + strlen (dd->name[i]) + 2)) == NULL)
+		e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+	      sprintf (tp, "%s%s", tmp2, dd->name[i]);
+
+	      if (WpeGrepFile (tp, string, sw))
+		{
+		  df->anz++;
+		  if ((tname =
+		       realloc (df->name, df->anz * sizeof (char *))) == NULL)
+		    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
+
+		  df->name = tname;
+		  df->name[df->anz - 1] = tp;
+		}
+	      else
+		free (tp);
+	    }
+	}
     }
-    /* file grep */
-    else
-    {
-      for(i = 0; i < dd->anz; i++)
-      {
-        if((tp = malloc(strlen(tmp2) + strlen(dd->name[i]) + 2)) == NULL)
-          e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-        sprintf(tp, "%s%s", tmp2, dd->name[i]);
-
-        if(WpeGrepFile(tp, string, sw))
-        {
-          df->anz++;
-          if((tname = realloc(df->name, df->anz * sizeof(char *))) == NULL)
-            e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
-
-          df->name = tname;
-          df->name[df->anz - 1] = tp;
-        }
-        else
-          free(tp);
-      }
-    }
-  }
-
-  freedf(dd);
-  free(tmp2);
-  free(tmp);
+  freedf (dd);
+  free (tmp2);
+  free (tmp);
 
   /* whether recursive action */
-  if(!(sw & 512))
-    return(df);
+  if (!(sw & 512))
+    return (df);
 
-  if((tmp = malloc(strlen(dirct) + strlen(SUDIR) + 2)) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->ed->fb);
+  if ((tmp = malloc (strlen (dirct) + strlen (SUDIR) + 2)) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->ed->fb);
 
-  if(dirct[strlen(dirct) - 1] != DIRC)
-    sprintf(tmp, "%s%c%s", dirct, DIRC, SUDIR);
+  if (dirct[strlen (dirct) - 1] != DIRC)
+    sprintf (tmp, "%s%c%s", dirct, DIRC, SUDIR);
   else
-    sprintf(tmp, "%s%s", dirct, SUDIR);
+    sprintf (tmp, "%s%s", dirct, SUDIR);
 
   /* find directories */
-  dd = e_find_dir(tmp, 0);
+  dd = e_find_dir (tmp, 0);
 
-  free(tmp);
+  free (tmp);
 
-  if(!dd)
-    return(df);
+  if (!dd)
+    return (df);
 
   rec++;
-  for(i = 0; i < dd->anz; i++)
-  {
-    if((tmp = malloc(strlen(dirct) + strlen(dd->name[i]) + 3)) == NULL)
+  for (i = 0; i < dd->anz; i++)
     {
-      e_error(e_msg[ERR_LOWMEM], 0, f->ed->fb);
-      rec--;
-      freedf(dd);
-      return(df);
+      if ((tmp = malloc (strlen (dirct) + strlen (dd->name[i]) + 3)) == NULL)
+	{
+	  e_error (e_msg[ERR_LOWMEM], 0, f->ed->fb);
+	  rec--;
+	  freedf (dd);
+	  return (df);
+	}
+
+      if (dirct[strlen (dirct) - 1] != DIRC)
+	sprintf (tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
+      else
+	sprintf (tmp, "%s%s", dirct, dd->name[i]);
+
+      df = WpeSearchFiles (f, tmp, file, string, df, sw);
+      free (tmp);
     }
 
-    if(dirct[strlen(dirct) - 1] != DIRC)
-      sprintf(tmp, "%s%c%s", dirct, DIRC, dd->name[i]);
-    else
-      sprintf(tmp, "%s%s", dirct, dd->name[i]);
-
-    df = WpeSearchFiles(f, tmp, file, string, df, sw);
-    free(tmp);
-  }
-
-  freedf(dd);
+  freedf (dd);
   rec--;
-  return(df);
+  return (df);
 
 }
 
 
-int WpeGrepWindow(FENSTER * f)
+int
+WpeGrepWindow (FENSTER * f)
 {
-  FIND           *fd = &(f->ed->fd);
-  int             ret;
-  char            strTemp[80];
-  W_OPTSTR       *o = e_init_opt_kst(f);
+  FIND *fd = &(f->ed->fd);
+  int ret;
+  char strTemp[80];
+  W_OPTSTR *o = e_init_opt_kst (f);
 
-  if(!o)
-    return(-1);
-  if(e_blck_dup(strTemp, f))
-  {
-    strcpy(fd->search, strTemp);
-    fd->sn = strlen(fd->search);
-  }
+  if (!o)
+    return (-1);
+  if (e_blck_dup (strTemp, f))
+    {
+      strcpy (fd->search, strTemp);
+      fd->sn = strlen (fd->search);
+    }
   o->xa = 7;
   o->ya = 3;
   o->xe = 63;
@@ -3298,45 +3409,49 @@ int WpeGrepWindow(FENSTER * f)
   o->bgsw = 0;
   o->name = "Grep";
   o->crsw = AltO;
-  e_add_txtstr(4, 4, "Options:", o);
-  e_add_wrstr(4, 2, 18, 2, 35, 128, 0, AltT, "Text to Find:", fd->search, &f->ed->sdf, o);
-  e_add_wrstr(4, 10, 17, 10, 36, 128, 0, AltF, "File:", fd->file, &f->ed->fdf, o);
-  e_add_wrstr(4, 12, 17, 12, 36, WPE_PATHMAX, 0, AltD, "Directory:", fd->dirct, &f->ed->ddf, o);
-  e_add_sswstr(5, 5, 0, AltC, fd->sw & 128 ? 1 : 0, "Case sensitive    ", o);
-  e_add_sswstr(5, 6, 0, AltW, fd->sw & 64 ? 1 : 0, "Whole words only  ", o);
-  e_add_sswstr(5, 7, 0, AltR, fd->sw & 32 ? 1 : 0, "Regular expression", o);
-  e_add_sswstr(5, 8, 0, AltS, 0, "Search Recursive  ", o);
-  e_add_bttstr(16, 14, 1, AltO, " Ok ", NULL, o);
-  e_add_bttstr(34, 14, -1, WPE_ESC, "Cancel", NULL, o);
-  ret = e_opt_kst(o);
-  if(ret != WPE_ESC)
-  {
-    fd->sw = 1024 + (o->sstr[0]->num << 7) + (o->sstr[1]->num << 6) +
-      (o->sstr[2]->num << 5) + (o->sstr[3]->num << 9);
-    strcpy(fd->search, o->wstr[0]->txt);
-    fd->sn = strlen(fd->search);
-    strcpy(fd->file, o->wstr[1]->txt);
-    if (fd->dirct)
+  e_add_txtstr (4, 4, "Options:", o);
+  e_add_wrstr (4, 2, 18, 2, 35, 128, 0, AltT, "Text to Find:", fd->search,
+	       &f->ed->sdf, o);
+  e_add_wrstr (4, 10, 17, 10, 36, 128, 0, AltF, "File:", fd->file,
+	       &f->ed->fdf, o);
+  e_add_wrstr (4, 12, 17, 12, 36, WPE_PATHMAX, 0, AltD, "Directory:",
+	       fd->dirct, &f->ed->ddf, o);
+  e_add_sswstr (5, 5, 0, AltC, fd->sw & 128 ? 1 : 0, "Case sensitive    ", o);
+  e_add_sswstr (5, 6, 0, AltW, fd->sw & 64 ? 1 : 0, "Whole words only  ", o);
+  e_add_sswstr (5, 7, 0, AltR, fd->sw & 32 ? 1 : 0, "Regular expression", o);
+  e_add_sswstr (5, 8, 0, AltS, 0, "Search Recursive  ", o);
+  e_add_bttstr (16, 14, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (34, 14, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
     {
-     free(fd->dirct);
+      fd->sw = 1024 + (o->sstr[0]->num << 7) + (o->sstr[1]->num << 6) +
+	(o->sstr[2]->num << 5) + (o->sstr[3]->num << 9);
+      strcpy (fd->search, o->wstr[0]->txt);
+      fd->sn = strlen (fd->search);
+      strcpy (fd->file, o->wstr[1]->txt);
+      if (fd->dirct)
+	{
+	  free (fd->dirct);
+	}
+      fd->dirct = WpeStrdup (o->wstr[2]->txt);
     }
-    fd->dirct = WpeStrdup(o->wstr[2]->txt);
-  }
-  freeostr(o);
-  if(ret != WPE_ESC)
-    ret = e_data_first(2, f->ed, fd->dirct);
-  return(ret);
+  freeostr (o);
+  if (ret != WPE_ESC)
+    ret = e_data_first (2, f->ed, fd->dirct);
+  return (ret);
 }
 
 
-int WpeFindWindow(FENSTER * f)
+int
+WpeFindWindow (FENSTER * f)
 {
-  FIND           *fd = &(f->ed->fd);
-  int             ret;
-  W_OPTSTR       *o = e_init_opt_kst(f);
+  FIND *fd = &(f->ed->fd);
+  int ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
 
-  if(!o)
-    return(-1);
+  if (!o)
+    return (-1);
   o->xa = 7;
   o->ya = 3;
   o->xe = 61;
@@ -3344,283 +3459,304 @@ int WpeFindWindow(FENSTER * f)
   o->bgsw = 0;
   o->name = "Find File";
   o->crsw = AltO;
-  e_add_txtstr(4, 6, "Options:", o);
-  e_add_wrstr(4, 2, 15, 2, 36, 128, 0, AltF, "File:", fd->file, &f->ed->fdf, o);
-  e_add_wrstr(4, 4, 15, 4, 36, WPE_PATHMAX, 0, AltD, "Directory:", fd->dirct, &f->ed->ddf, o);
-  e_add_sswstr(5, 7, 0, AltS, 1, "Search Recursive  ", o);
-  e_add_bttstr(13, 9, 1, AltO, " Ok ", NULL, o);
-  e_add_bttstr(33, 9, -1, WPE_ESC, "Cancel", NULL, o);
-  ret = e_opt_kst(o);
-  if(ret != WPE_ESC)
-  {
-    fd->sw = (o->sstr[0]->num << 9);
-    strcpy(fd->file, o->wstr[0]->txt);
-    if (fd->dirct)
+  e_add_txtstr (4, 6, "Options:", o);
+  e_add_wrstr (4, 2, 15, 2, 36, 128, 0, AltF, "File:", fd->file, &f->ed->fdf,
+	       o);
+  e_add_wrstr (4, 4, 15, 4, 36, WPE_PATHMAX, 0, AltD, "Directory:", fd->dirct,
+	       &f->ed->ddf, o);
+  e_add_sswstr (5, 7, 0, AltS, 1, "Search Recursive  ", o);
+  e_add_bttstr (13, 9, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (33, 9, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
     {
-     free(fd->dirct);
+      fd->sw = (o->sstr[0]->num << 9);
+      strcpy (fd->file, o->wstr[0]->txt);
+      if (fd->dirct)
+	{
+	  free (fd->dirct);
+	}
+      fd->dirct = WpeStrdup (o->wstr[1]->txt);
     }
-    fd->dirct = WpeStrdup(o->wstr[1]->txt);
-  }
-  freeostr(o);
-  if(ret != WPE_ESC)
-    ret = e_data_first(3, f->ed, fd->dirct);
-  return(ret);
+  freeostr (o);
+  if (ret != WPE_ESC)
+    ret = e_data_first (3, f->ed, fd->dirct);
+  return (ret);
 }
 
-int e_ed_man(unsigned char *str, FENSTER * f)
+int
+e_ed_man (unsigned char *str, FENSTER * f)
 {
-  char            command[256], tstr[_POSIX_PATH_MAX];
-  char            cc, hstr[80], nstr[10];
-  int             mdsv = f->ed->dtmd, bg, i, j = 0;
-  BUFFER         *b = 0;
+  char command[256], tstr[_POSIX_PATH_MAX];
+  char cc, hstr[80], nstr[10];
+  int mdsv = f->ed->dtmd, bg, i, j = 0;
+  BUFFER *b = 0;
 
-  if(!str)
-    return(0);
-  while(isspace(*str++));
-  if(!*--str)
-    return(0);
-  for(i = f->ed->mxedt; i >= 0; i--)
-  {
-    if(!strcmp(f->ed->f[i]->datnam, (const char *)str))
+  if (!str)
+    return (0);
+  while (isspace (*str++));
+  if (!*--str)
+    return (0);
+  for (i = f->ed->mxedt; i >= 0; i--)
     {
-      e_switch_window(f->ed->edt[i], f);
-      return(0);
+      if (!strcmp (f->ed->f[i]->datnam, (const char *) str))
+	{
+	  e_switch_window (f->ed->edt[i], f);
+	  return (0);
+	}
     }
-  }
-  WpeMouseChangeShape(WpeWorkingShape);
-  sprintf(tstr, "%s/%s", e_tmp_dir, str);
-  for(i = 0; (hstr[i] = str[i]) && str[i] != '(' && str[i] != ')'; i++);
+  WpeMouseChangeShape (WpeWorkingShape);
+  sprintf (tstr, "%s/%s", e_tmp_dir, str);
+  for (i = 0; (hstr[i] = str[i]) && str[i] != '(' && str[i] != ')'; i++);
   hstr[i] = '\0';
-  if(str[i] == '(')
-  {
-    for(++i; (nstr[j] = str[i]) && str[i] != ')' && str[i] != '('; i++, j++);
+  if (str[i] == '(')
+    {
+      for (++i; (nstr[j] = str[i]) && str[i] != ')' && str[i] != '(';
+	   i++, j++);
 
-    /* Some SEE ALSO's are list as "foobar(3X)" but are in section 3 not 3X.
-       This is a quick hack to fix the problem.  -- Dennis */
-    if(isdigit(nstr[0]))
-      j = 1;
-  }
+      /* Some SEE ALSO's are list as "foobar(3X)" but are in section 3 not 3X.
+         This is a quick hack to fix the problem.  -- Dennis */
+      if (isdigit (nstr[0]))
+	j = 1;
+    }
   nstr[j] = '\0';
 
-  while(1)
-  {
+  while (1)
+    {
 #ifdef MAN_S_OPT
-    if(!nstr[0])
-      sprintf(command, " man %s > \'%s\' 2> /dev/null", hstr, tstr);
-    else
-      sprintf(command, " man -s %s %s > \'%s\' 2> /dev/null", nstr, hstr, tstr);
+      if (!nstr[0])
+	sprintf (command, " man %s > \'%s\' 2> /dev/null", hstr, tstr);
+      else
+	sprintf (command, " man -s %s %s > \'%s\' 2> /dev/null", nstr, hstr,
+		 tstr);
 #else
-    sprintf(command, " man %s %s > \'%s\' 2> /dev/null", nstr, hstr, tstr);
+      sprintf (command, " man %s %s > \'%s\' 2> /dev/null", nstr, hstr, tstr);
 #endif
-    int ret = system(command);
-	if (WIFSIGNALED(ret) && (WTERMSIG(ret) == SIGINT || WTERMSIG(ret) == SIGQUIT)) {
-		printf("System call command %s resulted in an interrupt.\n%s\n", 
-			command,
-			"Program will quit executing commands.\n");
-		break;
-	} else if (ret == 127) {
-		printf("System call command %s failed with code 127\n%s\n%s\n%s\n", 
-			command, 
-			"This could mean one of two things:",
-			"1. No shell was available (should never happen unless using chroot)",
-			"2. The command returned 127.\n");
-		break;
-	} else if (ret != 0) {
-		printf("System call command %s failed. Return code = %i.\n", command, ret);
-		break;
+      int ret = system (command);
+      if (WIFSIGNALED (ret)
+	  && (WTERMSIG (ret) == SIGINT || WTERMSIG (ret) == SIGQUIT))
+	{
+	  printf ("System call command %s resulted in an interrupt.\n%s\n",
+		  command, "Program will quit executing commands.\n");
+	  break;
 	}
-    chmod(tstr, 0400);
-    f->ed->dtmd = DTMD_HELP;
-    e_edit(f->ed, tstr);
-    f->ed->dtmd = mdsv;
-    f = f->ed->f[f->ed->mxedt];
-    b = f->b;
-    if(b->mxlines > 1 || !nstr[1])
-      break;
-    nstr[1] = '\0';
-    chmod(tstr, 0600);
-    remove(tstr);
-    e_close_window(f);
-  }
-  if(b->mxlines == 1 && b->bf[0].len == 0)
-  {
-    e_ins_nchar(f->b, f->s, (unsigned char *)"No manual entry for ", 0, 0, 20);
-    e_ins_nchar(f->b, f->s, (unsigned char *)hstr, b->b.x, b->b.y, strlen(hstr));
-    e_ins_nchar(f->b, f->s, (unsigned char *)".", b->b.x, b->b.y, 1);
-  }
-  for(i = 0; i < b->mxlines; i++)
-    if(b->bf[i].len == 0 && (i == 0 || b->bf[i - 1].len == 0))
-    {
-      e_del_line(i, b, f->s);
-      i--;
+      else if (ret == 127)
+	{
+	  printf ("System call command %s failed with code 127\n%s\n%s\n%s\n",
+		  command,
+		  "This could mean one of two things:",
+		  "1. No shell was available (should never happen unless using chroot)",
+		  "2. The command returned 127.\n");
+	  break;
+	}
+      else if (ret != 0)
+	{
+	  printf ("System call command %s failed. Return code = %i.\n",
+		  command, ret);
+	  break;
+	}
+      chmod (tstr, 0400);
+      f->ed->dtmd = DTMD_HELP;
+      e_edit (f->ed, tstr);
+      f->ed->dtmd = mdsv;
+      f = f->ed->f[f->ed->mxedt];
+      b = f->b;
+      if (b->mxlines > 1 || !nstr[1])
+	break;
+      nstr[1] = '\0';
+      chmod (tstr, 0600);
+      remove (tstr);
+      e_close_window (f);
     }
-  for(bg = 0; bg < b->bf[0].len && isspace(b->bf[0].s[bg]); bg++);
-  if(bg == b->bf[0].len)
-    bg = 0;
-  for(i = 0;
-      i < b->mxlines &&
-      WpeStrnccmp((const char *)b->bf[i].s + bg, (const char *)"\017SEE\005 \017ALSO\005", 12) &&
-      WpeStrnccmp((const char *)b->bf[i].s + bg, (const char *)"SEE ALSO", 8);
-      i++);
-  if(i < b->mxlines)
-    for(bg = 0, i++; i < b->mxlines && b->bf[i].len > 0 && bg >= 0; i++)
+  if (b->mxlines == 1 && b->bf[0].len == 0)
     {
-      bg = 0;
-      while(b->bf[i].s[bg])
+      e_ins_nchar (f->b, f->s, (unsigned char *) "No manual entry for ", 0, 0,
+		   20);
+      e_ins_nchar (f->b, f->s, (unsigned char *) hstr, b->b.x, b->b.y,
+		   strlen (hstr));
+      e_ins_nchar (f->b, f->s, (unsigned char *) ".", b->b.x, b->b.y, 1);
+    }
+  for (i = 0; i < b->mxlines; i++)
+    if (b->bf[i].len == 0 && (i == 0 || b->bf[i - 1].len == 0))
       {
-        for(; isspace(b->bf[i].s[bg]); bg++);
-        if(!b->bf[i].s[bg])
-          continue;
-        for(j = bg + 1;
-            b->bf[i].s[j] && b->bf[i].s[j] != ',' && b->bf[i].s[j] != '.' &&
-            b->bf[i].s[j] != ' ' && b->bf[i].s[j] != '(';
-            j++);
-        if(b->bf[i].s[j] != '(')
-        {
-          bg = -1;
-          break;
-        }
-        if(b->bf[i].s[j - 1] == 5)
-          e_del_nchar(b, f->s, j - 1, i, 1);
-        for(j++; b->bf[i].s[j] && b->bf[i].s[j] != ',' && b->bf[i].s[j] != '.';
-            j++);
-        if(b->bf[i].s[bg] == 15)
-          b->bf[i].s[bg] = HFB;
-        else
-        {
-          cc = HFB;
-          e_ins_nchar(b, f->s, (unsigned char *)&cc, bg, i, 1);
-          j++;
-        }
-        cc = HED;
-        e_ins_nchar(b, f->s, (unsigned char *)&cc, j, i, 1);
-        j++;
-        if(b->bf[i].s[j])
-          j++;
-        bg = j;
+	e_del_line (i, b, f->s);
+	i--;
       }
-    }
+  for (bg = 0; bg < b->bf[0].len && isspace (b->bf[0].s[bg]); bg++);
+  if (bg == b->bf[0].len)
+    bg = 0;
+  for (i = 0;
+       i < b->mxlines &&
+       WpeStrnccmp ((const char *) b->bf[i].s + bg,
+		    (const char *) "\017SEE\005 \017ALSO\005", 12)
+       && WpeStrnccmp ((const char *) b->bf[i].s + bg,
+		       (const char *) "SEE ALSO", 8); i++);
+  if (i < b->mxlines)
+    for (bg = 0, i++; i < b->mxlines && b->bf[i].len > 0 && bg >= 0; i++)
+      {
+	bg = 0;
+	while (b->bf[i].s[bg])
+	  {
+	    for (; isspace (b->bf[i].s[bg]); bg++);
+	    if (!b->bf[i].s[bg])
+	      continue;
+	    for (j = bg + 1;
+		 b->bf[i].s[j] && b->bf[i].s[j] != ',' && b->bf[i].s[j] != '.'
+		 && b->bf[i].s[j] != ' ' && b->bf[i].s[j] != '('; j++);
+	    if (b->bf[i].s[j] != '(')
+	      {
+		bg = -1;
+		break;
+	      }
+	    if (b->bf[i].s[j - 1] == 5)
+	      e_del_nchar (b, f->s, j - 1, i, 1);
+	    for (j++;
+		 b->bf[i].s[j] && b->bf[i].s[j] != ','
+		 && b->bf[i].s[j] != '.'; j++);
+	    if (b->bf[i].s[bg] == 15)
+	      b->bf[i].s[bg] = HFB;
+	    else
+	      {
+		cc = HFB;
+		e_ins_nchar (b, f->s, (unsigned char *) &cc, bg, i, 1);
+		j++;
+	      }
+	    cc = HED;
+	    e_ins_nchar (b, f->s, (unsigned char *) &cc, j, i, 1);
+	    j++;
+	    if (b->bf[i].s[j])
+	      j++;
+	    bg = j;
+	  }
+      }
   b->b.x = b->b.y = 0;
-  chmod(tstr, 0600);
-  remove(tstr);
-  WpeMouseRestoreShape();
-  e_schirm(f, 1);
-  return(0);
+  chmod (tstr, 0600);
+  remove (tstr);
+  WpeMouseRestoreShape ();
+  e_schirm (f, 1);
+  return (0);
 }
 
-int e_funct(FENSTER * f)
+int
+e_funct (FENSTER * f)
 {
- char            str[80];
+  char str[80];
 
- if (f->ed->hdf && f->ed->hdf->anz > 0)
-  strcpy(str, f->ed->hdf->name[0]);
- else
-  str[0] = '\0';
- if (e_add_arguments(str, "Function", f, 0, AltF, &f->ed->hdf))
- {
-  f->ed->hdf = e_add_df(str, f->ed->hdf);
-  e_ed_man((unsigned char *)str, f);
- }
- return(0);
-}
-
-struct dirfile *e_make_funct(char *man)
-{
- struct dirfile *df = NULL, *dout = malloc(sizeof(struct dirfile));
- char *sustr, *subpath, *manpath;
- int ret = 0, n, i = 0, j, k, l = 0;
-
- manpath = NULL;
- WpeMouseChangeShape(WpeWorkingShape);
- dout->anz = 0;
- dout->name = NULL;
- if (getenv("MANPATH"))
- {
-  manpath = strdup(getenv("MANPATH"));
- }
- if ((!manpath) || (manpath[0] == '\0'))
- {
-  manpath = strdup("/usr/man:/usr/share/man:/usr/X11R6/man:/usr/local/man");
- }
- /* Allocate the maximum possible rather than continually realloc. */
- sustr = malloc(strlen(manpath) + 10);
- while (manpath[i])
- {
-  subpath = manpath + i;
-  for (n = 0; (manpath[i]) && (manpath[i] != PTHD); i++, n++);
-  if (manpath[i] == PTHD)
-  {
-   manpath[i] = '\0';
-   i++;
-  }
-  sprintf(sustr, "%s/man%s/*", subpath, man);
-  df = e_find_files(sustr, 0);
-  if (!df->anz)
-  {
-   freedf(df);
-   continue;
-  }
-  for (j = 0; j < df->anz; j++)
-  {
-   k = strlen(df->name[j]) - 1;
-
-   /* If the file is gzipped strip the .gz ending. */
-   if ((k > 2) && (strcmp(df->name[j] + k - 2, ".gz") == 0))
-   {
-    k -= 3;
-    *(df->name[j] + k + 1) = '\0';
-   }
-   else if ((k > 3) && (strcmp(df->name[j] + k - 3, ".bz2") == 0))
-   {
-    k -= 4;
-    *(df->name[j] + k + 1) = '\0';
-   }
-   else if ((k > 1) && (strcmp(df->name[j] + k - 1, ".Z") == 0))
-   {
-    k -= 2;
-    *(df->name[j] + k + 1) = '\0';
-   }
-
-   for (k = strlen(df->name[j]) - 1; k >= 0 && *(df->name[j] + k) != '.'; k--)
-    ;
-   if (k >= 0 /**(df->name[j]+k)*/ )
-   {
-    df->name[j] = realloc(df->name[j],
-      (l = strlen(df->name[j]) + 2) * sizeof(char));
-    *(df->name[j] + k) = '(';
-    *(df->name[j] + l - 2) = ')';
-    *(df->name[j] + l - 1) = '\0';
-   }
-  }
-  if (!dout->name)
-   dout->name = malloc(df->anz * sizeof(char *));
+  if (f->ed->hdf && f->ed->hdf->anz > 0)
+    strcpy (str, f->ed->hdf->name[0]);
   else
-   dout->name = realloc(dout->name, (df->anz + dout->anz) * sizeof(char *));
-  for (j = 0; j < df->anz; j++)
-  {
-   for (k = 0; k < dout->anz; k++)
-   {
-    if (!(ret = strcmp(df->name[j], dout->name[k])))
+    str[0] = '\0';
+  if (e_add_arguments (str, "Function", f, 0, AltF, &f->ed->hdf))
     {
-     free(df->name[j]);
-     break;
+      f->ed->hdf = e_add_df (str, f->ed->hdf);
+      e_ed_man ((unsigned char *) str, f);
     }
-    else if (ret < 0)
-     break;
-   }
-   if (!ret && dout->anz)
-    continue;
-   for (l = dout->anz; l > k; l--)
-    dout->name[l] = dout->name[l - 1];
-   dout->name[k] = df->name[j];
-   dout->anz++;
-  }
-  free(df);
- }
- free(manpath);
- free(sustr);
- WpeMouseRestoreShape();
- return(dout);
+  return (0);
+}
+
+struct dirfile *
+e_make_funct (char *man)
+{
+  struct dirfile *df = NULL, *dout = malloc (sizeof (struct dirfile));
+  char *sustr, *subpath, *manpath;
+  int ret = 0, n, i = 0, j, k, l = 0;
+
+  manpath = NULL;
+  WpeMouseChangeShape (WpeWorkingShape);
+  dout->anz = 0;
+  dout->name = NULL;
+  if (getenv ("MANPATH"))
+    {
+      manpath = strdup (getenv ("MANPATH"));
+    }
+  if ((!manpath) || (manpath[0] == '\0'))
+    {
+      manpath =
+	strdup ("/usr/man:/usr/share/man:/usr/X11R6/man:/usr/local/man");
+    }
+  /* Allocate the maximum possible rather than continually realloc. */
+  sustr = malloc (strlen (manpath) + 10);
+  while (manpath[i])
+    {
+      subpath = manpath + i;
+      for (n = 0; (manpath[i]) && (manpath[i] != PTHD); i++, n++);
+      if (manpath[i] == PTHD)
+	{
+	  manpath[i] = '\0';
+	  i++;
+	}
+      sprintf (sustr, "%s/man%s/*", subpath, man);
+      df = e_find_files (sustr, 0);
+      if (!df->anz)
+	{
+	  freedf (df);
+	  continue;
+	}
+      for (j = 0; j < df->anz; j++)
+	{
+	  k = strlen (df->name[j]) - 1;
+
+	  /* If the file is gzipped strip the .gz ending. */
+	  if ((k > 2) && (strcmp (df->name[j] + k - 2, ".gz") == 0))
+	    {
+	      k -= 3;
+	      *(df->name[j] + k + 1) = '\0';
+	    }
+	  else if ((k > 3) && (strcmp (df->name[j] + k - 3, ".bz2") == 0))
+	    {
+	      k -= 4;
+	      *(df->name[j] + k + 1) = '\0';
+	    }
+	  else if ((k > 1) && (strcmp (df->name[j] + k - 1, ".Z") == 0))
+	    {
+	      k -= 2;
+	      *(df->name[j] + k + 1) = '\0';
+	    }
+
+	  for (k = strlen (df->name[j]) - 1;
+	       k >= 0 && *(df->name[j] + k) != '.'; k--)
+	    ;
+	  if (k >= 0 /**(df->name[j]+k)*/ )
+	    {
+	      df->name[j] = realloc (df->name[j],
+				     (l =
+				      strlen (df->name[j]) +
+				      2) * sizeof (char));
+	      *(df->name[j] + k) = '(';
+	      *(df->name[j] + l - 2) = ')';
+	      *(df->name[j] + l - 1) = '\0';
+	    }
+	}
+      if (!dout->name)
+	dout->name = malloc (df->anz * sizeof (char *));
+      else
+	dout->name =
+	  realloc (dout->name, (df->anz + dout->anz) * sizeof (char *));
+      for (j = 0; j < df->anz; j++)
+	{
+	  for (k = 0; k < dout->anz; k++)
+	    {
+	      if (!(ret = strcmp (df->name[j], dout->name[k])))
+		{
+		  free (df->name[j]);
+		  break;
+		}
+	      else if (ret < 0)
+		break;
+	    }
+	  if (!ret && dout->anz)
+	    continue;
+	  for (l = dout->anz; l > k; l--)
+	    dout->name[l] = dout->name[l - 1];
+	  dout->name[k] = df->name[j];
+	  dout->anz++;
+	}
+      free (df);
+    }
+  free (manpath);
+  free (sustr);
+  WpeMouseRestoreShape ();
+  return (dout);
 }
 
 
@@ -3628,38 +3764,39 @@ struct dirfile *e_make_funct(char *man)
 extern struct dirfile **e_p_df;
 #endif
 
-int e_data_first(int sw, ECNT *cn, char *nstr)
+int
+e_data_first (int sw, ECNT * cn, char *nstr)
 {
-  extern char    *e_hlp_str[];
-  extern WOPT    *gblst, *oblst;
-  FENSTER        *f;
-  int             i, j;
+  extern char *e_hlp_str[];
+  extern WOPT *gblst, *oblst;
+  FENSTER *f;
+  int i, j;
   struct dirfile *df = NULL;
-  FLWND          *fw;
+  FLWND *fw;
 
-  if(cn->mxedt >= MAXEDT)
-  {
-    e_error(e_msg[ERR_MAXWINS], 0, cn->fb);
-    return(-1);
-  }
-  for(j = 1; j <= MAXEDT; j++)
-  {
-    for(i = 1; i <= cn->mxedt && cn->edt[i] != j; i++);
-    if(i > cn->mxedt)
-      break;
-  }
+  if (cn->mxedt >= MAXEDT)
+    {
+      e_error (e_msg[ERR_MAXWINS], 0, cn->fb);
+      return (-1);
+    }
+  for (j = 1; j <= MAXEDT; j++)
+    {
+      for (i = 1; i <= cn->mxedt && cn->edt[i] != j; i++);
+      if (i > cn->mxedt)
+	break;
+    }
   cn->curedt = j;
   (cn->mxedt)++;
   cn->edt[cn->mxedt] = j;
 
-  if((f = (FENSTER *) malloc(sizeof(FENSTER))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
-  if((fw = (FLWND *) malloc(sizeof(FLWND))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((f = (FENSTER *) malloc (sizeof (FENSTER))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+  if ((fw = (FLWND *) malloc (sizeof (FLWND))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
   f->fb = cn->fb;
   cn->f[cn->mxedt] = f;
-  f->a = e_set_pnt(22, 3);
-  f->e = e_set_pnt(f->a.x + 35, f->a.y + 18);
+  f->a = e_set_pnt (22, 3);
+  f->e = e_set_pnt (f->a.x + 35, f->a.y + 18);
   f->winnum = cn->curedt;
   f->dtmd = DTMD_DATA;
   f->ins = sw;
@@ -3671,67 +3808,65 @@ int e_data_first(int sw, ECNT *cn, char *nstr)
   f->pic = NULL;
   f->fd.dirct = NULL;
 
-  if(!nstr)
-    f->dirct = NULL; /* how about a free up ??? */
+  if (!nstr)
+    f->dirct = NULL;		/* how about a free up ??? */
   else
-  {
-    f->dirct = malloc(strlen(nstr) + 1);
-    strcpy(f->dirct, nstr);
-  }
-  WpeMouseChangeShape(WpeWorkingShape);
-  if(sw == 1)
-  {
-    f->datnam = "Function-Index";
-    df = e_make_funct(nstr);
-  }
-  else if(sw == 2)
-  {
-    f->datnam = "Grep";
-    df = WpeSearchFiles(f, nstr, cn->fd.file, 
-                        cn->fd.search, NULL,
-                        cn->fd.sw);
-  }
-  else if(sw == 3)
-  {
-    f->datnam = "Find";
-    df = WpeSearchFiles(f, nstr, cn->fd.file, 
-                        cn->fd.search, NULL,
-                        cn->fd.sw);
-  }
-  else if(sw == 7)
-  {
-    f->datnam = "Windows";
-    df = e_make_win_list(f);
-  }
+    {
+      f->dirct = malloc (strlen (nstr) + 1);
+      strcpy (f->dirct, nstr);
+    }
+  WpeMouseChangeShape (WpeWorkingShape);
+  if (sw == 1)
+    {
+      f->datnam = "Function-Index";
+      df = e_make_funct (nstr);
+    }
+  else if (sw == 2)
+    {
+      f->datnam = "Grep";
+      df = WpeSearchFiles (f, nstr, cn->fd.file,
+			   cn->fd.search, NULL, cn->fd.sw);
+    }
+  else if (sw == 3)
+    {
+      f->datnam = "Find";
+      df = WpeSearchFiles (f, nstr, cn->fd.file,
+			   cn->fd.search, NULL, cn->fd.sw);
+    }
+  else if (sw == 7)
+    {
+      f->datnam = "Windows";
+      df = e_make_win_list (f);
+    }
 #ifdef PROG
-  else if(sw == 4)
-  {
-    f->datnam = "Project";
-    df = e_p_df[0];
-  }
-  else if(sw == 5)
-  {
-    f->datnam = "Variables";
-    df = e_p_df[1];
-  }
-  else if(sw == 6)
-  {
-    f->datnam = "Install";
-    df = e_p_df[2];
-  }
+  else if (sw == 4)
+    {
+      f->datnam = "Project";
+      df = e_p_df[0];
+    }
+  else if (sw == 5)
+    {
+      f->datnam = "Variables";
+      df = e_p_df[1];
+    }
+  else if (sw == 6)
+    {
+      f->datnam = "Install";
+      df = e_p_df[2];
+    }
 #endif
   f->hlp_str = e_hlp_str[16 + sw];
-  if(sw < 4)
-  {
-    f->blst = gblst;
-    f->nblst = 4;
-  }
+  if (sw < 4)
+    {
+      f->blst = gblst;
+      f->nblst = 4;
+    }
   else
-  {
-    f->blst = oblst;
-    f->nblst = 4;
-  }
-  WpeMouseRestoreShape();
+    {
+      f->blst = oblst;
+      f->nblst = 4;
+    }
+  WpeMouseRestoreShape ();
   f->b = (BUFFER *) fw;
   fw->df = df;
 
@@ -3747,55 +3882,56 @@ int e_data_first(int sw, ECNT *cn, char *nstr)
   fw->ia = fw->nf = fw->nxfo = fw->nyfo = 0;
   fw->srcha = fw->ja = 0;
 
-  if(cn->mxedt > 1 && (f->ins < 5 || f->ins == 7))
-    e_ed_rahmen(cn->f[cn->mxedt - 1], 0);
-  e_firstl(f, 1);
-  e_data_schirm(f);
-  return(0);
+  if (cn->mxedt > 1 && (f->ins < 5 || f->ins == 7))
+    e_ed_rahmen (cn->f[cn->mxedt - 1], 0);
+  e_firstl (f, 1);
+  e_data_schirm (f);
+  return (0);
 }
 
-int e_data_schirm(FENSTER * f)
+int
+e_data_schirm (FENSTER * f)
 {
-  int             i, j;
-  FLWND          *fw = (FLWND *) f->b;
+  int i, j;
+  FLWND *fw = (FLWND *) f->b;
 
-  for(j = f->a.y + 1; j < f->e.y; j++)
-    for(i = f->a.x + 1; i < f->e.x; i++)
-      e_pr_char(i, j, ' ', f->fb->nt.fb);
+  for (j = f->a.y + 1; j < f->e.y; j++)
+    for (i = f->a.x + 1; i < f->e.x; i++)
+      e_pr_char (i, j, ' ', f->fb->nt.fb);
 
-  if(NUM_COLS_ON_SCREEN > 25)
-  {
-    if(f->ins < 4 || f->ins == 7)
-      e_pr_str((f->e.x - 9), f->e.y - 4, "Show", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-    else if(f->ins > 3)
+  if (NUM_COLS_ON_SCREEN > 25)
     {
-      e_pr_str((f->e.x - 9), f->e.y - 8, "Add", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-      e_pr_str((f->e.x - 9), f->e.y - 6, "Edit", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-      e_pr_str((f->e.x - 9), f->e.y - 4, "Delete", f->fb->nz.fb, 0, -1,
-               f->fb->ns.fb, f->fb->nt.fb);
-      if(f->ins == 4 && f->a.y < f->e.y - 10)
-      {
-        e_pr_str((f->e.x - 9), f->e.y - 10, "Options", f->fb->nz.fb,
-                 0, -1, f->fb->ns.fb, f->fb->nt.fb);
-      }
+      if (f->ins < 4 || f->ins == 7)
+	e_pr_str ((f->e.x - 9), f->e.y - 4, "Show", f->fb->nz.fb, 0, -1,
+		  f->fb->ns.fb, f->fb->nt.fb);
+      else if (f->ins > 3)
+	{
+	  e_pr_str ((f->e.x - 9), f->e.y - 8, "Add", f->fb->nz.fb, 0, -1,
+		    f->fb->ns.fb, f->fb->nt.fb);
+	  e_pr_str ((f->e.x - 9), f->e.y - 6, "Edit", f->fb->nz.fb, 0, -1,
+		    f->fb->ns.fb, f->fb->nt.fb);
+	  e_pr_str ((f->e.x - 9), f->e.y - 4, "Delete", f->fb->nz.fb, 0, -1,
+		    f->fb->ns.fb, f->fb->nt.fb);
+	  if (f->ins == 4 && f->a.y < f->e.y - 10)
+	    {
+	      e_pr_str ((f->e.x - 9), f->e.y - 10, "Options", f->fb->nz.fb,
+			0, -1, f->fb->ns.fb, f->fb->nt.fb);
+	    }
+	}
+      e_pr_str ((f->e.x - 9), f->e.y - 2, "Cancel", f->fb->nz.fb, -1, -1,
+		f->fb->ns.fb, f->fb->nt.fb);
     }
-    e_pr_str((f->e.x - 9), f->e.y - 2, "Cancel", f->fb->nz.fb, -1, -1,
-             f->fb->ns.fb, f->fb->nt.fb);
-  }
 
-  if(NUM_COLS_ON_SCREEN > 25)
-  {
-    fw->xa = f->a.x + 3;
-    fw->xe = f->e.x - 13;
-  }
+  if (NUM_COLS_ON_SCREEN > 25)
+    {
+      fw->xa = f->a.x + 3;
+      fw->xe = f->e.x - 13;
+    }
   else
-  {
-    fw->xa = f->a.x + 3;
-    fw->xe = f->e.x - 2;
-  }
+    {
+      fw->xa = f->a.x + 3;
+      fw->xe = f->e.x - 2;
+    }
   fw->mxa = f->a.x;
   fw->mxe = f->e.x;
   fw->mya = f->a.y;
@@ -3804,149 +3940,152 @@ int e_data_schirm(FENSTER * f)
   fw->ya = f->a.y + 3;
   fw->ye = f->e.y - 1;
 #ifdef PROG
-  if(f->ins == 4)
+  if (f->ins == 4)
     fw->df = e_p_df[0];
 #endif
-  if(f->ins == 1)
-    e_pr_str(fw->xa, f->a.y + 2, "Functions:", f->fb->nt.fb, 0, 1,
-             f->fb->nsnt.fb, f->fb->nt.fb);
-  else if(f->ins == 3)
-    e_pr_str(fw->xa, f->a.y + 2, "Directories:", f->fb->nt.fb, 0, 1,
-             f->fb->nsnt.fb, f->fb->nt.fb);
-  e_mouse_bar(fw->xe, fw->ya, fw->ye - fw->ya, 0, fw->f->fb->em.fb);
-  e_mouse_bar(fw->xa, fw->ye, fw->xe - fw->xa, 1, fw->f->fb->em.fb);
-  e_pr_file_window(fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
-  return(0);
+  if (f->ins == 1)
+    e_pr_str (fw->xa, f->a.y + 2, "Functions:", f->fb->nt.fb, 0, 1,
+	      f->fb->nsnt.fb, f->fb->nt.fb);
+  else if (f->ins == 3)
+    e_pr_str (fw->xa, f->a.y + 2, "Directories:", f->fb->nt.fb, 0, 1,
+	      f->fb->nsnt.fb, f->fb->nt.fb);
+  e_mouse_bar (fw->xe, fw->ya, fw->ye - fw->ya, 0, fw->f->fb->em.fb);
+  e_mouse_bar (fw->xa, fw->ye, fw->xe - fw->xa, 1, fw->f->fb->em.fb);
+  e_pr_file_window (fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
+  return (0);
 }
 
-int e_data_eingabe(ECNT * cn)
+int
+e_data_eingabe (ECNT * cn)
 {
-  FENSTER        *f = cn->f[cn->mxedt];
-  FLWND          *fw = (FLWND *) f->b;
-  int             c = AltF;
+  FENSTER *f = cn->f[cn->mxedt];
+  FLWND *fw = (FLWND *) f->b;
+  int c = AltF;
 
-  fk_cursor(0);
-  if(f->ins == 7)
-  {
-    freedf(fw->df);
-    fw->df = e_make_win_list(f);
-  }
-  while(c != WPE_ESC)
-  {
-    if(f->dtmd != DTMD_DATA)
-      return(0);
-#ifdef PROG
-    if(f->ins == 4)
-      fw->df = e_p_df[0];
-#endif
-    if(c == AltF)
-      c = e_file_window(0, fw, f->fb->ft.fb, f->fb->fz.fb);
-#if  MOUSE
-    if(c == MBKEY)
-      c = e_data_ein_mouse(f);
-#endif
-    if(((c == WPE_CR || c == AltS) && (f->ins < 4 || f->ins == 7)) ||
-       ((c == AltA || c == EINFG) && (f->ins > 3 && f->ins < 7)))
+  fk_cursor (0);
+  if (f->ins == 7)
     {
-      if(f->ins == 1)
-        e_ed_man((unsigned char *)fw->df->name[fw->nf], f);
-      else if(f->ins == 2)
-      {
-        e_edit(f->ed, fw->df->name[fw->nf]);
-        e_rep_search(f->ed->f[f->ed->mxedt]);
-      }
-      else if(f->ins == 3)
-      {
-        e_edit(f->ed, fw->df->name[fw->nf]);
+      freedf (fw->df);
+      fw->df = e_make_win_list (f);
+    }
+  while (c != WPE_ESC)
+    {
+      if (f->dtmd != DTMD_DATA)
+	return (0);
+#ifdef PROG
+      if (f->ins == 4)
+	fw->df = e_p_df[0];
+#endif
+      if (c == AltF)
+	c = e_file_window (0, fw, f->fb->ft.fb, f->fb->fz.fb);
+#if  MOUSE
+      if (c == MBKEY)
+	c = e_data_ein_mouse (f);
+#endif
+      if (((c == WPE_CR || c == AltS) && (f->ins < 4 || f->ins == 7)) ||
+	  ((c == AltA || c == EINFG) && (f->ins > 3 && f->ins < 7)))
+	{
+	  if (f->ins == 1)
+	    e_ed_man ((unsigned char *) fw->df->name[fw->nf], f);
+	  else if (f->ins == 2)
+	    {
+	      e_edit (f->ed, fw->df->name[fw->nf]);
+	      e_rep_search (f->ed->f[f->ed->mxedt]);
+	    }
+	  else if (f->ins == 3)
+	    {
+	      e_edit (f->ed, fw->df->name[fw->nf]);
 
 /*        WpeCreateFileManager(0, f->ed, fw->df->name[fw->nf]); */
-      }
-      else if(f->ins == 7)
-        e_switch_window(f->ed->edt[fw->df->anz - fw->nf], f);
+	    }
+	  else if (f->ins == 7)
+	    e_switch_window (f->ed->edt[fw->df->anz - fw->nf], f);
 #ifdef PROG
-      else if(f->ins == 4)
-      {
-        WpeCreateFileManager(5, f->ed, NULL);
-        while(WpeHandleFileManager(f->ed) != WPE_ESC);
-        e_p_df[f->ins - 4] = fw->df;
-        c = AltF;
-        f->save = 1;
-      }
-      else if(f->ins > 4 && f->ins < 7)
-      {
-        e_p_add_df(fw, f->ins);
-        e_p_df[f->ins - 4] = fw->df;
-        c = AltF;
-      }
+	  else if (f->ins == 4)
+	    {
+	      WpeCreateFileManager (5, f->ed, NULL);
+	      while (WpeHandleFileManager (f->ed) != WPE_ESC);
+	      e_p_df[f->ins - 4] = fw->df;
+	      c = AltF;
+	      f->save = 1;
+	    }
+	  else if (f->ins > 4 && f->ins < 7)
+	    {
+	      e_p_add_df (fw, f->ins);
+	      e_p_df[f->ins - 4] = fw->df;
+	      c = AltF;
+	    }
 #endif
-      if(f->ins < 4 || f->ins == 7)
-        return(0);
-    }
+	  if (f->ins < 4 || f->ins == 7)
+	    return (0);
+	}
 #ifdef PROG
-    else if(f->ins > 3 && f->ins < 7 && (c == AltD || c == ENTF))
-    {
-      e_p_del_df(fw, f->ins);
-      c = AltF;
-      f->save = 1;
-    }
-    else if(f->ins > 4 && f->ins < 7 && (c == AltE || c == WPE_CR))
-    {
-      e_p_edit_df(fw, f->ins);
-      c = AltF;
-      f->save = 1;
-    }
-    else if(f->ins == 4 && (c == AltE || c == WPE_CR))
-    {
-      e_edit(f->ed, fw->df->name[fw->nf]);
-      c = WPE_ESC;
-    }
-    else if(f->ins == 4 && c == AltO)
-    {
-      e_project_options(f);
-      c = AltF;
-    }
+      else if (f->ins > 3 && f->ins < 7 && (c == AltD || c == ENTF))
+	{
+	  e_p_del_df (fw, f->ins);
+	  c = AltF;
+	  f->save = 1;
+	}
+      else if (f->ins > 4 && f->ins < 7 && (c == AltE || c == WPE_CR))
+	{
+	  e_p_edit_df (fw, f->ins);
+	  c = AltF;
+	  f->save = 1;
+	}
+      else if (f->ins == 4 && (c == AltE || c == WPE_CR))
+	{
+	  e_edit (f->ed, fw->df->name[fw->nf]);
+	  c = WPE_ESC;
+	}
+      else if (f->ins == 4 && c == AltO)
+	{
+	  e_project_options (f);
+	  c = AltF;
+	}
 #endif
-    else if(c != AltF)
-    {
-      if(c == AltBl)
-        c = WPE_ESC;
-      else if(c == WPE_ESC)
-        c = (f->ed->edopt & ED_CUA_STYLE) ? CF4 : AF3;
-      if(f->ins == 7 && ((!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
-                         || ((f->ed->edopt & ED_CUA_STYLE) && c == CF4)))
-        e_close_window(f);
-      if(f->ins == 4 && ((!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
-                         || ((f->ed->edopt & ED_CUA_STYLE) && c == CF4)))
-      {
-        FLWND          *fw = (FLWND *) f->ed->f[f->ed->mxedt]->b;
-        fw->df = NULL;
-        e_close_window(f->ed->f[f->ed->mxedt]);
-        return(0);
-      }
-      if(f->ins == 4 && (!e_tst_dfkt(f, c) || !e_prog_switch(f, c)))
-        return(0);
-      if(f->ins > 4 && ((!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
-                        || ((f->ed->edopt & ED_CUA_STYLE) && c == CF4)))
-        return(c);
-      else if((f->ins < 4 || f->ins == 7) && !e_tst_dfkt(f, c))
-        return(0);
-      else
-        c = AltF;
+      else if (c != AltF)
+	{
+	  if (c == AltBl)
+	    c = WPE_ESC;
+	  else if (c == WPE_ESC)
+	    c = (f->ed->edopt & ED_CUA_STYLE) ? CF4 : AF3;
+	  if (f->ins == 7 && ((!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
+			      || ((f->ed->edopt & ED_CUA_STYLE) && c == CF4)))
+	    e_close_window (f);
+	  if (f->ins == 4 && ((!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
+			      || ((f->ed->edopt & ED_CUA_STYLE) && c == CF4)))
+	    {
+	      FLWND *fw = (FLWND *) f->ed->f[f->ed->mxedt]->b;
+	      fw->df = NULL;
+	      e_close_window (f->ed->f[f->ed->mxedt]);
+	      return (0);
+	    }
+	  if (f->ins == 4 && (!e_tst_dfkt (f, c) || !e_prog_switch (f, c)))
+	    return (0);
+	  if (f->ins > 4 && ((!(f->ed->edopt & ED_CUA_STYLE) && c == AF3)
+			     || ((f->ed->edopt & ED_CUA_STYLE) && c == CF4)))
+	    return (c);
+	  else if ((f->ins < 4 || f->ins == 7) && !e_tst_dfkt (f, c))
+	    return (0);
+	  else
+	    c = AltF;
+	}
     }
-  }
-  return((f->ed->edopt & ED_CUA_STYLE) ? CF4 : AF3);
+  return ((f->ed->edopt & ED_CUA_STYLE) ? CF4 : AF3);
 }
 
-int e_get_funct_in(char *nstr, FENSTER * f)
+int
+e_get_funct_in (char *nstr, FENSTER * f)
 {
-  return(e_data_first(1, f->ed, nstr));
+  return (e_data_first (1, f->ed, nstr));
 }
 
-int e_funct_in(FENSTER * f)
+int
+e_funct_in (FENSTER * f)
 {
-  int             n, xa = 37, ya = 2, num = 8;
-  OPTK           *opt = malloc(num * sizeof(OPTK));
-  char            nstr[2];
+  int n, xa = 37, ya = 2, num = 8;
+  OPTK *opt = malloc (num * sizeof (OPTK));
+  char nstr[2];
 
   opt[0].t = "User Commands";
   opt[0].x = 0;
@@ -3973,15 +4112,15 @@ int e_funct_in(FENSTER * f)
   opt[7].x = 0;
   opt[7].o = 'M';
 
-  n = e_opt_sec_box(xa, ya, num, opt, f, 1);
+  n = e_opt_sec_box (xa, ya, num, opt, f, 1);
 
-  free(opt);
-  if(n < 0)
-    return(WPE_ESC);
+  free (opt);
+  if (n < 0)
+    return (WPE_ESC);
 
   nstr[0] = '1' + n;
   nstr[1] = '\0';
-  return(e_get_funct_in(nstr, f));
+  return (e_get_funct_in (nstr, f));
 }
 
 #endif

--- a/src/we_fl_unix.h
+++ b/src/we_fl_unix.h
@@ -11,21 +11,21 @@
 #ifdef UNIX
 #include "we_fl_unix_private.h"
 
-int e_data_eingabe(ECNT *cn);
+int e_data_eingabe (ECNT * cn);
 
-char *WpeGetCurrentDir(ECNT *cn);
-struct dirfile *WpeCreateWorkingDirTree(int sw, ECNT *cn);
-char *WpeAssemblePath(char *pth, struct dirfile *cd, struct dirfile *dd, int n, 
-                      FENSTER *f);
-struct dirfile *WpeGraphicalFileList(struct dirfile *df, int sw, ECNT *cn);
-struct dirfile *WpeGraphicalDirTree(struct dirfile *cd, struct dirfile *dd,
-                                    ECNT *cn);
+char *WpeGetCurrentDir (ECNT * cn);
+struct dirfile *WpeCreateWorkingDirTree (int sw, ECNT * cn);
+char *WpeAssemblePath (char *pth, struct dirfile *cd, struct dirfile *dd,
+		       int n, FENSTER * f);
+struct dirfile *WpeGraphicalFileList (struct dirfile *df, int sw, ECNT * cn);
+struct dirfile *WpeGraphicalDirTree (struct dirfile *cd, struct dirfile *dd,
+				     ECNT * cn);
 /*   we_fl_unix.c  */
 
-int e_funct(FENSTER *f);
-int e_funct_in(FENSTER *f);
-int e_data_first(int sw, ECNT *cn, char *nstr);
-int e_data_schirm(FENSTER *f);
+int e_funct (FENSTER * f);
+int e_funct_in (FENSTER * f);
+int e_data_first (int sw, ECNT * cn, char *nstr);
+int e_data_schirm (FENSTER * f);
 
 #endif
 

--- a/src/we_fl_unix_private.h
+++ b/src/we_fl_unix_private.h
@@ -6,46 +6,46 @@
 /* This include is for the header of we_fl_unix only, no other header or source file */
 
 /*   we_fl_unix.c   */
-int WpeCreateFileManager(int sw, ECNT *cn, char *dirct);
-int WpeDrawFileManager(FENSTER *f);
-int WpeManagerFirst(FENSTER *f);
-int WpeManager(FENSTER *f);
-int WpeSaveAsManager(FENSTER *f);
-int WpeExecuteManager(FENSTER *f);
+int WpeCreateFileManager (int sw, ECNT * cn, char *dirct);
+int WpeDrawFileManager (FENSTER * f);
+int WpeManagerFirst (FENSTER * f);
+int WpeManager (FENSTER * f);
+int WpeSaveAsManager (FENSTER * f);
+int WpeExecuteManager (FENSTER * f);
 
-int WpeHandleFileManager(ECNT *cn);
-int WpeGrepFile(char *file, char *string, int sw);
-int WpeRemove(char *file, FENSTER *f);
+int WpeHandleFileManager (ECNT * cn);
+int WpeGrepFile (char *file, char *string, int sw);
+int WpeRemove (char *file, FENSTER * f);
 
-int WpeFindWindow(FENSTER *f);
-int WpeGrepWindow(FENSTER *f);
+int WpeFindWindow (FENSTER * f);
+int WpeGrepWindow (FENSTER * f);
 
-struct dirfile *WpeSearchFiles(FENSTER *f, 
-                               char *dirct, char *file, char *string,
-                               struct dirfile *df, int sw);
-int WpeShell(FENSTER *f);
-int WpePrintFile(FENSTER *f);
-int e_rename(char *file, char *newname, FENSTER *f);
-int WpeFileManagerOptions(FENSTER *f);
-int WpeShowWastebasket(FENSTER *f);
-int WpeDelWastebasket(FENSTER *f);
-int WpeQuitWastebasket(FENSTER *f);
-int WpeRemoveDir(char *dirct, char *file, FENSTER * f, int rec);
-char  *WpeGetWastefile(char *file);
-int e_copy(char *file, char *newname, FENSTER *f);
-int e_link(char *file, char *newname, FENSTER *f);
-int e_duplicate(char *file, FENSTER *f);
-int WpeMakeNewDir(FENSTER *f);
-int WpeFileDirAttributes(char *filen, FENSTER *f);
-int WpeRenameCopyDir(char *dirct, char *file, char *newname, 
-                     FENSTER *f, int rec, int sw);
-int WpeRenameCopy(char *file, char *newname, FENSTER *f, int sw);
-int WpeCopyFileCont(char *oldfile, char *newfile, FENSTER *f);
+struct dirfile *WpeSearchFiles (FENSTER * f,
+				char *dirct, char *file, char *string,
+				struct dirfile *df, int sw);
+int WpeShell (FENSTER * f);
+int WpePrintFile (FENSTER * f);
+int e_rename (char *file, char *newname, FENSTER * f);
+int WpeFileManagerOptions (FENSTER * f);
+int WpeShowWastebasket (FENSTER * f);
+int WpeDelWastebasket (FENSTER * f);
+int WpeQuitWastebasket (FENSTER * f);
+int WpeRemoveDir (char *dirct, char *file, FENSTER * f, int rec);
+char *WpeGetWastefile (char *file);
+int e_copy (char *file, char *newname, FENSTER * f);
+int e_link (char *file, char *newname, FENSTER * f);
+int e_duplicate (char *file, FENSTER * f);
+int WpeMakeNewDir (FENSTER * f);
+int WpeFileDirAttributes (char *filen, FENSTER * f);
+int WpeRenameCopyDir (char *dirct, char *file, char *newname,
+		      FENSTER * f, int rec, int sw);
+int WpeRenameCopy (char *file, char *newname, FENSTER * f, int sw);
+int WpeCopyFileCont (char *oldfile, char *newfile, FENSTER * f);
 
-int WpeDirDelOptions(FENSTER *f);
+int WpeDirDelOptions (FENSTER * f);
 #ifdef HAVE_SYMLINK
-int WpeLinkFile(char *fl, char *ln, int sw, FENSTER *f);
-int WpeRenameLink(char *old, char *ln, char *fl, FENSTER *f);
+int WpeLinkFile (char *fl, char *ln, int sw, FENSTER * f);
+int WpeRenameLink (char *old, char *ln, char *fl, FENSTER * f);
 #endif
-int e_ed_man(unsigned char *str, FENSTER *f);
+int e_ed_man (unsigned char *str, FENSTER * f);
 #endif

--- a/src/we_gpm.c
+++ b/src/we_gpm.c
@@ -11,63 +11,65 @@ Based on we_linux.c -- Created by Sebastiano Suraci */
 #include "edit.h"
 #include <gpm.h>
 
-int WpeGpmHandler(Gpm_Event *ep, void *data);
+int WpeGpmHandler (Gpm_Event * ep, void *data);
 
-int WpeGpmMouseInit(void)
+int
+WpeGpmMouseInit (void)
 {
- Gpm_Connect c;
- int ret;
+  Gpm_Connect c;
+  int ret;
 
- Gpm_GetServerVersion(NULL);
- gpm_zerobased = 1;
- c.eventMask = ~0;
- c.defaultMask = ~GPM_HARD;
- c.minMod = 0;
- c.maxMod = ~0;
- ret = Gpm_Open(&c, 0);
- if (ret == -2)
- {
-  /* Xterms returns mouse information through stdin which xwpe currently
-    doesn't support */
-  Gpm_Close();
-  return(-1);
- }
- if (ret == -1)
- {
-  return(-1);
- }
- gpm_handler = WpeGpmHandler;
- return(0);
+  Gpm_GetServerVersion (NULL);
+  gpm_zerobased = 1;
+  c.eventMask = ~0;
+  c.defaultMask = ~GPM_HARD;
+  c.minMod = 0;
+  c.maxMod = ~0;
+  ret = Gpm_Open (&c, 0);
+  if (ret == -2)
+    {
+      /* Xterms returns mouse information through stdin which xwpe currently
+         doesn't support */
+      Gpm_Close ();
+      return (-1);
+    }
+  if (ret == -1)
+    {
+      return (-1);
+    }
+  gpm_handler = WpeGpmHandler;
+  return (0);
 }
 
-int WpeGpmHandler(Gpm_Event *ep, void *data)
+int
+WpeGpmHandler (Gpm_Event * ep, void *data)
 {
- UNUSED(data);
- extern struct mouse e_mouse;
+  UNUSED (data);
+  extern struct mouse e_mouse;
 
- GPM_DRAWPOINTER(ep);
- if (ep->buttons & 7)
- {
-  e_mouse.x = ep->x;
-  e_mouse.y = ep->y;
-  e_mouse.k = ep->buttons;
-  return(-(ep->buttons ^ 5));
- }
- e_mouse.k = 0;
- return(0);
+  GPM_DRAWPOINTER (ep);
+  if (ep->buttons & 7)
+    {
+      e_mouse.x = ep->x;
+      e_mouse.y = ep->y;
+      e_mouse.k = ep->buttons;
+      return (-(ep->buttons ^ 5));
+    }
+  e_mouse.k = 0;
+  return (0);
 }
 
-int WpeGpmMouse(int *g)
+int
+WpeGpmMouse (int *g)
 {
- Gpm_Event e;
+  Gpm_Event e;
 
- while (Gpm_GetSnapshot(&e) == 0)
-  Gpm_GetEvent(&e);
- g[1] = g[0] = e.buttons;
- g[2] = e.x * 8;
- g[3] = e.y * 8;
- return(1);
+  while (Gpm_GetSnapshot (&e) == 0)
+    Gpm_GetEvent (&e);
+  g[1] = g[0] = e.buttons;
+  g[2] = e.x * 8;
+  g[3] = e.y * 8;
+  return (1);
 }
 
 #endif
-

--- a/src/we_gpm.h
+++ b/src/we_gpm.h
@@ -3,8 +3,8 @@
 
 /* we_gpm.c */
 #ifdef HAVE_LIBGPM
-int WpeGpmMouseInit(void);
-int WpeGpmMouse(int *g);
+int WpeGpmMouseInit (void);
+int WpeGpmMouse (int *g);
 #endif // #ifdef HAVE_LIBGPM
 
 #endif

--- a/src/we_hfkt.c
+++ b/src/we_hfkt.c
@@ -15,244 +15,262 @@
 #include <regex.h>
 
 /*        find string in text line    */
-int e_strstr(int x, int n, unsigned char *s, unsigned char *f)
+int
+e_strstr (int x, int n, unsigned char *s, unsigned char *f)
 {
- int i, j, nf = strlen((const char *)f);
+  int i, j, nf = strlen ((const char *) f);
 
- if (x > n)
- {
-  for (i = x - nf; i >= n; i--)
-  {
-   for (j = 0; j < nf; j++)
-    if (s[i+j] != f[j])
-     break;
-   if (j == nf)
-    return(i);
-  }
- }
- else
- {
-  for (i = x >= 0 ? x : 0; i <= n - nf /* && s[i] != '\0' && s[i] != WR */; i++)
-  {
-   for (j = 0; j < nf; j++)
-    if (s[i+j] != f[j])
-     break;
-   if (j == nf)
-    return(i);
-  }
- }
- return(-1);
+  if (x > n)
+    {
+      for (i = x - nf; i >= n; i--)
+	{
+	  for (j = 0; j < nf; j++)
+	    if (s[i + j] != f[j])
+	      break;
+	  if (j == nf)
+	    return (i);
+	}
+    }
+  else
+    {
+      for (i = x >= 0 ? x : 0;
+	   i <= n - nf /* && s[i] != '\0' && s[i] != WR */ ; i++)
+	{
+	  for (j = 0; j < nf; j++)
+	    if (s[i + j] != f[j])
+	      break;
+	  if (j == nf)
+	    return (i);
+	}
+    }
+  return (-1);
 }
 
 /*        Find string in line (ignoring case)   */
-int e_ustrstr(int x, int n, unsigned char *s, unsigned char *f)
+int
+e_ustrstr (int x, int n, unsigned char *s, unsigned char *f)
 {
- int i, j, nf = strlen((const char *)f);
+  int i, j, nf = strlen ((const char *) f);
 
- if(x > n)
- {
-  for (i = x-nf; i >= n; i--)
-  {
-   for (j = 0; j < nf; j++)
-    if (toupper(s[i+j]) != toupper(f[j]))
-     break;
-   if (j == nf)
-    return(i);
-  }
- }
- else
- {
-  for (i = x < 0 ? 0 : x; i <= n - nf; i++)
-  {
-   for (j = 0; j < nf; j++)
-    if (toupper(s[i+j]) != toupper(f[j]))
-     break;
-   if (j == nf)
-    return(i);
-  }
- }
- return(-1);
+  if (x > n)
+    {
+      for (i = x - nf; i >= n; i--)
+	{
+	  for (j = 0; j < nf; j++)
+	    if (toupper (s[i + j]) != toupper (f[j]))
+	      break;
+	  if (j == nf)
+	    return (i);
+	}
+    }
+  else
+    {
+      for (i = x < 0 ? 0 : x; i <= n - nf; i++)
+	{
+	  for (j = 0; j < nf; j++)
+	    if (toupper (s[i + j]) != toupper (f[j]))
+	      break;
+	  if (j == nf)
+	    return (i);
+	}
+    }
+  return (-1);
 }
 
 /*   find string in text line (including control chars), case insensitive */
-int e_urstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn)
+int
+e_urstrstr (int x, int n, unsigned char *s, unsigned char *f, int *nn)
 {
- int i;
- unsigned char *str;
- unsigned char *ft = malloc((strlen((const char *)f)+1)*sizeof(unsigned char));
+  int i;
+  unsigned char *str;
+  unsigned char *ft =
+    malloc ((strlen ((const char *) f) + 1) * sizeof (unsigned char));
 
- if (x <= n)
- {
-  str = malloc((n+1)*sizeof(unsigned char));
-  for (i = 0; i < n; i++)
-   str[i] = toupper(s[i]);
-  str[n] = '\0';
- }
- else
- {
-  str = malloc((x+1)*sizeof(unsigned char));
-  for (i = 0; i < x; i++)
-   str[i] = toupper(s[i]);
-  str[x] = '\0';
- }
- for (i = 0; (ft[i] = toupper(f[i])) != '\0'; i++)
-  ;
+  if (x <= n)
+    {
+      str = malloc ((n + 1) * sizeof (unsigned char));
+      for (i = 0; i < n; i++)
+	str[i] = toupper (s[i]);
+      str[n] = '\0';
+    }
+  else
+    {
+      str = malloc ((x + 1) * sizeof (unsigned char));
+      for (i = 0; i < x; i++)
+	str[i] = toupper (s[i]);
+      str[x] = '\0';
+    }
+  for (i = 0; (ft[i] = toupper (f[i])) != '\0'; i++)
+    ;
 
- i = e_rstrstr(x, n, str, ft, nn);
- free(str);
- free(ft);
- return(i);
+  i = e_rstrstr (x, n, str, ft, nn);
+  free (str);
+  free (ft);
+  return (i);
 }
 
 /*   find string in text line (including control chars) */
-int e_rstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn)
+int
+e_rstrstr (int x, int n, unsigned char *s, unsigned char *f, int *nn)
 {
- regex_t *regz;
- regmatch_t *matches = NULL;
- int start, end, i, len;
- int res;
- unsigned char old;
+  regex_t *regz;
+  regmatch_t *matches = NULL;
+  int start, end, i, len;
+  int res;
+  unsigned char old;
 
- regz = malloc(sizeof(regex_t));
- if (regcomp(regz,(const char *)f,REG_EXTENDED))
- {
-  free(regz);
-  return (-1);
- }
- len = regz->re_nsub;
- if (len)
-  matches = malloc(len*sizeof(regmatch_t));
- start = (x < n) ? x : n;
- end = (n > x) ? n : x;
- if (start < 0)
-  start = 0;
- old = s[end];/* Save char */
- s[end] = '\0';
- res=regexec(regz,(const char *)&s[start],len,matches,REG_NOTBOL|REG_NOTEOL);
- s[end] = old;/* Restore char */
- regfree(regz);
- free(regz);
- if (res != 0)
- { 
-  free(matches);
-  return (-1); /* Can't find any occurences */
- }
- start=strlen((const char *)s);
- end=0;
+  regz = malloc (sizeof (regex_t));
+  if (regcomp (regz, (const char *) f, REG_EXTENDED))
+    {
+      free (regz);
+      return (-1);
+    }
+  len = regz->re_nsub;
+  if (len)
+    matches = malloc (len * sizeof (regmatch_t));
+  start = (x < n) ? x : n;
+  end = (n > x) ? n : x;
+  if (start < 0)
+    start = 0;
+  old = s[end];			/* Save char */
+  s[end] = '\0';
+  res =
+    regexec (regz, (const char *) &s[start], len, matches,
+	     REG_NOTBOL | REG_NOTEOL);
+  s[end] = old;			/* Restore char */
+  regfree (regz);
+  free (regz);
+  if (res != 0)
+    {
+      free (matches);
+      return (-1);		/* Can't find any occurences */
+    }
+  start = strlen ((const char *) s);
+  end = 0;
 
- for (i=0;i<len;i++)
- {
-  start = (matches[i].rm_so<start) ? matches[i].rm_so : start;
-  end = (matches[i].rm_eo>end) ? matches[i].rm_eo : end;
- }
- if (start > end)/* Whole line matches regex */
- {
-  end = start;
-  start = 0;
- }
- if (matches)
-  free(matches);
- *nn=end;
- return start;
+  for (i = 0; i < len; i++)
+    {
+      start = (matches[i].rm_so < start) ? matches[i].rm_so : start;
+      end = (matches[i].rm_eo > end) ? matches[i].rm_eo : end;
+    }
+  if (start > end)		/* Whole line matches regex */
+    {
+      end = start;
+      start = 0;
+    }
+  if (matches)
+    free (matches);
+  *nn = end;
+  return start;
 }
 
 /*   numbers box (numbers input/edit)     */
-int e_num_kst(char *s, int num, int max, FENSTER *f, int n, int sw)
+int
+e_num_kst (char *s, int num, int max, FENSTER * f, int n, int sw)
 {
- int ret, nz = WpeNumberOfPlaces(max);
- char *tmp = malloc((strlen(s)+2) * sizeof(char));
- W_OPTSTR *o = e_init_opt_kst(f);
+  int ret, nz = WpeNumberOfPlaces (max);
+  char *tmp = malloc ((strlen (s) + 2) * sizeof (char));
+  W_OPTSTR *o = e_init_opt_kst (f);
 
- if (!o || !tmp)
-  return(-1);
- o->xa = 20;  o->ya = 4;  o->xe = 52;  o->ye = 10;
- o->bgsw = 0;
- o->name = s;
- o->crsw = AltO;
- sprintf(tmp, "%s:", s);
- e_add_numstr(3, 2, 29-nz, 2, nz, max, n, sw, tmp, num, o);
- free(tmp);
- e_add_bttstr(6, 4, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(21, 4, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
-  num = o->nstr[0]->num;
- freeostr(o);
- return(num);
+  if (!o || !tmp)
+    return (-1);
+  o->xa = 20;
+  o->ya = 4;
+  o->xe = 52;
+  o->ye = 10;
+  o->bgsw = 0;
+  o->name = s;
+  o->crsw = AltO;
+  sprintf (tmp, "%s:", s);
+  e_add_numstr (3, 2, 29 - nz, 2, nz, max, n, sw, tmp, num, o);
+  free (tmp);
+  e_add_bttstr (6, 4, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (21, 4, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    num = o->nstr[0]->num;
+  freeostr (o);
+  return (num);
 }
 
 /*   determine string length */
-int e_str_len(unsigned char *s)
+int
+e_str_len (unsigned char *s)
 {
- int i;
+  int i;
 
- for (i = 0; *(s+i) != '\0' && *(s+i) != WPE_WR; i++)
-  ;
- return (i);
+  for (i = 0; *(s + i) != '\0' && *(s + i) != WPE_WR; i++)
+    ;
+  return (i);
 }
 
 /*           COLOR - fill struct with constants           */
-COLOR e_s_x_clr(int f, int b)
+COLOR
+e_s_x_clr (int f, int b)
 {
- COLOR c;
+  COLOR c;
 
- c.f = f;
- c.b = b;
- c.fb = 16*b + f;
- return(c);
+  c.f = f;
+  c.b = b;
+  c.fb = 16 * b + f;
+  return (c);
 }
 
-COLOR e_n_x_clr(int fb)
+COLOR
+e_n_x_clr (int fb)
 {
- COLOR f;
+  COLOR f;
 
- f.fb = fb;
- f.b = fb / 16;
- f.f = fb % 16;
- return(f);
+  f.fb = fb;
+  f.b = fb / 16;
+  f.f = fb % 16;
+  return (f);
 }
 
-COLOR e_s_t_clr(int f, int b)
+COLOR
+e_s_t_clr (int f, int b)
 {
- COLOR c;
+  COLOR c;
 
- c.f = f;
- c.b = b;
- c.fb = f;
- return(c);
+  c.f = f;
+  c.b = b;
+  c.fb = f;
+  return (c);
 }
 
-COLOR e_n_t_clr(int fb)
+COLOR
+e_n_t_clr (int fb)
 {
- COLOR f;
+  COLOR f;
 
- f.fb = fb;
- f.b = fb;
- f.f = fb;
- return(f);
+  f.fb = fb;
+  f.b = fb;
+  f.f = fb;
+  return (f);
 }
 
 /*            POINT - fill struct with constants            */
-POINT e_set_pnt(int x, int y)
+POINT
+e_set_pnt (int x, int y)
 {
- POINT p;
+  POINT p;
 
- p.x = x;
- p.y = y;
- return(p);
+  p.x = x;
+  p.y = y;
+  return (p);
 }
 
-int e_pr_uul(FARBE *fb)
+int
+e_pr_uul (FARBE * fb)
 {
- extern WOPT *blst;
- extern int nblst;
- int i;
+  extern WOPT *blst;
+  extern int nblst;
+  int i;
 
- e_blk(MAXSCOL, 0, MAXSLNS-1, fb->mt.fb);
- for (i = 0; i < nblst && blst[i].x < MAXSCOL; ++i)
-  e_pr_str_scan(blst[i].x+1, MAXSLNS-1, blst[i].t, fb->mt.fb,
-			blst[i].s, blst[i].n, fb->ms.fb, blst[i].x,
-			i == nblst-1 ? MAXSCOL-1 : blst[i+1].x-1);
- return(i);
+  e_blk (MAXSCOL, 0, MAXSLNS - 1, fb->mt.fb);
+  for (i = 0; i < nblst && blst[i].x < MAXSCOL; ++i)
+    e_pr_str_scan (blst[i].x + 1, MAXSLNS - 1, blst[i].t, fb->mt.fb,
+		   blst[i].s, blst[i].n, fb->ms.fb, blst[i].x,
+		   i == nblst - 1 ? MAXSCOL - 1 : blst[i + 1].x - 1);
+  return (i);
 }
-

--- a/src/we_hfkt.h
+++ b/src/we_hfkt.h
@@ -5,20 +5,20 @@
 #include "we_opt.h"
 
 /*   we_hfkt.c   */
-int e_strstr(int x, int n, unsigned char *s, unsigned char *f);
-int e_ustrstr(int x, int n, unsigned char *s, unsigned char *f);
-int e_urstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn);
-int e_rstrstr(int x, int n, unsigned char *s, unsigned char *f, int *nn);
-int e_str_len(unsigned char *s);
+int e_strstr (int x, int n, unsigned char *s, unsigned char *f);
+int e_ustrstr (int x, int n, unsigned char *s, unsigned char *f);
+int e_urstrstr (int x, int n, unsigned char *s, unsigned char *f, int *nn);
+int e_rstrstr (int x, int n, unsigned char *s, unsigned char *f, int *nn);
+int e_str_len (unsigned char *s);
 
-int e_num_kst(char *s, int num, int max, FENSTER *f, int n, int sw);
-COLOR e_s_x_clr(int f, int b);
-COLOR e_n_x_clr(int fb);
+int e_num_kst (char *s, int num, int max, FENSTER * f, int n, int sw);
+COLOR e_s_x_clr (int f, int b);
+COLOR e_n_x_clr (int fb);
 #ifdef UNIX
-COLOR e_s_t_clr(int f, int b);
-COLOR e_n_t_clr(int fb);
+COLOR e_s_t_clr (int f, int b);
+COLOR e_n_t_clr (int fb);
 #endif
-POINT e_set_pnt(int x, int y);
-int e_pr_uul(FARBE *fb);
+POINT e_set_pnt (int x, int y);
+int e_pr_uul (FARBE * fb);
 
 #endif

--- a/src/we_main.c
+++ b/src/we_main.c
@@ -53,572 +53,667 @@ int nblst = 7;
 
 #if MOUSE
 int fk__mouse_stat = 1;
-struct mouse e_mouse = {  0, 0, 0  };
+struct mouse e_mouse = { 0, 0, 0 };
 #endif
 
 /* prototypes */
-int e_read_help_str(void);
+int e_read_help_str (void);
 
 /* preinitialized arrays */
-char *e_msg[] = {  "Not Enough Memory",
-		   "Option-File got the Wrong Version",
-		   "Can\'t read Option-File",
-		   "More Than 35 Windows",
-		   "String NOT found",
-		   "Can\'t open File %s",             /*  Number 5  */
-		   "Can\'t close File",
-		   "No more Undo",
-		   "Execute Command: %s\n",
-		   "Command not found",
-		   "\nStrike <Return> to continue\n", /*  Number 10 */
-		   "Not Installed",
-		   "Can\'t open Option-File",
-		   "Can\'t write to Option-File",
-		   "File failed to save",
-		   "Not all files saved",             /*  Number 15  */
-		   "Can\'t Print File",
-		   "No more Redo",
-                   "Can\'t open directory",
-                   "Can\'t open HOME directory",
-                   "System error",                    /*  Number 20 */
-                   "Wastebasket is not available",
-                   "Can\'t create directory",
-                   "Can\'t access file or directory",
-                   "Can\'t remove file or directory",
-                   "Can\'t link file or directory",   /*  Number 25 */
-                   "File already exist with \"new.dir\" name",
-                   "Cannot change permissions",
-                   "Can\'t rename file or directory",
-                   "Can\'t open file for reading",
-                   "Can\'t open file for writing",    /*  Number 30 */
-                   "Can\'t allocate buffer for copying",
-                   "Inconsistent copying"
-		};
+char *e_msg[] = { "Not Enough Memory",
+  "Option-File got the Wrong Version",
+  "Can\'t read Option-File",
+  "More Than 35 Windows",
+  "String NOT found",
+  "Can\'t open File %s",	/*  Number 5  */
+  "Can\'t close File",
+  "No more Undo",
+  "Execute Command: %s\n",
+  "Command not found",
+  "\nStrike <Return> to continue\n",	/*  Number 10 */
+  "Not Installed",
+  "Can\'t open Option-File",
+  "Can\'t write to Option-File",
+  "File failed to save",
+  "Not all files saved",	/*  Number 15  */
+  "Can\'t Print File",
+  "No more Redo",
+  "Can\'t open directory",
+  "Can\'t open HOME directory",
+  "System error",		/*  Number 20 */
+  "Wastebasket is not available",
+  "Can\'t create directory",
+  "Can\'t access file or directory",
+  "Can\'t remove file or directory",
+  "Can\'t link file or directory",	/*  Number 25 */
+  "File already exist with \"new.dir\" name",
+  "Cannot change permissions",
+  "Can\'t rename file or directory",
+  "Can\'t open file for reading",
+  "Can\'t open file for writing",	/*  Number 30 */
+  "Can\'t allocate buffer for copying",
+  "Inconsistent copying"
+};
 
-OPT opt[] = {  {"#",        3, '#', AltSYS},
-	       {"File",    10, 'F', AltF},
-	       {"Edit",    19, 'E', AltE},
-	       {"Search",  28, 'S', AltS},
-	       {"Block",   39, 'B', AltB},
-	       {"Options", 49, 'O', AltO},
-	       {"Window",  61, 'W', AltW},
-	       {"Help",    72, 'H', AltH}
+OPT opt[] = { {"#", 3, '#', AltSYS},
+{"File", 10, 'F', AltF},
+{"Edit", 19, 'E', AltE},
+{"Search", 28, 'S', AltS},
+{"Block", 39, 'B', AltB},
+{"Options", 49, 'O', AltO},
+{"Window", 61, 'W', AltW},
+{"Help", 72, 'H', AltH}
 #ifdef PROG
-	       , {NULL,  0, 0, 0}
-	       , {NULL,  0, 0, 0}
+, {NULL, 0, 0, 0}
+, {NULL, 0, 0, 0}
 #endif
 #ifdef DEBUGGER
-	       , {NULL, 0, 0, 0}
+, {NULL, 0, 0, 0}
 #endif
-	    };
+};
 
-WOPT eblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"F2 Save",  9, 0, 2, F2},
-		    {"F3 Files", 18, 0, 2,  F3},
-		    {"Alt-F3 Close W.", 28, 0, 6, AF3},
-		    {"F4 Search", 45, 0, 2, F4},
-		    {"^L S.Again", 56, 0, 2, CF4},
-		    {"Alt-X Quit",  68, 0, 5, AltX}  };
+WOPT eblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"F2 Save", 9, 0, 2, F2},
+{"F3 Files", 18, 0, 2, F3},
+{"Alt-F3 Close W.", 28, 0, 6, AF3},
+{"F4 Search", 45, 0, 2, F4},
+{"^L S.Again", 56, 0, 2, CF4},
+{"Alt-X Quit", 68, 0, 5, AltX}
+};
 
-WOPT eblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Alt-F2 Save",  9, 0, 6, AF2},
-		    {"F2 Files", 22, 0, 2,  F2},
-		    {"^F4 Close ", 32, 0, 3, CF4},
-		    {"Alt-F3 Srch", 44, 0, 6, AF3},
-		    {"F3 S.Ag.", 57, 0, 2, F3},
-		    {"Alt-F4 Quit",  67, 0, 6, AF4}  };
+WOPT eblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Alt-F2 Save", 9, 0, 6, AF2},
+{"F2 Files", 22, 0, 2, F2},
+{"^F4 Close ", 32, 0, 3, CF4},
+{"Alt-F3 Srch", 44, 0, 6, AF3},
+{"F3 S.Ag.", 57, 0, 2, F3},
+{"Alt-F4 Quit", 67, 0, 6, AF4}
+};
 
-WOPT fblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Edit",  10, 0, 1, AltE},
-		    {"Attributes", 17, 0, 1,  AltA},
-		    {"Move", 29, 0, 1, AltM},
-		    {"COpy", 35, 1, 1, AltO},
-		    {"Remove", 41, 0, 1, AltR},
-		    {"Alt-F3 Close W.", 49, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT fblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Edit", 10, 0, 1, AltE},
+{"Attributes", 17, 0, 1, AltA},
+{"Move", 29, 0, 1, AltM},
+{"COpy", 35, 1, 1, AltO},
+{"Remove", 41, 0, 1, AltR},
+{"Alt-F3 Close W.", 49, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT fblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Edit",  9, 0, 1, AltE},
-		    {"RePlace", 15, 2, 1,  AltP},
-		    {"Move", 24, 0, 1, AltM},
-		    {"DUplicate", 30, 1, 1, AltU},
-		    {"Remove", 41, 0, 1, AltR},
-		    {"^F4 Close W.", 49, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT fblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Edit", 9, 0, 1, AltE},
+{"RePlace", 15, 2, 1, AltP},
+{"Move", 24, 0, 1, AltM},
+{"DUplicate", 30, 1, 1, AltU},
+{"Remove", 41, 0, 1, AltR},
+{"^F4 Close W.", 49, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-WOPT mblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"PreV. Err.",  9, 3, 1, AltV},
-		    {"NexT Err.", 21, 3, 1,  AltT},
-		    {"Compile", 32, 0, 1, AltC},
-		    {"Make", 41, 0, 1, AltM},
-		    {"RUn", 47, 1, 1, AltU},
-		    {"Alt-F3 Close", 52, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT mblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"PreV. Err.", 9, 3, 1, AltV},
+{"NexT Err.", 21, 3, 1, AltT},
+{"Compile", 32, 0, 1, AltC},
+{"Make", 41, 0, 1, AltM},
+{"RUn", 47, 1, 1, AltU},
+{"Alt-F3 Close", 52, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT mblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"PreV. Err.",  9, 3, 1, AltV},
-		    {"NexT Err.", 21, 3, 1,  AltT},
-		    {"Compile", 32, 0, 1, AltC},
-		    {"Make", 41, 0, 1, AltM},
-		    {"RUn", 47, 1, 1, AltU},
-		    {"^F4 Close", 52, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT mblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"PreV. Err.", 9, 3, 1, AltV},
+{"NexT Err.", 21, 3, 1, AltT},
+{"Compile", 32, 0, 1, AltC},
+{"Make", 41, 0, 1, AltM},
+{"RUn", 47, 1, 1, AltU},
+{"^F4 Close", 52, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-WOPT dblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"^F7 Make Watch",  9, 0, 3, CF7},
-		    {"F7 Trace", 25, 0, 2,  F7},
-                    {"F8 Step", 34, 0, 2, F8},
-		    {"^F10 Run", 43, 0, 4, F10},
-		    {"Alt-F3 Close", 53, 0, 6, AF3},
-		    {"Alt-X Quit",  67, 0, 5, AltX}  };
+WOPT dblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"^F7 Make Watch", 9, 0, 3, CF7},
+{"F7 Trace", 25, 0, 2, F7},
+{"F8 Step", 34, 0, 2, F8},
+{"^F10 Run", 43, 0, 4, F10},
+{"Alt-F3 Close", 53, 0, 6, AF3},
+{"Alt-X Quit", 67, 0, 5, AltX}
+};
 
-WOPT dblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"^F5 Make Watch",  9, 0, 3, CF7},
-		    {"F7 Trace", 25, 0, 2,  F7},
-		    {"F8 Step", 34, 0, 2, F8},
-		    {"^F10 Run", 43, 0, 4, F10},
-		    {"^F4 Close", 53, 0, 3, CF4},
-                    {"Alt-F4 Quit",  64, 0, 6, AF4}  };
+WOPT dblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"^F5 Make Watch", 9, 0, 3, CF7},
+{"F7 Trace", 25, 0, 2, F7},
+{"F8 Step", 34, 0, 2, F8},
+{"^F10 Run", 43, 0, 4, F10},
+{"^F4 Close", 53, 0, 3, CF4},
+{"Alt-F4 Quit", 64, 0, 6, AF4}
+};
 
-WOPT xblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Execute",  19, 0, 1, AltE},
-		    {"Alt-F3 Close W.", 38, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT xblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Execute", 19, 0, 1, AltE},
+{"Alt-F3 Close W.", 38, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT xblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Execute",  19, 0, 1, AltE},
-		    {"^F4 Close W.", 38, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT xblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Execute", 19, 0, 1, AltE},
+{"^F4 Close W.", 38, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-WOPT wblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Write",  19, 0, 1, AltW},
-		    {"Alt-F3 Close W.", 38, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT wblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Write", 19, 0, 1, AltW},
+{"Alt-F3 Close W.", 38, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT wblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Write",  19, 0, 1, AltW},
-		    {"^F4 Close W.", 38, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT wblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Write", 19, 0, 1, AltW},
+{"^F4 Close W.", 38, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-WOPT rblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Read",  19, 0, 1, AltR},
-		    {"Alt-F3 Close W.", 38, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT rblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Read", 19, 0, 1, AltR},
+{"Alt-F3 Close W.", 38, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT rblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Read",  19, 0, 1, AltR},
-		    {"^F4 Close W.", 38, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT rblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Read", 19, 0, 1, AltR},
+{"^F4 Close W.", 38, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-WOPT ablst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Add",  19, 0, 1, AltA},
-		    {"Alt-F3 Close W.", 38, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT ablst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Add", 19, 0, 1, AltA},
+{"Alt-F3 Close W.", 38, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT ablst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Add",  19, 0, 1, AltA},
-		    {"^F4 Close W.", 38, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT ablst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Add", 19, 0, 1, AltA},
+{"^F4 Close W.", 38, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-WOPT sblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Save",  14, 0, 1, AltS},
-		    {"Change Dir",  25, 0, 1, AltC},
-		    {"Alt-F3 Close W.", 42, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT sblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Save", 14, 0, 1, AltS},
+{"Change Dir", 25, 0, 1, AltC},
+{"Alt-F3 Close W.", 42, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT sblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Save",  14, 0, 1, AltS},
-		    {"Change Dir",  25, 0, 1, AltC},
-		    {"^F4 Close W.", 42, 0, 3, CF4},
-		    {"Alt-F4 Quit",  66, 0, 6, AF4}  };
+WOPT sblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Save", 14, 0, 1, AltS},
+{"Change Dir", 25, 0, 1, AltC},
+{"^F4 Close W.", 42, 0, 3, CF4},
+{"Alt-F4 Quit", 66, 0, 6, AF4}
+};
 
-WOPT hblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"<BSP> Back",  9, 0, 5, WPE_DC},
-		    {"<CR> Goto",  21, 0, 4, WPE_CR},
-		    {" PreVious",  32, 4, 1, AltV},
-		    {" NexT",  45, 4, 1, AltT},
-		    {"Alt-F3 Close", 54, 0, 6, AF3},
-		    {"Alt-X Quit",  68, 0, 5, AltX}  };
+WOPT hblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"<BSP> Back", 9, 0, 5, WPE_DC},
+{"<CR> Goto", 21, 0, 4, WPE_CR},
+{" PreVious", 32, 4, 1, AltV},
+{" NexT", 45, 4, 1, AltT},
+{"Alt-F3 Close", 54, 0, 6, AF3},
+{"Alt-X Quit", 68, 0, 5, AltX}
+};
 
-WOPT hblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"<BSP> Back",  9, 0, 5, WPE_DC},
-		    {"<CR> Goto",  21, 0, 4, WPE_CR},
-		    {" PreVious",  32, 4, 1, AltV},
-		    {" NexT",  45, 4, 1, AltT},
-		    {"^F4 Close", 54, 0, 3, CF4},
-		    {"Alt-F4 Quit",  65, 0, 6, AF4}  };
+WOPT hblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"<BSP> Back", 9, 0, 5, WPE_DC},
+{"<CR> Goto", 21, 0, 4, WPE_CR},
+{" PreVious", 32, 4, 1, AltV},
+{" NexT", 45, 4, 1, AltT},
+{"^F4 Close", 54, 0, 3, CF4},
+{"Alt-F4 Quit", 65, 0, 6, AF4}
+};
 
-WOPT gblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Show",  19, 0, 1, AltS},
-		    {"Alt-F3 Close W.", 38, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX}  };
+WOPT gblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Show", 19, 0, 1, AltS},
+{"Alt-F3 Close W.", 38, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT gblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Show",  19, 0, 1, AltS},
-		    {"^F4 Close W.", 38, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT gblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Show", 19, 0, 1, AltS},
+{"^F4 Close W.", 38, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-WOPT oblst_o[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Add",  14, 0, 1, AltA},
-		    {"Delete",  25, 0, 1, AltD},
-		    {"Alt-F3 Close W.", 42, 0, 6, AF3},
-		    {"Alt-X Quit",  66, 0, 5, AltX} };
+WOPT oblst_o[] = { {"F1 Help", 0, 0, 2, F1},
+{"Add", 14, 0, 1, AltA},
+{"Delete", 25, 0, 1, AltD},
+{"Alt-F3 Close W.", 42, 0, 6, AF3},
+{"Alt-X Quit", 66, 0, 5, AltX}
+};
 
-WOPT oblst_u[] = {  {"F1 Help",  0, 0, 2, F1},
-		    {"Add",  14, 0, 1, AltA},
-		    {"Delete",  25, 0, 1, AltD},
-		    {"^F4 Close W.", 42, 0, 3, CF4},
-		    {"Alt-F4 Quit",  63, 0, 6, AF4}  };
+WOPT oblst_u[] = { {"F1 Help", 0, 0, 2, F1},
+{"Add", 14, 0, 1, AltA},
+{"Delete", 25, 0, 1, AltD},
+{"^F4 Close W.", 42, 0, 3, CF4},
+{"Alt-F4 Quit", 63, 0, 6, AF4}
+};
 
-void ECNT_Init(ECNT *cn)
+void
+ECNT_Init (ECNT * cn)
 {
- cn->mxedt = -1;
- cn->curedt = 0;
- cn->edt[0] = 0;
- cn->fb = NULL;
- cn->print_cmd = WpeStrdup(PRNTCMD);
+  cn->mxedt = -1;
+  cn->curedt = 0;
+  cn->edt[0] = 0;
+  cn->fb = NULL;
+  cn->print_cmd = WpeStrdup (PRNTCMD);
 
- cn->dirct = WpeGetCurrentDir(cn);
+  cn->dirct = WpeGetCurrentDir (cn);
 
- strcpy(cn->fd.search, "");
- strcpy(cn->fd.replace, "");
- strcpy(cn->fd.file, SUDIR);
- cn->fd.dirct = WpeStrdup(cn->dirct);
+  strcpy (cn->fd.search, "");
+  strcpy (cn->fd.replace, "");
+  strcpy (cn->fd.file, SUDIR);
+  cn->fd.dirct = WpeStrdup (cn->dirct);
 
- cn->fd.sw = 16;
- cn->fd.sn = 0;
- cn->fd.rn = 0;
+  cn->fd.sw = 16;
+  cn->fd.sn = 0;
+  cn->fd.rn = 0;
 
- cn->sdf = cn->rdf = cn->fdf = cn->ddf = cn->wdf = cn->hdf = cn->shdf = NULL;
+  cn->sdf = cn->rdf = cn->fdf = cn->ddf = cn->wdf = cn->hdf = cn->shdf = NULL;
 
- /*   standard adjustments    */
- cn->dtmd = DTMD_NORMAL;
- cn->autosv = 0;
- cn->maxchg = 999;
- cn->numundo = 10;
- cn->maxcol = MAXCOLUM;
- cn->tabn = 8;
- cn->autoindent = 3;
- cn->tabs = malloc((cn->tabn+1)*sizeof(char));
- WpeStringBlank(cn->tabs, cn->tabn);
- cn->flopt = FM_REKURSIVE_ACTIONS | FM_REMOVE_INTO_WB | FM_MOVE_PROMPT |
-   FM_MOVE_PROMPT | FM_PROMPT_DELETE;
- cn->edopt = ED_SOURCE_AUTO_INDENT | ED_ERRORS_STOP_AT | ED_SYNTAX_HIGHLIGHT;
+  /*   standard adjustments    */
+  cn->dtmd = DTMD_NORMAL;
+  cn->autosv = 0;
+  cn->maxchg = 999;
+  cn->numundo = 10;
+  cn->maxcol = MAXCOLUM;
+  cn->tabn = 8;
+  cn->autoindent = 3;
+  cn->tabs = malloc ((cn->tabn + 1) * sizeof (char));
+  WpeStringBlank (cn->tabs, cn->tabn);
+  cn->flopt = FM_REKURSIVE_ACTIONS | FM_REMOVE_INTO_WB | FM_MOVE_PROMPT |
+    FM_MOVE_PROMPT | FM_PROMPT_DELETE;
+  cn->edopt = ED_SOURCE_AUTO_INDENT | ED_ERRORS_STOP_AT | ED_SYNTAX_HIGHLIGHT;
 }
 
-int main(int argc, char **argv)
+int
+main (int argc, char **argv)
 {
- FARBE *fb;
- ECNT *cn;
- int i, err = 0, g[4];
- int so = 0, sd = 1;
- char *tp;
+  FARBE *fb;
+  ECNT *cn;
+  int i, err = 0, g[4];
+  int so = 0, sd = 1;
+  char *tp;
 
- if ((cn = (ECNT *)malloc(sizeof(ECNT))) == NULL) {
-  printf(" Fatal Error: %s\n", e_msg[ERR_LOWMEM]);
-  return 0;
- }
- ECNT_Init(cn);
- e_ini_unix(&argc, argv);
- (*e_u_switch_screen)(1);
- fb = e_ini_farbe();
- WpeEditor = cn;
- cn->fb = fb;
+  if ((cn = (ECNT *) malloc (sizeof (ECNT))) == NULL)
+    {
+      printf (" Fatal Error: %s\n", e_msg[ERR_LOWMEM]);
+      return 0;
+    }
+  ECNT_Init (cn);
+  e_ini_unix (&argc, argv);
+  (*e_u_switch_screen) (1);
+  fb = e_ini_farbe ();
+  WpeEditor = cn;
+  cn->fb = fb;
 
- info_file = malloc((strlen(INFO_DIR)+1)*sizeof(char));
- strcpy(info_file, INFO_DIR);
- e_read_help_str();
- e_hlp = e_hlp_str[0];
- if (!(user_shell = getenv("SHELL"))) user_shell = DEF_SHELL;
+  info_file = malloc ((strlen (INFO_DIR) + 1) * sizeof (char));
+  strcpy (info_file, INFO_DIR);
+  e_read_help_str ();
+  e_hlp = e_hlp_str[0];
+  if (!(user_shell = getenv ("SHELL")))
+    user_shell = DEF_SHELL;
 #ifdef HAVE_MKDTEMP
- e_tmp_dir = strdup("/tmp/xwpe_XXXXXX");
- if (mkdtemp(e_tmp_dir) == NULL)
+  e_tmp_dir = strdup ("/tmp/xwpe_XXXXXX");
+  if (mkdtemp (e_tmp_dir) == NULL)
 #else
 #if defined(HAVE_TEMPNAM)
- e_tmp_dir = tempnam(NULL, "xwpe_");
+  e_tmp_dir = tempnam (NULL, "xwpe_");
 #else
- e_tmp_dir = malloc(128);
- sprintf(e_tmp_dir, "/tmp/we_%u", (unsigned) getpid());
- e_tmp_dir = realloc(e_tmp_dir, (strlen(e_tmp_dir)+1)*sizeof(char));
+  e_tmp_dir = malloc (128);
+  sprintf (e_tmp_dir, "/tmp/we_%u", (unsigned) getpid ());
+  e_tmp_dir = realloc (e_tmp_dir, (strlen (e_tmp_dir) + 1) * sizeof (char));
 #endif
- if ((e_tmp_dir == NULL) || (mkdir(e_tmp_dir, 0700) != 0))
+  if ((e_tmp_dir == NULL) || (mkdir (e_tmp_dir, 0700) != 0))
 #endif
- {
-  perror("Xwpe: ");
-  return 1;
- }
+    {
+      perror ("Xwpe: ");
+      return 1;
+    }
 
- for (i = 1; i < argc; i++)
- {
-  if (*argv[i] == '-')
-  {
-   if (*(argv[i]+1) == 's' && *(argv[i]+2) == 'o') so = 1;
-   else if (*(argv[i]+1) == 's' && *(argv[i]+2) == 'f')
-   {
-    sd = 0;
-    cn->optfile = malloc((strlen(argv[i+1])+1)*sizeof(char));
-    strcpy(cn->optfile, argv[i+1]);
-   }
-  }
- }
+  for (i = 1; i < argc; i++)
+    {
+      if (*argv[i] == '-')
+	{
+	  if (*(argv[i] + 1) == 's' && *(argv[i] + 2) == 'o')
+	    so = 1;
+	  else if (*(argv[i] + 1) == 's' && *(argv[i] + 2) == 'f')
+	    {
+	      sd = 0;
+	      cn->optfile =
+		malloc ((strlen (argv[i + 1]) + 1) * sizeof (char));
+	      strcpy (cn->optfile, argv[i + 1]);
+	    }
+	}
+    }
 #ifdef PROG
- e_ini_prog(cn);
+  e_ini_prog (cn);
 #endif
- if (sd != 0)
- {
-  FILE *f = fopen(OPTION_FILE, "r");
-  if (f)
-  {
-   fclose(f);
-   cn->optfile = e_mkfilename(cn->dirct, OPTION_FILE);
-  }
+  if (sd != 0)
+    {
+      FILE *f = fopen (OPTION_FILE, "r");
+      if (f)
+	{
+	  fclose (f);
+	  cn->optfile = e_mkfilename (cn->dirct, OPTION_FILE);
+	}
+      else
+	{
+	  cn->optfile = e_mkfilename (getenv ("HOME"), XWPE_HOME);
+	  cn->optfile = realloc (cn->optfile,
+				 strlen (cn->optfile) + strlen (OPTION_FILE) +
+				 2);
+	  strcat (cn->optfile, DIRS);
+	  strcat (cn->optfile, OPTION_FILE);
+	}
+    }
+  if (so == 0)
+    err = e_opt_read (cn);
+  e_edit (cn, "");		/* Clipboard (must first read option file) */
+  if ((tp = getenv ("INFOPATH")) != NULL)
+    {
+      if (info_file)
+	free (info_file);
+      info_file = WpeStrdup (tp);
+    }
+  if (cn->edopt & ED_CUA_STYLE)
+    blst = eblst_u;
   else
-  {
-   cn->optfile = e_mkfilename(getenv("HOME"), XWPE_HOME);
-   cn->optfile = realloc(cn->optfile,
-     strlen(cn->optfile) + strlen(OPTION_FILE) + 2);
-   strcat(cn->optfile, DIRS);
-   strcat(cn->optfile, OPTION_FILE);
-  }
- }
- if (so == 0) err = e_opt_read(cn);
- e_edit(cn, ""); /* Clipboard (must first read option file) */
- if ((tp = getenv("INFOPATH")) != NULL)
- {
-  if (info_file) free(info_file);
-  info_file = WpeStrdup(tp);
- }
- if (cn->edopt & ED_CUA_STYLE) blst = eblst_u;
- else blst = eblst_o;
- e_ini_desk(cn);
- cn->f[0]->blst = eblst;
+    blst = eblst_o;
+  e_ini_desk (cn);
+  cn->f[0]->blst = eblst;
 #if MOUSE
- g[0] = 4; g[2] = 0; g[3] = 0;
- fk_mouse(g);
- g[0] = 1;
- fk_mouse(g);
+  g[0] = 4;
+  g[2] = 0;
+  g[3] = 0;
+  fk_mouse (g);
+  g[0] = 1;
+  fk_mouse (g);
 #endif
- /* this error comes from reading the options file */
- if (err > 0) e_error(e_msg[err], 0, cn->fb);
- if (WpeIsProg()) WpeSyntaxReadFile(cn);
+  /* this error comes from reading the options file */
+  if (err > 0)
+    e_error (e_msg[err], 0, cn->fb);
+  if (WpeIsProg ())
+    WpeSyntaxReadFile (cn);
 #ifdef UNIX
- for (i = 1; i < argc; i++)
-  if (!strcmp(argv[i], "-r")) e_recover(cn);
+  for (i = 1; i < argc; i++)
+    if (!strcmp (argv[i], "-r"))
+      e_recover (cn);
 #endif
- for (i = 1; i < argc; i++)
- {
-  if (*argv[i] == '-')
-  {
-   if (*(argv[i]+1) == 's' && *(argv[i]+2) == 'f') i++;
+  for (i = 1; i < argc; i++)
+    {
+      if (*argv[i] == '-')
+	{
+	  if (*(argv[i] + 1) == 's' && *(argv[i] + 2) == 'f')
+	    i++;
 #if defined(UNIX) && defined(PROG)
-   else if (*(argv[i]+1) == 'p' && *(argv[i]+2) == 'm') e_we_sw |= 8;
+	  else if (*(argv[i] + 1) == 'p' && *(argv[i] + 2) == 'm')
+	    e_we_sw |= 8;
 #endif
-   continue;
-  }
-  else e_edit(cn, argv[i]);
- }
- if (cn->mxedt == 0) WpeManager(cn->f[cn->mxedt]);
- do
- {
-  if (cn->f[cn->mxedt]->dtmd == DTMD_FILEMANAGER) i = WpeHandleFileManager(cn);
-  else if (cn->f[cn->mxedt]->dtmd == DTMD_DATA) i = e_data_eingabe(cn);
-  else i = e_eingabe(cn);
-  if (i == AltX) i = e_quit(cn->f[cn->mxedt]);
- }
- while (i != AltX);
- WpeExit(0);
- return 0;
+	  continue;
+	}
+      else
+	e_edit (cn, argv[i]);
+    }
+  if (cn->mxedt == 0)
+    WpeManager (cn->f[cn->mxedt]);
+  do
+    {
+      if (cn->f[cn->mxedt]->dtmd == DTMD_FILEMANAGER)
+	i = WpeHandleFileManager (cn);
+      else if (cn->f[cn->mxedt]->dtmd == DTMD_DATA)
+	i = e_data_eingabe (cn);
+      else
+	i = e_eingabe (cn);
+      if (i == AltX)
+	i = e_quit (cn->f[cn->mxedt]);
+    }
+  while (i != AltX);
+  WpeExit (0);
+  return 0;
 }
 
-int e_switch_blst(ECNT *cn)
+int
+e_switch_blst (ECNT * cn)
 {
- int i;
- FENSTER *f;
+  int i;
+  FENSTER *f;
 
- if (cn->edopt & ED_CUA_STYLE)
- {
-  for (i = 0; i <= cn->mxedt; i++)
-  {
-   f = cn->f[i];
-   if (f->blst == eblst_o) f->blst = eblst_u;
-   else if (f->blst == fblst_o) f->blst= fblst_u;
-   else if (f->blst == mblst_o) f->blst= mblst_u;
-   else if (f->blst == dblst_o) f->blst= dblst_u;
-   else if (f->blst == xblst_o) f->blst= xblst_u;
-   else if (f->blst == wblst_o) f->blst= wblst_u;
-   else if (f->blst == rblst_o) f->blst= rblst_u;
-   else if (f->blst == ablst_o) f->blst= ablst_u;
-   else if (f->blst == sblst_o) f->blst= sblst_u;
-   else if (f->blst == hblst_o) f->blst= hblst_u;
-   else if (f->blst == gblst_o) f->blst= gblst_u;
-   else if (f->blst == oblst_o) f->blst= oblst_u;
-  }
- }
- else
- {
-  for(i = 0; i <= cn->mxedt; i++)
-  {
-   f = cn->f[i];
-   if (f->blst == eblst_u) f->blst= eblst_o;
-   else if (f->blst == fblst_u) f->blst= fblst_o;
-   else if (f->blst == mblst_u) f->blst= mblst_o;
-   else if (f->blst == dblst_u) f->blst= dblst_o;
-   else if (f->blst == xblst_u) f->blst= xblst_o;
-   else if (f->blst == wblst_u) f->blst= wblst_o;
-   else if (f->blst == rblst_u) f->blst= rblst_o;
-   else if (f->blst == ablst_u) f->blst= ablst_o;
-   else if (f->blst == sblst_u) f->blst= sblst_o;
-   else if (f->blst == hblst_u) f->blst= hblst_o;
-   else if (f->blst == gblst_u) f->blst= gblst_o;
-   else if (f->blst == oblst_u) f->blst= oblst_o;
-  }
- }
- return(0);
-}
-
-void e_ini_desk(ECNT *cn)
-{
- extern int e_mn_men;
- int i;
-
- if (cn->edopt & ED_CUA_STYLE)
- {
-  eblst = eblst_u; fblst = fblst_u; mblst = mblst_u; dblst = dblst_u;
-  xblst = xblst_u; wblst = wblst_u; rblst = rblst_u; ablst = ablst_u;
-  sblst = sblst_u; hblst = hblst_u; gblst = gblst_u; oblst = oblst_u;
- }
- else
- {
-  eblst = eblst_o; fblst = fblst_o; mblst = mblst_o; dblst = dblst_o;
-  xblst = xblst_o; wblst = wblst_o; rblst = rblst_o; ablst = ablst_o;
-  sblst = sblst_o; hblst = hblst_o; gblst = gblst_o; oblst = oblst_o;
- }
- e_cls(cn->fb->df.fb, cn->fb->dc);
- e_blk(MAXSCOL, 0, 0, cn->fb->mt.fb);
-
- /* put out the main menu */
- for (i = 0; i < MENOPT; ++i)
- {
-    e_pr_str_wsd(opt[i].x, 0, opt[i].t, cn->fb->mt.fb, 0, 1, cn->fb->ms.fb,
-                 ( i == 0 ? 0 : opt[i].x-e_mn_men),
-                 (i == MENOPT-1) ? MAXSCOL-1 : opt[i+1].x-e_mn_men-1);
- }
-
- e_pr_uul(cn->fb);
-}
-
-void FARBE_Init(FARBE *fb)
-{
- fb->er = e_s_x_clr(15,4);  /*  Editor Frames         */
- fb->et = e_s_x_clr(11,4);  /*  Editor Text           */
- fb->ez = e_s_x_clr(4,7);   /*  Editors Text highlighted  */
- fb->es = e_s_x_clr(10,4);  /*  Editors Window-Button */
- fb->ek = e_s_x_clr(11,6);  /*  Editors highlighted (find) */
- fb->em = e_s_x_clr(4,6);   /*  Mouse slider bar         */
- fb->mr = e_s_x_clr(0,7);   /*  Menu Frame             */
- fb->mt = e_s_x_clr(0,7);   /*  Menu Text               */
- fb->mz = e_s_x_clr(0,2);   /*  Menu Text highlighted      */
- fb->ms = e_s_x_clr(1,7);   /*  Menu-Switch           */
- fb->nr = e_s_x_clr(15,7);  /*  Options Frame         */
- fb->nt = e_s_x_clr(0,7);   /*  Options Text           */
- fb->nsnt = e_s_x_clr(11,7);/*  Options Text-Switch  */
- fb->ne = e_s_x_clr(1, 7);  /*  Options Window-Button */
- fb->fr = e_s_x_clr(15,4);  /*  Editor Control Bar (?) (Schreibleiste) passive */
- fb->fa = e_s_x_clr(15,2);  /*  Editor Control Bar (?) (Schreibleiste) active */
- fb->ft = e_s_x_clr(0,6);   /*  Data Text		  */
- fb->fz = e_s_x_clr(15,2);  /*  Data active highlighted	  */
- fb->frft = e_s_x_clr(15,6);/*  Data passive highlighted	  */
- fb->fs = e_s_x_clr(0,6);   /*  Switch Text		  */
- fb->nsft = e_s_x_clr(14,6);/*  Switch Switch	  */
- fb->fsm = e_s_x_clr(14,6); /*  Switch active	  */
- fb->nz = e_s_x_clr(15,2);  /*  Button Text             */
- fb->ns = e_s_x_clr(11,2);  /*  Button Switch         */
- fb->nm = e_s_x_clr(11,2);  /*  Button Text highlighted    */
- fb->hh = e_s_x_clr(12,6);  /*  Help Header		  */
- fb->hb = e_s_x_clr(11,2);  /*  Help Button		  */
- fb->hm = e_s_x_clr(10,4);  /*  Help highlighted		  */
- fb->df = e_s_x_clr(7,0);   /*  Background		  */
- fb->of = e_s_x_clr(8,0);   /*  void	(unused)	  */
- fb->db = e_s_x_clr(0,1);   /*  Breakpoint		  	  */
- fb->dy = e_s_x_clr(12,6);  /*  Debugger Stop		  */
- fb->ct = e_s_x_clr(11, 4); /*  C-Prog. Text                 */
- fb->cr = e_s_x_clr(15, 4); /*  C-Prog. res. Words           */
- fb->ck = e_s_x_clr(14, 4); /*  C-Prog. Constants           */
- fb->cp = e_s_x_clr(10, 4); /*  C-Prog. Pre-processor         */
- fb->cc = e_s_x_clr( 7, 4); /*  C-Prog. Comments               */
- fb->dc = ' ';
- fb->ws = 7;
-}
-
-FARBE *e_ini_farbe()
-{
- if (WpeIsXwin())
- {
-  if (!x_fb)
-   x_fb = malloc(sizeof(FARBE));
-  FARBE_Init(x_fb);
-  return x_fb;
- }
- else
- {
-  if (!u_fb)
-   u_fb = malloc(sizeof(FARBE));
-  if (col_num)
-  {
-   FARBE_Init(u_fb);
-  }
+  if (cn->edopt & ED_CUA_STYLE)
+    {
+      for (i = 0; i <= cn->mxedt; i++)
+	{
+	  f = cn->f[i];
+	  if (f->blst == eblst_o)
+	    f->blst = eblst_u;
+	  else if (f->blst == fblst_o)
+	    f->blst = fblst_u;
+	  else if (f->blst == mblst_o)
+	    f->blst = mblst_u;
+	  else if (f->blst == dblst_o)
+	    f->blst = dblst_u;
+	  else if (f->blst == xblst_o)
+	    f->blst = xblst_u;
+	  else if (f->blst == wblst_o)
+	    f->blst = wblst_u;
+	  else if (f->blst == rblst_o)
+	    f->blst = rblst_u;
+	  else if (f->blst == ablst_o)
+	    f->blst = ablst_u;
+	  else if (f->blst == sblst_o)
+	    f->blst = sblst_u;
+	  else if (f->blst == hblst_o)
+	    f->blst = hblst_u;
+	  else if (f->blst == gblst_o)
+	    f->blst = gblst_u;
+	  else if (f->blst == oblst_o)
+	    f->blst = oblst_u;
+	}
+    }
   else
-  {
-   u_fb->er = e_n_t_clr(0);
-   u_fb->et = e_n_t_clr(0);
-   u_fb->ez = e_n_t_clr(A_REVERSE);
-   u_fb->es = e_n_t_clr(0);
-   u_fb->ek = e_n_t_clr(A_UNDERLINE);
-   u_fb->em = e_n_t_clr(A_STANDOUT);
-   u_fb->mr = e_n_t_clr(A_STANDOUT);
-   u_fb->mt = e_n_t_clr(A_STANDOUT);
-   u_fb->mz = e_n_t_clr(0);
-   u_fb->ms = e_n_t_clr(0);
-   u_fb->nr = e_n_t_clr(A_STANDOUT);
-   u_fb->nt = e_n_t_clr(A_REVERSE);
-   u_fb->nsnt = e_n_t_clr(A_BOLD);
-   u_fb->ne = e_n_t_clr(0);
-   u_fb->fr = e_n_t_clr(0);
-   u_fb->fa = e_n_t_clr(A_REVERSE);
-   u_fb->ft = e_n_t_clr(0);
-   u_fb->fz = e_n_t_clr(A_STANDOUT);
-   u_fb->frft = e_n_t_clr(0);
-   u_fb->fs = e_n_t_clr(0);
-   u_fb->nsft = e_n_t_clr(A_BOLD);
-   u_fb->fsm = e_n_t_clr(A_BOLD);
-   u_fb->nz = e_n_t_clr(0);
-   u_fb->ns = e_n_t_clr(A_BOLD);
-   u_fb->nm = e_n_t_clr(A_BOLD);
-   u_fb->hh = e_n_t_clr(A_REVERSE);
-   u_fb->hb = e_n_t_clr(A_REVERSE);
-   u_fb->hm = e_n_t_clr(A_BOLD);
-   u_fb->of = e_n_t_clr(A_STANDOUT);
-   u_fb->df = e_n_t_clr(0);
-   u_fb->db = e_n_t_clr(A_STANDOUT);
-   u_fb->dy = e_n_t_clr(A_STANDOUT);
-   u_fb->ct = e_n_t_clr(0);
-   u_fb->cr = e_n_t_clr(0);
-   u_fb->ck = e_n_t_clr(0);
-   u_fb->cp = e_n_t_clr(0);
-   u_fb->cc = e_n_t_clr(0);
-   u_fb->dc = 0x20;
-   u_fb->ws = 0;
-  }
-  return u_fb;
- }
+    {
+      for (i = 0; i <= cn->mxedt; i++)
+	{
+	  f = cn->f[i];
+	  if (f->blst == eblst_u)
+	    f->blst = eblst_o;
+	  else if (f->blst == fblst_u)
+	    f->blst = fblst_o;
+	  else if (f->blst == mblst_u)
+	    f->blst = mblst_o;
+	  else if (f->blst == dblst_u)
+	    f->blst = dblst_o;
+	  else if (f->blst == xblst_u)
+	    f->blst = xblst_o;
+	  else if (f->blst == wblst_u)
+	    f->blst = wblst_o;
+	  else if (f->blst == rblst_u)
+	    f->blst = rblst_o;
+	  else if (f->blst == ablst_u)
+	    f->blst = ablst_o;
+	  else if (f->blst == sblst_u)
+	    f->blst = sblst_o;
+	  else if (f->blst == hblst_u)
+	    f->blst = hblst_o;
+	  else if (f->blst == gblst_u)
+	    f->blst = gblst_o;
+	  else if (f->blst == oblst_u)
+	    f->blst = oblst_o;
+	}
+    }
+  return (0);
 }
 
-void e_free_find(FIND *fd)
+void
+e_ini_desk (ECNT * cn)
 {
- if (fd->dirct)
- {
-  free(fd->dirct);
-  fd->dirct = NULL;
- }
+  extern int e_mn_men;
+  int i;
+
+  if (cn->edopt & ED_CUA_STYLE)
+    {
+      eblst = eblst_u;
+      fblst = fblst_u;
+      mblst = mblst_u;
+      dblst = dblst_u;
+      xblst = xblst_u;
+      wblst = wblst_u;
+      rblst = rblst_u;
+      ablst = ablst_u;
+      sblst = sblst_u;
+      hblst = hblst_u;
+      gblst = gblst_u;
+      oblst = oblst_u;
+    }
+  else
+    {
+      eblst = eblst_o;
+      fblst = fblst_o;
+      mblst = mblst_o;
+      dblst = dblst_o;
+      xblst = xblst_o;
+      wblst = wblst_o;
+      rblst = rblst_o;
+      ablst = ablst_o;
+      sblst = sblst_o;
+      hblst = hblst_o;
+      gblst = gblst_o;
+      oblst = oblst_o;
+    }
+  e_cls (cn->fb->df.fb, cn->fb->dc);
+  e_blk (MAXSCOL, 0, 0, cn->fb->mt.fb);
+
+  /* put out the main menu */
+  for (i = 0; i < MENOPT; ++i)
+    {
+      e_pr_str_wsd (opt[i].x, 0, opt[i].t, cn->fb->mt.fb, 0, 1, cn->fb->ms.fb,
+		    (i == 0 ? 0 : opt[i].x - e_mn_men),
+		    (i ==
+		     MENOPT - 1) ? MAXSCOL - 1 : opt[i + 1].x - e_mn_men - 1);
+    }
+
+  e_pr_uul (cn->fb);
 }
 
+void
+FARBE_Init (FARBE * fb)
+{
+  fb->er = e_s_x_clr (15, 4);	/*  Editor Frames         */
+  fb->et = e_s_x_clr (11, 4);	/*  Editor Text           */
+  fb->ez = e_s_x_clr (4, 7);	/*  Editors Text highlighted  */
+  fb->es = e_s_x_clr (10, 4);	/*  Editors Window-Button */
+  fb->ek = e_s_x_clr (11, 6);	/*  Editors highlighted (find) */
+  fb->em = e_s_x_clr (4, 6);	/*  Mouse slider bar         */
+  fb->mr = e_s_x_clr (0, 7);	/*  Menu Frame             */
+  fb->mt = e_s_x_clr (0, 7);	/*  Menu Text               */
+  fb->mz = e_s_x_clr (0, 2);	/*  Menu Text highlighted      */
+  fb->ms = e_s_x_clr (1, 7);	/*  Menu-Switch           */
+  fb->nr = e_s_x_clr (15, 7);	/*  Options Frame         */
+  fb->nt = e_s_x_clr (0, 7);	/*  Options Text           */
+  fb->nsnt = e_s_x_clr (11, 7);	/*  Options Text-Switch  */
+  fb->ne = e_s_x_clr (1, 7);	/*  Options Window-Button */
+  fb->fr = e_s_x_clr (15, 4);	/*  Editor Control Bar (?) (Schreibleiste) passive */
+  fb->fa = e_s_x_clr (15, 2);	/*  Editor Control Bar (?) (Schreibleiste) active */
+  fb->ft = e_s_x_clr (0, 6);	/*  Data Text                 */
+  fb->fz = e_s_x_clr (15, 2);	/*  Data active highlighted   */
+  fb->frft = e_s_x_clr (15, 6);	/*  Data passive highlighted          */
+  fb->fs = e_s_x_clr (0, 6);	/*  Switch Text               */
+  fb->nsft = e_s_x_clr (14, 6);	/*  Switch Switch     */
+  fb->fsm = e_s_x_clr (14, 6);	/*  Switch active     */
+  fb->nz = e_s_x_clr (15, 2);	/*  Button Text             */
+  fb->ns = e_s_x_clr (11, 2);	/*  Button Switch         */
+  fb->nm = e_s_x_clr (11, 2);	/*  Button Text highlighted    */
+  fb->hh = e_s_x_clr (12, 6);	/*  Help Header               */
+  fb->hb = e_s_x_clr (11, 2);	/*  Help Button               */
+  fb->hm = e_s_x_clr (10, 4);	/*  Help highlighted                  */
+  fb->df = e_s_x_clr (7, 0);	/*  Background                */
+  fb->of = e_s_x_clr (8, 0);	/*  void    (unused)          */
+  fb->db = e_s_x_clr (0, 1);	/*  Breakpoint                        */
+  fb->dy = e_s_x_clr (12, 6);	/*  Debugger Stop             */
+  fb->ct = e_s_x_clr (11, 4);	/*  C-Prog. Text                 */
+  fb->cr = e_s_x_clr (15, 4);	/*  C-Prog. res. Words           */
+  fb->ck = e_s_x_clr (14, 4);	/*  C-Prog. Constants           */
+  fb->cp = e_s_x_clr (10, 4);	/*  C-Prog. Pre-processor         */
+  fb->cc = e_s_x_clr (7, 4);	/*  C-Prog. Comments               */
+  fb->dc = ' ';
+  fb->ws = 7;
+}
+
+FARBE *
+e_ini_farbe ()
+{
+  if (WpeIsXwin ())
+    {
+      if (!x_fb)
+	x_fb = malloc (sizeof (FARBE));
+      FARBE_Init (x_fb);
+      return x_fb;
+    }
+  else
+    {
+      if (!u_fb)
+	u_fb = malloc (sizeof (FARBE));
+      if (col_num)
+	{
+	  FARBE_Init (u_fb);
+	}
+      else
+	{
+	  u_fb->er = e_n_t_clr (0);
+	  u_fb->et = e_n_t_clr (0);
+	  u_fb->ez = e_n_t_clr (A_REVERSE);
+	  u_fb->es = e_n_t_clr (0);
+	  u_fb->ek = e_n_t_clr (A_UNDERLINE);
+	  u_fb->em = e_n_t_clr (A_STANDOUT);
+	  u_fb->mr = e_n_t_clr (A_STANDOUT);
+	  u_fb->mt = e_n_t_clr (A_STANDOUT);
+	  u_fb->mz = e_n_t_clr (0);
+	  u_fb->ms = e_n_t_clr (0);
+	  u_fb->nr = e_n_t_clr (A_STANDOUT);
+	  u_fb->nt = e_n_t_clr (A_REVERSE);
+	  u_fb->nsnt = e_n_t_clr (A_BOLD);
+	  u_fb->ne = e_n_t_clr (0);
+	  u_fb->fr = e_n_t_clr (0);
+	  u_fb->fa = e_n_t_clr (A_REVERSE);
+	  u_fb->ft = e_n_t_clr (0);
+	  u_fb->fz = e_n_t_clr (A_STANDOUT);
+	  u_fb->frft = e_n_t_clr (0);
+	  u_fb->fs = e_n_t_clr (0);
+	  u_fb->nsft = e_n_t_clr (A_BOLD);
+	  u_fb->fsm = e_n_t_clr (A_BOLD);
+	  u_fb->nz = e_n_t_clr (0);
+	  u_fb->ns = e_n_t_clr (A_BOLD);
+	  u_fb->nm = e_n_t_clr (A_BOLD);
+	  u_fb->hh = e_n_t_clr (A_REVERSE);
+	  u_fb->hb = e_n_t_clr (A_REVERSE);
+	  u_fb->hm = e_n_t_clr (A_BOLD);
+	  u_fb->of = e_n_t_clr (A_STANDOUT);
+	  u_fb->df = e_n_t_clr (0);
+	  u_fb->db = e_n_t_clr (A_STANDOUT);
+	  u_fb->dy = e_n_t_clr (A_STANDOUT);
+	  u_fb->ct = e_n_t_clr (0);
+	  u_fb->cr = e_n_t_clr (0);
+	  u_fb->ck = e_n_t_clr (0);
+	  u_fb->cp = e_n_t_clr (0);
+	  u_fb->cc = e_n_t_clr (0);
+	  u_fb->dc = 0x20;
+	  u_fb->ws = 0;
+	}
+      return u_fb;
+    }
+}
+
+void
+e_free_find (FIND * fd)
+{
+  if (fd->dirct)
+    {
+      free (fd->dirct);
+      fd->dirct = NULL;
+    }
+}

--- a/src/we_main.h
+++ b/src/we_main.h
@@ -11,11 +11,11 @@
 #include "we_opt.h"
 #include "we_unix.h"
 
-void e_ini_desk(ECNT * cn);
-void FARBE_Init(FARBE * fb);
-FARBE * e_ini_farbe();
-int e_switch_blst(ECNT * cn);
-void e_free_find(FIND * fd);
+void e_ini_desk (ECNT * cn);
+void FARBE_Init (FARBE * fb);
+FARBE *e_ini_farbe ();
+int e_switch_blst (ECNT * cn);
+void e_free_find (FIND * fd);
 
 extern char *e_msg[];
 

--- a/src/we_menue.c
+++ b/src/we_menue.c
@@ -15,45 +15,46 @@
 #include "we_progn.h"
 #include "we_prog.h"
 
-int             e_p_show_messages(FENSTER *f);
-int             e_p_show_watches(FENSTER *f);
-int             e_blck_gt_beg(FENSTER *f);
-int             e_blck_gt_end(FENSTER *f);
-int             e_blck_mrk_line(FENSTER *f);
-int             e_blck_mrk_all(FENSTER *f);
-int             e_blck_to_left(FENSTER *f);
-int             e_blck_to_right(FENSTER *f);
-int             e_cl_project(FENSTER *f);
-int             e_p_add_item(FENSTER *f);
-int             e_p_del_item(FENSTER *f);
-int             e_show_project(FENSTER *f);
-int             e_info(FENSTER *f);
-int             e_help_options(FENSTER *f);
-int             e_hp_ret(FENSTER *f);
-int             e_hp_back(FENSTER *f);
-int             e_hp_prev(FENSTER *f);
-int             e_hp_next(FENSTER *f);
+int e_p_show_messages (FENSTER * f);
+int e_p_show_watches (FENSTER * f);
+int e_blck_gt_beg (FENSTER * f);
+int e_blck_gt_end (FENSTER * f);
+int e_blck_mrk_line (FENSTER * f);
+int e_blck_mrk_all (FENSTER * f);
+int e_blck_to_left (FENSTER * f);
+int e_blck_to_right (FENSTER * f);
+int e_cl_project (FENSTER * f);
+int e_p_add_item (FENSTER * f);
+int e_p_del_item (FENSTER * f);
+int e_show_project (FENSTER * f);
+int e_info (FENSTER * f);
+int e_help_options (FENSTER * f);
+int e_hp_ret (FENSTER * f);
+int e_hp_back (FENSTER * f);
+int e_hp_prev (FENSTER * f);
+int e_hp_next (FENSTER * f);
 
 /* main menu control bar */
-int WpeHandleMainmenu(int n, FENSTER *f)
+int
+WpeHandleMainmenu (int n, FENSTER * f)
 {
-  extern int      e_mn_men;
-  int             i, c = 255, nold = n <= 0 ? 1 : n - 1;
-  extern OPT      opt[];
-  extern char    *e_hlp, *e_hlp_str[];
-  ECNT           *cn = f->ed;
-  MENU           *mainmenu = malloc(MENOPT * sizeof(MENU));
+  extern int e_mn_men;
+  int i, c = 255, nold = n <= 0 ? 1 : n - 1;
+  extern OPT opt[];
+  extern char *e_hlp, *e_hlp_str[];
+  ECNT *cn = f->ed;
+  MENU *mainmenu = malloc (MENOPT * sizeof (MENU));
 
-  for(i = 0; i < MENOPT; i++)
+  for (i = 0; i < MENOPT; i++)
     mainmenu[i].width = 0;
-  fk_cursor(0);
-  if(n < 0)
+  fk_cursor (0);
+  if (n < 0)
     n = 0;
   else
     c = WPE_CR;
 #ifdef UNIX
 #ifdef NEWSTYLE
-  if(WpeIsXwin())
+  if (WpeIsXwin ())
     mainmenu[0].position = -3;
   else
 #endif
@@ -65,175 +66,293 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   mainmenu[0].no_of_items = 4;
   mainmenu[0].width = 20;
 #endif
-  if((mainmenu[0].menuitems = malloc(mainmenu[0].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  mainmenu[0].menuitems[0] = WpeFillSubmenuItem("About WE", 0, 'A', e_about_WE);
-  mainmenu[0].menuitems[1] = WpeFillSubmenuItem("Clear Desktop", 0, 'C', e_clear_desk);
-  mainmenu[0].menuitems[2] = WpeFillSubmenuItem("Repaint Desktop", 0, 'R', e_repaint_desk);
-  mainmenu[0].menuitems[3] = WpeFillSubmenuItem("System Info", 0, 'S', e_sys_info);
+  if ((mainmenu[0].menuitems =
+       malloc (mainmenu[0].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  mainmenu[0].menuitems[0] =
+    WpeFillSubmenuItem ("About WE", 0, 'A', e_about_WE);
+  mainmenu[0].menuitems[1] =
+    WpeFillSubmenuItem ("Clear Desktop", 0, 'C', e_clear_desk);
+  mainmenu[0].menuitems[2] =
+    WpeFillSubmenuItem ("Repaint Desktop", 0, 'R', e_repaint_desk);
+  mainmenu[0].menuitems[3] =
+    WpeFillSubmenuItem ("System Info", 0, 'S', e_sys_info);
 #ifdef UNIX
-  mainmenu[0].menuitems[4] = WpeFillSubmenuItem("Show Wastebasket", 5, 'W', WpeShowWastebasket);
-  mainmenu[0].menuitems[5] = WpeFillSubmenuItem("Delete Wastebasket", 0, 'D', WpeDelWastebasket);
+  mainmenu[0].menuitems[4] =
+    WpeFillSubmenuItem ("Show Wastebasket", 5, 'W', WpeShowWastebasket);
+  mainmenu[0].menuitems[5] =
+    WpeFillSubmenuItem ("Delete Wastebasket", 0, 'D', WpeDelWastebasket);
 #endif
   mainmenu[1].position = -3;
 #ifdef UNIX
   mainmenu[1].width = 24;
   mainmenu[1].no_of_items = 11;
-  if((mainmenu[1].menuitems = malloc(mainmenu[1].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  if(f->ed->edopt & ED_CUA_STYLE)
-  {
-    mainmenu[1].menuitems[0] = WpeFillSubmenuItem("File-Manager     F2", 0, 'M', WpeManager);
-    mainmenu[1].menuitems[2] = WpeFillSubmenuItem("Save         Alt F2", 0, 'S', e_m_save);
-    mainmenu[1].menuitems[10] = WpeFillSubmenuItem("Quit         Alt F4", 0, 'Q', e_quit);
-  }
+  if ((mainmenu[1].menuitems =
+       malloc (mainmenu[1].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  if (f->ed->edopt & ED_CUA_STYLE)
+    {
+      mainmenu[1].menuitems[0] =
+	WpeFillSubmenuItem ("File-Manager     F2", 0, 'M', WpeManager);
+      mainmenu[1].menuitems[2] =
+	WpeFillSubmenuItem ("Save         Alt F2", 0, 'S', e_m_save);
+      mainmenu[1].menuitems[10] =
+	WpeFillSubmenuItem ("Quit         Alt F4", 0, 'Q', e_quit);
+    }
   else
-  {
-    mainmenu[1].menuitems[0] = WpeFillSubmenuItem("File-Manager     F3", 0, 'M', WpeManager);
-    mainmenu[1].menuitems[2] = WpeFillSubmenuItem("Save             F2", 0, 'S', e_m_save);
-    mainmenu[1].menuitems[10] = WpeFillSubmenuItem("Quit          Alt X", 0, 'Q', e_quit);
-  }
-  mainmenu[1].menuitems[1] = WpeFillSubmenuItem("New", 0, 'N', e_new);
-  mainmenu[1].menuitems[3] = WpeFillSubmenuItem("Save As", 5, 'A', WpeSaveAsManager);
-  mainmenu[1].menuitems[4] = WpeFillSubmenuItem("Save aLl", 6, 'L', e_saveall);
-  mainmenu[1].menuitems[5] = WpeFillSubmenuItem("Execute", 0, 'E', WpeExecuteManager);
-  mainmenu[1].menuitems[6] = WpeFillSubmenuItem("SHell", 1, 'H', WpeShell);
-  mainmenu[1].menuitems[7] = WpeFillSubmenuItem("Find", 0, 'F', WpeFindWindow);
-  mainmenu[1].menuitems[8] = WpeFillSubmenuItem("Grep", 0, 'G', WpeGrepWindow);
-  mainmenu[1].menuitems[9] = WpeFillSubmenuItem("Print File", 0, 'P', WpePrintFile);
+    {
+      mainmenu[1].menuitems[0] =
+	WpeFillSubmenuItem ("File-Manager     F3", 0, 'M', WpeManager);
+      mainmenu[1].menuitems[2] =
+	WpeFillSubmenuItem ("Save             F2", 0, 'S', e_m_save);
+      mainmenu[1].menuitems[10] =
+	WpeFillSubmenuItem ("Quit          Alt X", 0, 'Q', e_quit);
+    }
+  mainmenu[1].menuitems[1] = WpeFillSubmenuItem ("New", 0, 'N', e_new);
+  mainmenu[1].menuitems[3] =
+    WpeFillSubmenuItem ("Save As", 5, 'A', WpeSaveAsManager);
+  mainmenu[1].menuitems[4] =
+    WpeFillSubmenuItem ("Save aLl", 6, 'L', e_saveall);
+  mainmenu[1].menuitems[5] =
+    WpeFillSubmenuItem ("Execute", 0, 'E', WpeExecuteManager);
+  mainmenu[1].menuitems[6] = WpeFillSubmenuItem ("SHell", 1, 'H', WpeShell);
+  mainmenu[1].menuitems[7] =
+    WpeFillSubmenuItem ("Find", 0, 'F', WpeFindWindow);
+  mainmenu[1].menuitems[8] =
+    WpeFillSubmenuItem ("Grep", 0, 'G', WpeGrepWindow);
+  mainmenu[1].menuitems[9] =
+    WpeFillSubmenuItem ("Print File", 0, 'P', WpePrintFile);
 #endif
   mainmenu[2].position = -3;
   mainmenu[2].width = 27;
-#if !defined(NO_XWINDOWS) 
-  if(WpeIsXwin())
+#if !defined(NO_XWINDOWS)
+  if (WpeIsXwin ())
     mainmenu[2].no_of_items = 9;
   else
 #endif
     mainmenu[2].no_of_items = 7;
-  if((mainmenu[2].menuitems = malloc(mainmenu[2].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  mainmenu[2].menuitems[0] = WpeFillSubmenuItem("Cut     Shift Del / ^X", 2, 'T', e_edt_del);
-  mainmenu[2].menuitems[1] = WpeFillSubmenuItem("Copy         ^Ins / ^C", 0, 'C', e_edt_copy);
-  mainmenu[2].menuitems[2] = WpeFillSubmenuItem("Paste   Shift Ins / ^V", 0, 'P', e_edt_einf);
-  mainmenu[2].menuitems[3] = WpeFillSubmenuItem("Show Buffer         ^W", 0, 'S', e_show_clipboard);
-  mainmenu[2].menuitems[4] = WpeFillSubmenuItem("Delete            ^Del", 0, 'D', e_blck_del);
-  mainmenu[2].menuitems[5] = WpeFillSubmenuItem("Undo                ^U", 0, 'U', e_make_undo);
-  mainmenu[2].menuitems[6] = WpeFillSubmenuItem("Redo                ^R", 0, 'R', e_make_redo);
+  if ((mainmenu[2].menuitems =
+       malloc (mainmenu[2].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  mainmenu[2].menuitems[0] =
+    WpeFillSubmenuItem ("Cut     Shift Del / ^X", 2, 'T', e_edt_del);
+  mainmenu[2].menuitems[1] =
+    WpeFillSubmenuItem ("Copy         ^Ins / ^C", 0, 'C', e_edt_copy);
+  mainmenu[2].menuitems[2] =
+    WpeFillSubmenuItem ("Paste   Shift Ins / ^V", 0, 'P', e_edt_einf);
+  mainmenu[2].menuitems[3] =
+    WpeFillSubmenuItem ("Show Buffer         ^W", 0, 'S', e_show_clipboard);
+  mainmenu[2].menuitems[4] =
+    WpeFillSubmenuItem ("Delete            ^Del", 0, 'D', e_blck_del);
+  mainmenu[2].menuitems[5] =
+    WpeFillSubmenuItem ("Undo                ^U", 0, 'U', e_make_undo);
+  mainmenu[2].menuitems[6] =
+    WpeFillSubmenuItem ("Redo                ^R", 0, 'R', e_make_redo);
 #ifndef NO_XWINDOWS
-  if(WpeIsXwin())
-  {
-    mainmenu[2].menuitems[7] = WpeFillSubmenuItem("PAste(XBuffer) Alt Ins", 0, 'A', e_u_copy_X_buffer);
-    mainmenu[2].menuitems[8] = WpeFillSubmenuItem("COpy(XBuffer)  Alt Del", 0, 'O', e_u_paste_X_buffer);
-  }
+  if (WpeIsXwin ())
+    {
+      mainmenu[2].menuitems[7] =
+	WpeFillSubmenuItem ("PAste(XBuffer) Alt Ins", 0, 'A',
+			    e_u_copy_X_buffer);
+      mainmenu[2].menuitems[8] =
+	WpeFillSubmenuItem ("COpy(XBuffer)  Alt Del", 0, 'O',
+			    e_u_paste_X_buffer);
+    }
 #endif
   mainmenu[3].position = -3;
   mainmenu[3].width = 28;
   mainmenu[3].no_of_items = 4;
-  if((mainmenu[3].menuitems = malloc(mainmenu[3].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  if(f->ed->edopt & ED_CUA_STYLE)
-  {
-    mainmenu[3].menuitems[0] = WpeFillSubmenuItem("Find      Alt F3 / ^O F", 0, 'F', e_find);
-    mainmenu[3].menuitems[1] = WpeFillSubmenuItem("Replace Shift F3 / ^O A", 0, 'R', e_replace);
-    mainmenu[3].menuitems[2] = WpeFillSubmenuItem("Search again         F3", 0, 'S', e_rep_search);
-  }
+  if ((mainmenu[3].menuitems =
+       malloc (mainmenu[3].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  if (f->ed->edopt & ED_CUA_STYLE)
+    {
+      mainmenu[3].menuitems[0] =
+	WpeFillSubmenuItem ("Find      Alt F3 / ^O F", 0, 'F', e_find);
+      mainmenu[3].menuitems[1] =
+	WpeFillSubmenuItem ("Replace Shift F3 / ^O A", 0, 'R', e_replace);
+      mainmenu[3].menuitems[2] =
+	WpeFillSubmenuItem ("Search again         F3", 0, 'S', e_rep_search);
+    }
   else
-  {
-    mainmenu[3].menuitems[0] = WpeFillSubmenuItem("Find          F4 / ^O F", 0, 'F', e_find);
-    mainmenu[3].menuitems[1] = WpeFillSubmenuItem("Replace   Alt F4 / ^O A", 0, 'R', e_replace);
-    mainmenu[3].menuitems[2] = WpeFillSubmenuItem("Search again         ^L", 0, 'S', e_rep_search);
-  }
-  mainmenu[3].menuitems[3] = WpeFillSubmenuItem("Go to Line        Alt G", 0, 'G', e_goto_line);
+    {
+      mainmenu[3].menuitems[0] =
+	WpeFillSubmenuItem ("Find          F4 / ^O F", 0, 'F', e_find);
+      mainmenu[3].menuitems[1] =
+	WpeFillSubmenuItem ("Replace   Alt F4 / ^O A", 0, 'R', e_replace);
+      mainmenu[3].menuitems[2] =
+	WpeFillSubmenuItem ("Search again         ^L", 0, 'S', e_rep_search);
+    }
+  mainmenu[3].menuitems[3] =
+    WpeFillSubmenuItem ("Go to Line        Alt G", 0, 'G', e_goto_line);
   mainmenu[4].position = -3;
   mainmenu[4].width = 25;
   mainmenu[4].no_of_items = 15;
-  if((mainmenu[4].menuitems = malloc(mainmenu[4].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  mainmenu[4].menuitems[0] = WpeFillSubmenuItem("Begin Mark      ^K B", 0, 'B', e_blck_begin);
-  mainmenu[4].menuitems[1] = WpeFillSubmenuItem("End Mark        ^K K", 0, 'E', e_blck_end);
-  mainmenu[4].menuitems[2] = WpeFillSubmenuItem("Mark WhOle      ^K X", 7, 'O', e_blck_mrk_all);
-  mainmenu[4].menuitems[3] = WpeFillSubmenuItem("Mark Line       ^K L", 5, 'L', e_blck_mrk_line);
-  mainmenu[4].menuitems[4] = WpeFillSubmenuItem("Goto Begin      ^K A", 0, 'G', e_blck_gt_beg);
-  mainmenu[4].menuitems[5] = WpeFillSubmenuItem("Goto ENd        ^K Z", 6, 'N', e_blck_gt_end);
-  mainmenu[4].menuitems[6] = WpeFillSubmenuItem("Copy            ^K C", 0, 'C', e_blck_copy);
-  mainmenu[4].menuitems[7] = WpeFillSubmenuItem("Move            ^K V", 0, 'M', e_blck_move);
-  mainmenu[4].menuitems[8] = WpeFillSubmenuItem("Delete          ^K Y", 0, 'D', e_blck_del);
-  mainmenu[4].menuitems[9] = WpeFillSubmenuItem("Hide            ^K H", 0, 'H', e_blck_hide);
-  mainmenu[4].menuitems[10] = WpeFillSubmenuItem("Read            ^K R", 0, 'R', e_blck_read);
-  mainmenu[4].menuitems[11] = WpeFillSubmenuItem("Write           ^K W", 0, 'W', e_blck_write);
-  mainmenu[4].menuitems[12] = WpeFillSubmenuItem("Move to RIght   ^K I", 9, 'I', e_blck_to_right);
-  mainmenu[4].menuitems[13] = WpeFillSubmenuItem("Move to LefT    ^K U", 11, 'T', e_blck_to_left);
-  mainmenu[4].menuitems[14] = WpeFillSubmenuItem("ChAnge Case     ^K D", 2, 'A', e_changecase_dialog);
+  if ((mainmenu[4].menuitems =
+       malloc (mainmenu[4].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  mainmenu[4].menuitems[0] =
+    WpeFillSubmenuItem ("Begin Mark      ^K B", 0, 'B', e_blck_begin);
+  mainmenu[4].menuitems[1] =
+    WpeFillSubmenuItem ("End Mark        ^K K", 0, 'E', e_blck_end);
+  mainmenu[4].menuitems[2] =
+    WpeFillSubmenuItem ("Mark WhOle      ^K X", 7, 'O', e_blck_mrk_all);
+  mainmenu[4].menuitems[3] =
+    WpeFillSubmenuItem ("Mark Line       ^K L", 5, 'L', e_blck_mrk_line);
+  mainmenu[4].menuitems[4] =
+    WpeFillSubmenuItem ("Goto Begin      ^K A", 0, 'G', e_blck_gt_beg);
+  mainmenu[4].menuitems[5] =
+    WpeFillSubmenuItem ("Goto ENd        ^K Z", 6, 'N', e_blck_gt_end);
+  mainmenu[4].menuitems[6] =
+    WpeFillSubmenuItem ("Copy            ^K C", 0, 'C', e_blck_copy);
+  mainmenu[4].menuitems[7] =
+    WpeFillSubmenuItem ("Move            ^K V", 0, 'M', e_blck_move);
+  mainmenu[4].menuitems[8] =
+    WpeFillSubmenuItem ("Delete          ^K Y", 0, 'D', e_blck_del);
+  mainmenu[4].menuitems[9] =
+    WpeFillSubmenuItem ("Hide            ^K H", 0, 'H', e_blck_hide);
+  mainmenu[4].menuitems[10] =
+    WpeFillSubmenuItem ("Read            ^K R", 0, 'R', e_blck_read);
+  mainmenu[4].menuitems[11] =
+    WpeFillSubmenuItem ("Write           ^K W", 0, 'W', e_blck_write);
+  mainmenu[4].menuitems[12] =
+    WpeFillSubmenuItem ("Move to RIght   ^K I", 9, 'I', e_blck_to_right);
+  mainmenu[4].menuitems[13] =
+    WpeFillSubmenuItem ("Move to LefT    ^K U", 11, 'T', e_blck_to_left);
+  mainmenu[4].menuitems[14] =
+    WpeFillSubmenuItem ("ChAnge Case     ^K D", 2, 'A', e_changecase_dialog);
 #ifdef PROG
-  if(WpeIsProg())
-  {
-    mainmenu[5].position = -3;
-    mainmenu[5].width = 35;
-    mainmenu[5].no_of_items = 12;
-    if((mainmenu[5].menuitems = malloc(mainmenu[5].no_of_items * sizeof(OPTK))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-    mainmenu[5].menuitems[0] = WpeFillSubmenuItem("Compile         Alt F9 / Alt C", 0, 'C', e_compile);
-    mainmenu[5].menuitems[1] = WpeFillSubmenuItem("Make                F9 / Alt M", 0, 'M', e_p_make);
-    mainmenu[5].menuitems[2] = WpeFillSubmenuItem("Run                ^F9 / Alt U", 0, 'R', e_run);
-    mainmenu[5].menuitems[3] = WpeFillSubmenuItem("Install                  Alt L", 0, 'I', e_install);
-    mainmenu[5].menuitems[4] = WpeFillSubmenuItem("Execute Make             Alt A", 0, 'E', e_exec_make);
-    mainmenu[5].menuitems[5] = WpeFillSubmenuItem("Next Error      Alt F8 / Alt T", 0, 'N', e_next_error);
-    mainmenu[5].menuitems[6] = WpeFillSubmenuItem("Previous Error  Alt F7 / Alt V", 0, 'P', e_previous_error);
-    mainmenu[5].menuitems[7] = WpeFillSubmenuItem("Show Definition           ^O S", 0, 'S', e_sh_def);
-    mainmenu[5].menuitems[8] = WpeFillSubmenuItem("Show NeXt Definition      ^O N", 7, 'X', e_sh_nxt_def);
-    mainmenu[5].menuitems[9] = WpeFillSubmenuItem("Matching BracKet          ^O K", 13, 'K', e_nxt_brk);
-    mainmenu[5].menuitems[10] = WpeFillSubmenuItem("Beautify                  ^O B", 0, 'B', e_p_beautify);
-    mainmenu[5].menuitems[11] = WpeFillSubmenuItem("Arguments                     ", 0, 'A', e_arguments);
+  if (WpeIsProg ())
+    {
+      mainmenu[5].position = -3;
+      mainmenu[5].width = 35;
+      mainmenu[5].no_of_items = 12;
+      if ((mainmenu[5].menuitems =
+	   malloc (mainmenu[5].no_of_items * sizeof (OPTK))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+      mainmenu[5].menuitems[0] =
+	WpeFillSubmenuItem ("Compile         Alt F9 / Alt C", 0, 'C',
+			    e_compile);
+      mainmenu[5].menuitems[1] =
+	WpeFillSubmenuItem ("Make                F9 / Alt M", 0, 'M',
+			    e_p_make);
+      mainmenu[5].menuitems[2] =
+	WpeFillSubmenuItem ("Run                ^F9 / Alt U", 0, 'R', e_run);
+      mainmenu[5].menuitems[3] =
+	WpeFillSubmenuItem ("Install                  Alt L", 0, 'I',
+			    e_install);
+      mainmenu[5].menuitems[4] =
+	WpeFillSubmenuItem ("Execute Make             Alt A", 0, 'E',
+			    e_exec_make);
+      mainmenu[5].menuitems[5] =
+	WpeFillSubmenuItem ("Next Error      Alt F8 / Alt T", 0, 'N',
+			    e_next_error);
+      mainmenu[5].menuitems[6] =
+	WpeFillSubmenuItem ("Previous Error  Alt F7 / Alt V", 0, 'P',
+			    e_previous_error);
+      mainmenu[5].menuitems[7] =
+	WpeFillSubmenuItem ("Show Definition           ^O S", 0, 'S',
+			    e_sh_def);
+      mainmenu[5].menuitems[8] =
+	WpeFillSubmenuItem ("Show NeXt Definition      ^O N", 7, 'X',
+			    e_sh_nxt_def);
+      mainmenu[5].menuitems[9] =
+	WpeFillSubmenuItem ("Matching BracKet          ^O K", 13, 'K',
+			    e_nxt_brk);
+      mainmenu[5].menuitems[10] =
+	WpeFillSubmenuItem ("Beautify                  ^O B", 0, 'B',
+			    e_p_beautify);
+      mainmenu[5].menuitems[11] =
+	WpeFillSubmenuItem ("Arguments                     ", 0, 'A',
+			    e_arguments);
 
-    mainmenu[MENOPT - 4].position = -3;
-    mainmenu[MENOPT - 4].width = 23;
-    mainmenu[MENOPT - 4].no_of_items = 5;
-    if((mainmenu[MENOPT - 4].menuitems = malloc(mainmenu[MENOPT - 4].no_of_items * sizeof(OPTK))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-    mainmenu[MENOPT - 4].menuitems[0] = WpeFillSubmenuItem("Open Project", 5, 'P', e_project);
-    mainmenu[MENOPT - 4].menuitems[1] = WpeFillSubmenuItem("Close Project", 0, 'C', e_cl_project);
-    mainmenu[MENOPT - 4].menuitems[2] = WpeFillSubmenuItem("Add Item", 0, 'A', e_p_add_item);
-    mainmenu[MENOPT - 4].menuitems[3] = WpeFillSubmenuItem("Delete Item", 0, 'D', e_p_del_item);
-    mainmenu[MENOPT - 4].menuitems[4] = WpeFillSubmenuItem("Options", 0, 'O', e_project_options);
-  }
+      mainmenu[MENOPT - 4].position = -3;
+      mainmenu[MENOPT - 4].width = 23;
+      mainmenu[MENOPT - 4].no_of_items = 5;
+      if ((mainmenu[MENOPT - 4].menuitems =
+	   malloc (mainmenu[MENOPT - 4].no_of_items * sizeof (OPTK))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+      mainmenu[MENOPT - 4].menuitems[0] =
+	WpeFillSubmenuItem ("Open Project", 5, 'P', e_project);
+      mainmenu[MENOPT - 4].menuitems[1] =
+	WpeFillSubmenuItem ("Close Project", 0, 'C', e_cl_project);
+      mainmenu[MENOPT - 4].menuitems[2] =
+	WpeFillSubmenuItem ("Add Item", 0, 'A', e_p_add_item);
+      mainmenu[MENOPT - 4].menuitems[3] =
+	WpeFillSubmenuItem ("Delete Item", 0, 'D', e_p_del_item);
+      mainmenu[MENOPT - 4].menuitems[4] =
+	WpeFillSubmenuItem ("Options", 0, 'O', e_project_options);
+    }
 #endif
 #ifdef DEBUGGER
-  if(WpeIsProg())
-  {
-    mainmenu[MENOPT - 5].position = -3;
-    mainmenu[MENOPT - 5].width = 33;
-    mainmenu[MENOPT - 5].no_of_items = 13;
-    if((mainmenu[MENOPT - 5].menuitems = malloc(mainmenu[MENOPT - 5].no_of_items * sizeof(OPTK))) == NULL)
-      e_error(e_msg[ERR_LOWMEM], 1, f->fb);
+  if (WpeIsProg ())
+    {
+      mainmenu[MENOPT - 5].position = -3;
+      mainmenu[MENOPT - 5].width = 33;
+      mainmenu[MENOPT - 5].no_of_items = 13;
+      if ((mainmenu[MENOPT - 5].menuitems =
+	   malloc (mainmenu[MENOPT - 5].no_of_items * sizeof (OPTK))) == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->fb);
 
-    if(f->ed->edopt & ED_CUA_STYLE)
-    {
-      mainmenu[MENOPT - 5].menuitems[0] = WpeFillSubmenuItem("Toggle Breakpoint  F5 / ^G B", 7, 'B', e_breakpoint);
-      mainmenu[MENOPT - 5].menuitems[2] = WpeFillSubmenuItem("Make Watch        ^F5 / ^G W", 5, 'W', e_make_watches);
-      mainmenu[MENOPT - 5].menuitems[6] = WpeFillSubmenuItem("Show stacK        ^F3 / ^G K", 9, 'K', e_deb_stack);
+      if (f->ed->edopt & ED_CUA_STYLE)
+	{
+	  mainmenu[MENOPT - 5].menuitems[0] =
+	    WpeFillSubmenuItem ("Toggle Breakpoint  F5 / ^G B", 7, 'B',
+				e_breakpoint);
+	  mainmenu[MENOPT - 5].menuitems[2] =
+	    WpeFillSubmenuItem ("Make Watch        ^F5 / ^G W", 5, 'W',
+				e_make_watches);
+	  mainmenu[MENOPT - 5].menuitems[6] =
+	    WpeFillSubmenuItem ("Show stacK        ^F3 / ^G K", 9, 'K',
+				e_deb_stack);
+	}
+      else
+	{
+	  mainmenu[MENOPT - 5].menuitems[0] =
+	    WpeFillSubmenuItem ("Toggle Breakpoint ^F8 / ^G B", 7, 'B',
+				e_breakpoint);
+	  mainmenu[MENOPT - 5].menuitems[2] =
+	    WpeFillSubmenuItem ("Make Watch        ^F7 / ^G W", 5, 'W',
+				e_make_watches);
+	  mainmenu[MENOPT - 5].menuitems[6] =
+	    WpeFillSubmenuItem ("Show stacK        ^F6 / ^G K", 9, 'K',
+				e_deb_stack);
+	}
+      mainmenu[MENOPT - 5].menuitems[1] =
+	WpeFillSubmenuItem ("ReMove all Breakp.      ^G M", 2, 'M',
+			    e_remove_breakpoints);
+      mainmenu[MENOPT - 5].menuitems[3] =
+	WpeFillSubmenuItem ("Edit watch              ^G E", 0, 'E',
+			    e_edit_watches);
+      mainmenu[MENOPT - 5].menuitems[4] =
+	WpeFillSubmenuItem ("Delete watch            ^G D", 0, 'D',
+			    e_delete_watches);
+      mainmenu[MENOPT - 5].menuitems[5] =
+	WpeFillSubmenuItem ("Remove All watches      ^G A", 7, 'A',
+			    e_remove_all_watches);
+      mainmenu[MENOPT - 5].menuitems[7] =
+	WpeFillSubmenuItem ("Goto cursor             ^G U", 0, 'U',
+			    e_d_goto_cursor);
+      mainmenu[MENOPT - 5].menuitems[8] =
+	WpeFillSubmenuItem ("Finish function         ^G F", 0, 'F',
+			    e_d_finish_func);
+      mainmenu[MENOPT - 5].menuitems[9] =
+	WpeFillSubmenuItem ("Trace              F7 / ^G T", 0, 'T',
+			    e_deb_trace);
+      mainmenu[MENOPT - 5].menuitems[10] =
+	WpeFillSubmenuItem ("Step               F8 / ^G S", 0, 'S',
+			    e_deb_next);
+      mainmenu[MENOPT - 5].menuitems[11] =
+	WpeFillSubmenuItem ("Run/Continue     ^F10 / ^G R", 0, 'R',
+			    e_deb_run);
+      mainmenu[MENOPT - 5].menuitems[12] =
+	WpeFillSubmenuItem ("Quit              ^F2 / ^G Q", 0, 'Q', e_d_quit);
     }
-    else
-    {
-      mainmenu[MENOPT - 5].menuitems[0] = WpeFillSubmenuItem("Toggle Breakpoint ^F8 / ^G B", 7, 'B', e_breakpoint);
-      mainmenu[MENOPT - 5].menuitems[2] = WpeFillSubmenuItem("Make Watch        ^F7 / ^G W", 5, 'W', e_make_watches);
-      mainmenu[MENOPT - 5].menuitems[6] = WpeFillSubmenuItem("Show stacK        ^F6 / ^G K", 9, 'K', e_deb_stack);
-    }
-    mainmenu[MENOPT - 5].menuitems[1] = WpeFillSubmenuItem("ReMove all Breakp.      ^G M", 2, 'M', e_remove_breakpoints);
-    mainmenu[MENOPT - 5].menuitems[3] = WpeFillSubmenuItem("Edit watch              ^G E", 0, 'E', e_edit_watches);
-    mainmenu[MENOPT - 5].menuitems[4] = WpeFillSubmenuItem("Delete watch            ^G D", 0, 'D', e_delete_watches);
-    mainmenu[MENOPT - 5].menuitems[5] = WpeFillSubmenuItem("Remove All watches      ^G A", 7, 'A', e_remove_all_watches);
-    mainmenu[MENOPT - 5].menuitems[7] = WpeFillSubmenuItem("Goto cursor             ^G U", 0, 'U', e_d_goto_cursor);
-    mainmenu[MENOPT - 5].menuitems[8] = WpeFillSubmenuItem("Finish function         ^G F", 0, 'F', e_d_finish_func);
-    mainmenu[MENOPT - 5].menuitems[9] = WpeFillSubmenuItem("Trace              F7 / ^G T", 0, 'T', e_deb_trace);
-    mainmenu[MENOPT - 5].menuitems[10] = WpeFillSubmenuItem("Step               F8 / ^G S", 0, 'S', e_deb_next);
-    mainmenu[MENOPT - 5].menuitems[11] = WpeFillSubmenuItem("Run/Continue     ^F10 / ^G R", 0, 'R', e_deb_run);
-    mainmenu[MENOPT - 5].menuitems[12] = WpeFillSubmenuItem("Quit              ^F2 / ^G Q", 0, 'Q', e_d_quit);
-  }
 #endif
   mainmenu[MENOPT - 3].position = -4;
   mainmenu[MENOPT - 3].width = 22;
 #ifdef PROG
-  if(WpeIsProg())
+  if (WpeIsProg ())
 #ifdef DEBUGGER
     mainmenu[MENOPT - 3].no_of_items = 8;
 #else
@@ -242,25 +361,34 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   else
 #endif
     mainmenu[MENOPT - 3].no_of_items = 5;
-  if((mainmenu[MENOPT - 3].menuitems = malloc(mainmenu[MENOPT - 3].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  mainmenu[MENOPT - 3].menuitems[0] = WpeFillSubmenuItem("Adjust Colors", 0, 'A', e_ad_colors);
-  mainmenu[MENOPT - 3].menuitems[1] = WpeFillSubmenuItem("Save Options", 0, 'S', e_opt_save);
-  mainmenu[MENOPT - 3].menuitems[2] = WpeFillSubmenuItem("Editor", 0, 'E', e_edt_options);
-  mainmenu[MENOPT - 3].menuitems[3] = WpeFillSubmenuItem("File-Manager", 0, 'F', WpeFileManagerOptions);
-  mainmenu[MENOPT - 3].menuitems[4] = WpeFillSubmenuItem("Help", 0, 'H', e_help_options);
+  if ((mainmenu[MENOPT - 3].menuitems =
+       malloc (mainmenu[MENOPT - 3].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  mainmenu[MENOPT - 3].menuitems[0] =
+    WpeFillSubmenuItem ("Adjust Colors", 0, 'A', e_ad_colors);
+  mainmenu[MENOPT - 3].menuitems[1] =
+    WpeFillSubmenuItem ("Save Options", 0, 'S', e_opt_save);
+  mainmenu[MENOPT - 3].menuitems[2] =
+    WpeFillSubmenuItem ("Editor", 0, 'E', e_edt_options);
+  mainmenu[MENOPT - 3].menuitems[3] =
+    WpeFillSubmenuItem ("File-Manager", 0, 'F', WpeFileManagerOptions);
+  mainmenu[MENOPT - 3].menuitems[4] =
+    WpeFillSubmenuItem ("Help", 0, 'H', e_help_options);
 #ifdef PROG
-  if(WpeIsProg())
-  {
-    mainmenu[MENOPT - 3].menuitems[5] = WpeFillSubmenuItem("ProGramming", 3, 'G', e_program_opt);
-    mainmenu[MENOPT - 3].menuitems[6] = WpeFillSubmenuItem("Compiler", 0, 'C', e_run_options);
+  if (WpeIsProg ())
+    {
+      mainmenu[MENOPT - 3].menuitems[5] =
+	WpeFillSubmenuItem ("ProGramming", 3, 'G', e_program_opt);
+      mainmenu[MENOPT - 3].menuitems[6] =
+	WpeFillSubmenuItem ("Compiler", 0, 'C', e_run_options);
 #ifdef DEBUGGER
-    mainmenu[MENOPT - 3].menuitems[7] = WpeFillSubmenuItem("Debugger", 0, 'D', e_deb_options);
+      mainmenu[MENOPT - 3].menuitems[7] =
+	WpeFillSubmenuItem ("Debugger", 0, 'D', e_deb_options);
 #endif
-  }
+    }
 #endif
 #ifdef NEWSTYLE
-  if(WpeIsXwin())
+  if (WpeIsXwin ())
     mainmenu[MENOPT - 2].position = -13;
   else
 #endif
@@ -268,393 +396,424 @@ int WpeHandleMainmenu(int n, FENSTER *f)
   mainmenu[MENOPT - 2].width = 28;
 #ifdef UNIX
 #ifdef PROG
-  if(WpeIsProg())
+  if (WpeIsProg ())
 #ifdef DEBUGGER
-    mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin()? 11 : 10;
+    mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin ()? 11 : 10;
 #else
-    mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin()? 10 : 9;
+    mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin ()? 10 : 9;
 #endif
   else
 #endif
-    mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin()? 8 : 7;
+    mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin ()? 8 : 7;
 #else
-  mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin()? 7 : 6;
+  mainmenu[MENOPT - 2].no_of_items = !WpeIsXwin ()? 7 : 6;
 #endif
-  if((mainmenu[MENOPT - 2].menuitems = malloc(mainmenu[MENOPT - 2].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  if(f->ed->edopt & ED_CUA_STYLE)
-  {
-    mainmenu[MENOPT - 2].menuitems[0] = WpeFillSubmenuItem("Size/Move            ^L", 0, 'S', e_size_move);
-    mainmenu[MENOPT - 2].menuitems[1] = WpeFillSubmenuItem("Zoom   Shift F6 / Alt Z", 0, 'Z', e_ed_zoom);
-    mainmenu[MENOPT - 2].menuitems[4] = WpeFillSubmenuItem("Next        ^F6 / Alt N", 2, 'X', e_ed_next);
-    mainmenu[MENOPT - 2].menuitems[5] = WpeFillSubmenuItem("Close       ^F4 / Alt X", 0, 'C', e_close_window);
-  }
+  if ((mainmenu[MENOPT - 2].menuitems =
+       malloc (mainmenu[MENOPT - 2].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  if (f->ed->edopt & ED_CUA_STYLE)
+    {
+      mainmenu[MENOPT - 2].menuitems[0] =
+	WpeFillSubmenuItem ("Size/Move            ^L", 0, 'S', e_size_move);
+      mainmenu[MENOPT - 2].menuitems[1] =
+	WpeFillSubmenuItem ("Zoom   Shift F6 / Alt Z", 0, 'Z', e_ed_zoom);
+      mainmenu[MENOPT - 2].menuitems[4] =
+	WpeFillSubmenuItem ("Next        ^F6 / Alt N", 2, 'X', e_ed_next);
+      mainmenu[MENOPT - 2].menuitems[5] =
+	WpeFillSubmenuItem ("Close       ^F4 / Alt X", 0, 'C',
+			    e_close_window);
+    }
   else
-  {
-    mainmenu[MENOPT - 2].menuitems[0] = WpeFillSubmenuItem("Size/Move        Alt F2", 0, 'S', e_size_move);
-    mainmenu[MENOPT - 2].menuitems[1] = WpeFillSubmenuItem("Zoom         F5 / Alt Z", 0, 'Z', e_ed_zoom);
-    mainmenu[MENOPT - 2].menuitems[4] = WpeFillSubmenuItem("Next         F6 / Alt N", 2, 'X', e_ed_next);
-    mainmenu[MENOPT - 2].menuitems[5] = WpeFillSubmenuItem("Close            Alt F3", 0, 'C', e_close_window);
-  }
-  mainmenu[MENOPT - 2].menuitems[2] = WpeFillSubmenuItem("Tile           Shift F4", 0, 'T', e_ed_tile);
-  mainmenu[MENOPT - 2].menuitems[3] = WpeFillSubmenuItem("Cascade        Shift F5", 1, 'A', e_ed_cascade);
-  mainmenu[MENOPT - 2].menuitems[6] = WpeFillSubmenuItem("List All          Alt 0", 0, 'L', e_list_all_win);
-  if(!WpeIsXwin())
-    mainmenu[MENOPT - 2].menuitems[7] = WpeFillSubmenuItem("Output    Alt F5 / ^G P", 0, 'O', e_u_deb_out);
+    {
+      mainmenu[MENOPT - 2].menuitems[0] =
+	WpeFillSubmenuItem ("Size/Move        Alt F2", 0, 'S', e_size_move);
+      mainmenu[MENOPT - 2].menuitems[1] =
+	WpeFillSubmenuItem ("Zoom         F5 / Alt Z", 0, 'Z', e_ed_zoom);
+      mainmenu[MENOPT - 2].menuitems[4] =
+	WpeFillSubmenuItem ("Next         F6 / Alt N", 2, 'X', e_ed_next);
+      mainmenu[MENOPT - 2].menuitems[5] =
+	WpeFillSubmenuItem ("Close            Alt F3", 0, 'C',
+			    e_close_window);
+    }
+  mainmenu[MENOPT - 2].menuitems[2] =
+    WpeFillSubmenuItem ("Tile           Shift F4", 0, 'T', e_ed_tile);
+  mainmenu[MENOPT - 2].menuitems[3] =
+    WpeFillSubmenuItem ("Cascade        Shift F5", 1, 'A', e_ed_cascade);
+  mainmenu[MENOPT - 2].menuitems[6] =
+    WpeFillSubmenuItem ("List All          Alt 0", 0, 'L', e_list_all_win);
+  if (!WpeIsXwin ())
+    mainmenu[MENOPT - 2].menuitems[7] =
+      WpeFillSubmenuItem ("Output    Alt F5 / ^G P", 0, 'O', e_u_deb_out);
 #ifdef PROG
-  if(WpeIsProg())
-  {
-    mainmenu[MENOPT - 2].menuitems[mainmenu[MENOPT - 2].no_of_items - 2] = 
-      WpeFillSubmenuItem("Messages", 0, 'M', e_p_show_messages);
-    mainmenu[MENOPT - 2].menuitems[mainmenu[MENOPT - 2].no_of_items - 1] = 
-      WpeFillSubmenuItem("Project", 0, 'P', e_show_project);
+  if (WpeIsProg ())
+    {
+      mainmenu[MENOPT - 2].menuitems[mainmenu[MENOPT - 2].no_of_items - 2] =
+	WpeFillSubmenuItem ("Messages", 0, 'M', e_p_show_messages);
+      mainmenu[MENOPT - 2].menuitems[mainmenu[MENOPT - 2].no_of_items - 1] =
+	WpeFillSubmenuItem ("Project", 0, 'P', e_show_project);
 #ifdef DEBUGGER
-    mainmenu[MENOPT - 2].menuitems[mainmenu[MENOPT - 2].no_of_items - 3] = 
-      WpeFillSubmenuItem("Watches", 0, 'W', e_p_show_watches);
+      mainmenu[MENOPT - 2].menuitems[mainmenu[MENOPT - 2].no_of_items - 3] =
+	WpeFillSubmenuItem ("Watches", 0, 'W', e_p_show_watches);
 #endif
-  }
+    }
 #endif
 #ifdef NEWSTYLE
-  if(WpeIsXwin())
+  if (WpeIsXwin ())
     mainmenu[MENOPT - 1].position = -21;
   else
 #endif
     mainmenu[MENOPT - 1].position = -22;
   mainmenu[MENOPT - 1].width = 27;
-#if defined(PROG) 
+#if defined(PROG)
   mainmenu[MENOPT - 1].no_of_items = 8;
 #else
   mainmenu[MENOPT - 1].no_of_items = 6;
 #endif
-  if((mainmenu[MENOPT - 1].menuitems = malloc(mainmenu[MENOPT - 1].no_of_items * sizeof(OPTK))) == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  mainmenu[MENOPT - 1].menuitems[0] = WpeFillSubmenuItem("Editor              F1", 0, 'E', e_help);
-#if defined(PROG) 
-  mainmenu[MENOPT - 1].menuitems[1] = WpeFillSubmenuItem("Topic Search       ^F1", 0, 'T', e_topic_search);
-  mainmenu[MENOPT - 1].menuitems[2] = WpeFillSubmenuItem("FUnction Index  Alt F1", 1, 'U', e_funct_in);
+  if ((mainmenu[MENOPT - 1].menuitems =
+       malloc (mainmenu[MENOPT - 1].no_of_items * sizeof (OPTK))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+  mainmenu[MENOPT - 1].menuitems[0] =
+    WpeFillSubmenuItem ("Editor              F1", 0, 'E', e_help);
+#if defined(PROG)
+  mainmenu[MENOPT - 1].menuitems[1] =
+    WpeFillSubmenuItem ("Topic Search       ^F1", 0, 'T', e_topic_search);
+  mainmenu[MENOPT - 1].menuitems[2] =
+    WpeFillSubmenuItem ("FUnction Index  Alt F1", 1, 'U', e_funct_in);
 /*   mainmenu[MENOPT-1].menuitems[2] = WpeFillSubmenuItem("Functions      Alt F1", 0, 'F', e_funct); */
 #endif
-  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 5] = 
-    WpeFillSubmenuItem("Info                  ", 0, 'I', e_info);
-  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 4] = 
-    WpeFillSubmenuItem("Goto              <CR>", 0, 'G', e_hp_ret);
-  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 3] = 
-    WpeFillSubmenuItem("Back             <BSP>", 0, 'B', e_hp_back);
-  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 2] = 
-    WpeFillSubmenuItem("Next    Alt F8 / Alt T", 0, 'G', e_hp_next);
-  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 1] = 
-    WpeFillSubmenuItem("Prev.   Alt F7 / Alt V", 0, 'P', e_hp_prev);
+  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 5] =
+    WpeFillSubmenuItem ("Info                  ", 0, 'I', e_info);
+  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 4] =
+    WpeFillSubmenuItem ("Goto              <CR>", 0, 'G', e_hp_ret);
+  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 3] =
+    WpeFillSubmenuItem ("Back             <BSP>", 0, 'B', e_hp_back);
+  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 2] =
+    WpeFillSubmenuItem ("Next    Alt F8 / Alt T", 0, 'G', e_hp_next);
+  mainmenu[MENOPT - 1].menuitems[mainmenu[MENOPT - 1].no_of_items - 1] =
+    WpeFillSubmenuItem ("Prev.   Alt F7 / Alt V", 0, 'P', e_hp_prev);
 
   /* check for valid n */
-  if(n < 0 || n > MENOPT - 1)
+  if (n < 0 || n > MENOPT - 1)
     n = 0;
 
   /* go until the user leaves the main control bar */
-  while(c != WPE_ESC)
-  {
-
-    f = cn->f[cn->mxedt];
-    if(e_tst_dfkt(f, c) == 0)
+  while (c != WPE_ESC)
     {
-      c = 0;
-      break;
-    }
 
-    /* check for a menu shortcut */
-    for(i = 0; i < MENOPT; i++)
-      if(c == opt[i].s || c == opt[i].as)
-      {
-        n = i;
-        c = WPE_CR;
-      }
+      f = cn->f[cn->mxedt];
+      if (e_tst_dfkt (f, c) == 0)
+	{
+	  c = 0;
+	  break;
+	}
 
-    /* if the selection is not the same as before do some drawing */
-    if(nold != n)
-    {
-      /* paint unselected the option */
-      e_pr_str_wsd(opt[nold].x, 0, opt[nold].t, f->fb->mt.fb, 0, 1,
-                   f->fb->ms.fb, (nold == 0 ? 0 : opt[nold].x - e_mn_men),
-       (nold == MENOPT - 1) ? MAXSCOL - 1 : opt[nold + 1].x - e_mn_men - 1);
+      /* check for a menu shortcut */
+      for (i = 0; i < MENOPT; i++)
+	if (c == opt[i].s || c == opt[i].as)
+	  {
+	    n = i;
+	    c = WPE_CR;
+	  }
 
-      /* paint selected the option */
-      e_pr_str_wsd(opt[n].x, 0, opt[n].t, f->fb->mz.fb, 0, 1,
-                   f->fb->mz.fb, (n == 0 ? 0 : opt[n].x - e_mn_men),
-             (n == MENOPT - 1) ? MAXSCOL - 1 : opt[n + 1].x - e_mn_men - 1);
+      /* if the selection is not the same as before do some drawing */
+      if (nold != n)
+	{
+	  /* paint unselected the option */
+	  e_pr_str_wsd (opt[nold].x, 0, opt[nold].t, f->fb->mt.fb, 0, 1,
+			f->fb->ms.fb,
+			(nold == 0 ? 0 : opt[nold].x - e_mn_men),
+			(nold ==
+			 MENOPT - 1) ? MAXSCOL - 1 : opt[nold + 1].x -
+			e_mn_men - 1);
 
-      /* store the selected menu option for later use */
-      nold = n;
-    }
+	  /* paint selected the option */
+	  e_pr_str_wsd (opt[n].x, 0, opt[n].t, f->fb->mz.fb, 0, 1,
+			f->fb->mz.fb, (n == 0 ? 0 : opt[n].x - e_mn_men),
+			(n ==
+			 MENOPT - 1) ? MAXSCOL - 1 : opt[n + 1].x - e_mn_men -
+			1);
 
-    if(c == WPE_CR)
+	  /* store the selected menu option for later use */
+	  nold = n;
+	}
+
+      if (c == WPE_CR)
 #ifdef PROG
 #ifdef DEBUGGER
-    {
-      if(!WpeIsProg() && n > 4)
-        e_hlp = e_hlp_str[9 + n];
-      else
-        e_hlp = e_hlp_str[6 + n];
+	{
+	  if (!WpeIsProg () && n > 4)
+	    e_hlp = e_hlp_str[9 + n];
+	  else
+	    e_hlp = e_hlp_str[6 + n];
 #else
-    {
-      if(!WpeIsProg() && n > 4)
-        e_hlp = e_hlp_str[8 + n];
-      else
-        e_hlp = e_hlp_str[6 + n];
+	{
+	  if (!WpeIsProg () && n > 4)
+	    e_hlp = e_hlp_str[8 + n];
+	  else
+	    e_hlp = e_hlp_str[6 + n];
 #endif
 #else
-    {
-      e_hlp = e_hlp_str[6 + n];
+	{
+	  e_hlp = e_hlp_str[6 + n];
 #endif
-      /* Handle user interaction with the submenu.
-         If the user moved to another main option, the function returns. */
-      if(mainmenu[n].width != 0)
-        c = WpeHandleSubmenu(opt[n].x + mainmenu[n].position, 1,
-                             opt[n].x + mainmenu[n].width + mainmenu[n].position, 
-                             mainmenu[n].no_of_items + 2, n, mainmenu[n].menuitems, f);
-      if(c < MENOPT)
-      {
-        n = c;
-        c = WPE_CR;
-      }
-      else if(c != WPE_ESC)
-        c = 0;
-    }
-    else
-    {
-      e_hlp = e_hlp_str[24];
+	  /* Handle user interaction with the submenu.
+	     If the user moved to another main option, the function returns. */
+	  if (mainmenu[n].width != 0)
+	    c = WpeHandleSubmenu (opt[n].x + mainmenu[n].position, 1,
+				  opt[n].x + mainmenu[n].width +
+				  mainmenu[n].position,
+				  mainmenu[n].no_of_items + 2, n,
+				  mainmenu[n].menuitems, f);
+	  if (c < MENOPT)
+	    {
+	      n = c;
+	      c = WPE_CR;
+	    }
+	  else if (c != WPE_ESC)
+	    c = 0;
+	}
+      else
+	{
+	  e_hlp = e_hlp_str[24];
 #if MOUSE
-      if((c = e_getch()) == -1)
-        c = e_m1_mouse();
+	  if ((c = e_getch ()) == -1)
+	    c = e_m1_mouse ();
 #else
-      c = e_getch();
+	  c = e_getch ();
 #endif
-      c = toupper(c);
-    }
-    if(c == CDO || c == CtrlN)        /* down -> submenu open */
-      c = WPE_CR;
-    else if(c == CLE || c == CtrlB)   /* going left in the main menu */
-      n--;
-    else if(c == CRI || c == CtrlF)   /* going right in the main menu */
-      n++;
-    else if(c == POS1 || c == CtrlA)  /* most left in the main menu */
-      n = 0;
-    else if(c == ENDE || c == CtrlE)  /* most right in the main menu */
-      n = MENOPT - 1;
-    else if(c == AltX)                /* quit the whole business */
-      c = e_quit(f);
+	  c = toupper (c);
+	}
+      if (c == CDO || c == CtrlN)	/* down -> submenu open */
+	c = WPE_CR;
+      else if (c == CLE || c == CtrlB)	/* going left in the main menu */
+	n--;
+      else if (c == CRI || c == CtrlF)	/* going right in the main menu */
+	n++;
+      else if (c == POS1 || c == CtrlA)	/* most left in the main menu */
+	n = 0;
+      else if (c == ENDE || c == CtrlE)	/* most right in the main menu */
+	n = MENOPT - 1;
+      else if (c == AltX)	/* quit the whole business */
+	c = e_quit (f);
 
-    /* adjust the selected main menu */
-    if(n < 0)
-      n = MENOPT - 1;
-    else if(n >= MENOPT)
-      n = 0;
-  }
+      /* adjust the selected main menu */
+      if (n < 0)
+	n = MENOPT - 1;
+      else if (n >= MENOPT)
+	n = 0;
+    }
 
   /* paint unselected the last selected main menu option */
   f = cn->f[cn->mxedt];
-  e_pr_str_wsd(opt[nold].x, 0, opt[nold].t, f->fb->mt.fb, 0, 1,
-               f->fb->ms.fb, (nold == 0 ? 0 : opt[nold].x - e_mn_men),
-       (nold == MENOPT - 1) ? MAXSCOL - 1 : opt[nold + 1].x - e_mn_men - 1);
+  e_pr_str_wsd (opt[nold].x, 0, opt[nold].t, f->fb->mt.fb, 0, 1,
+		f->fb->ms.fb, (nold == 0 ? 0 : opt[nold].x - e_mn_men),
+		(nold ==
+		 MENOPT - 1) ? MAXSCOL - 1 : opt[nold + 1].x - e_mn_men - 1);
 
   /* free up the submenu structure */
-  for(i = 0; i < MENOPT; i++)
-    if(mainmenu[i].width != 0)
-      free(mainmenu[i].menuitems);
-  free(mainmenu);
+  for (i = 0; i < MENOPT; i++)
+    if (mainmenu[i].width != 0)
+      free (mainmenu[i].menuitems);
+  free (mainmenu);
 
-  fk_cursor(1);
-  return(c);
+  fk_cursor (1);
+  return (c);
 }
 
 /* sub menu box */
-int WpeHandleSubmenu(int xa, int ya, int xe, int ye, int nm, OPTK * fopt, FENSTER * f)
+int
+WpeHandleSubmenu (int xa, int ya, int xe, int ye, int nm, OPTK * fopt,
+		  FENSTER * f)
 {
 #if MOUSE
   extern struct mouse e_mouse;
-  extern int      e_mn_men;
+  extern int e_mn_men;
 #endif
-  view            *pic;
-  int             i, n = 0, nold = 1, c = 0;
-  extern OPT      opt[];
+  view *pic;
+  int i, n = 0, nold = 1, c = 0;
+  extern OPT opt[];
 
   /* save whatever will be behind the submenu */
 #ifdef NEWSTYLE
-  if(WpeIsXwin())
-    pic = e_open_view(xa + 1, ya, xe - 1, ye, f->fb->mt.fb, 1);
+  if (WpeIsXwin ())
+    pic = e_open_view (xa + 1, ya, xe - 1, ye, f->fb->mt.fb, 1);
   else
 #endif
-    pic = e_open_view(xa, ya, xe, ye, f->fb->mt.fb, 1);
+    pic = e_open_view (xa, ya, xe, ye, f->fb->mt.fb, 1);
 
-  if(pic == NULL)
-  {
-    e_error(e_msg[ERR_LOWMEM], 0, f->fb);
-    return(WPE_ESC);
-  }
+  if (pic == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+      return (WPE_ESC);
+    }
 
   /* draw the frame and the background of the submenu */
-  e_std_rahmen(xa + 1, ya, xe - 1, ye, NULL, 0, f->fb->mr.fb, 0);
+  e_std_rahmen (xa + 1, ya, xe - 1, ye, NULL, 0, f->fb->mr.fb, 0);
 
   /* draw the submenu items (colors are default, none selected) */
-  for(i = ya + 1; i < ye; i++)
-    e_pr_str_scan(xa + 3, i, fopt[i - ya - 1].t, f->fb->mt.fb, fopt[i - ya - 1].x, 1,
-                  f->fb->ms.fb, xa + 2, xe - 2);
+  for (i = ya + 1; i < ye; i++)
+    e_pr_str_scan (xa + 3, i, fopt[i - ya - 1].t, f->fb->mt.fb,
+		   fopt[i - ya - 1].x, 1, f->fb->ms.fb, xa + 2, xe - 2);
 
 #if MOUSE
   /* show the actual changes */
-  e_refresh();
+  e_refresh ();
   /* until mouse button released */
-  while(e_mshit() != 0)
-  {
-    c = -1;
-    /* mouse is in the range of the submenu */
-    if(e_mouse.y > ya && e_mouse.y < ye)
+  while (e_mshit () != 0)
     {
-      n = e_mouse.y - ya - 1;
-      /* if a new item is selected */
-      if(nold != n)
-      {
-        /* check whether nold is in the range of the available items and unselect it */
-        if(nold < ye - ya - 1 && nold >= 0)
-          e_pr_str_scan(xa + 3, nold + ya + 1, fopt[nold].t, f->fb->mt.fb, fopt[nold].x,
-                        1, f->fb->ms.fb, xa + 2, xe - 2);
-        /* draw the newly selected item */
-        e_pr_str_scan(xa + 3, n + ya + 1, fopt[n].t, f->fb->mz.fb, fopt[n].x, 1,
-                      f->fb->mz.fb, xa + 2, xe - 2);
-        /* save the selection */
-        nold = n;
-        e_refresh();
-      }
+      c = -1;
+      /* mouse is in the range of the submenu */
+      if (e_mouse.y > ya && e_mouse.y < ye)
+	{
+	  n = e_mouse.y - ya - 1;
+	  /* if a new item is selected */
+	  if (nold != n)
+	    {
+	      /* check whether nold is in the range of the available items and unselect it */
+	      if (nold < ye - ya - 1 && nold >= 0)
+		e_pr_str_scan (xa + 3, nold + ya + 1, fopt[nold].t,
+			       f->fb->mt.fb, fopt[nold].x, 1, f->fb->ms.fb,
+			       xa + 2, xe - 2);
+	      /* draw the newly selected item */
+	      e_pr_str_scan (xa + 3, n + ya + 1, fopt[n].t, f->fb->mz.fb,
+			     fopt[n].x, 1, f->fb->mz.fb, xa + 2, xe - 2);
+	      /* save the selection */
+	      nold = n;
+	      e_refresh ();
+	    }
+	}
+      /* mouse is in the main menu area */
+      else if (e_mouse.y == 0)
+	{
+	  /* search for the selected main menu option */
+	  for (i = 1; i < MENOPT; i++)
+	    if (e_mouse.x < opt[i].x - e_mn_men)
+	      break;
+	  /* check whether a new menu option has been selected */
+	  if (i != nm + 1)
+	    {
+	      /* if yes, restore what was behind */
+	      e_close_view (pic, 1);
+	      return (i - 1);
+	    }
+	}
     }
-    /* mouse is in the main menu area */
-    else if(e_mouse.y == 0)
-    {
-      /* search for the selected main menu option */
-      for(i = 1; i < MENOPT; i++)
-        if(e_mouse.x < opt[i].x - e_mn_men)
-          break;
-      /* check whether a new menu option has been selected */
-      if(i != nm + 1)
-      {
-        /* if yes, restore what was behind */
-        e_close_view(pic, 1);
-        return(i - 1);
-      }
-    }
-  }
 
   /* there was a selection and mouse is within the submenu !!! */
-  if(c < 0 && e_mouse.y > ya && e_mouse.y < ye && e_mouse.x > xa &&
-     e_mouse.x < xe)
+  if (c < 0 && e_mouse.y > ya && e_mouse.y < ye && e_mouse.x > xa &&
+      e_mouse.x < xe)
     c = MBKEY;
 #endif
 
-  while(c != WPE_ESC)
-  {
-    if(nold != n)
+  while (c != WPE_ESC)
     {
-      /* check whether nold is in the range of the available items and unselect it */
-      if(nold < ye - ya - 1 && nold >= 0)
-        e_pr_str_scan(xa + 3, nold + ya + 1, fopt[nold].t, f->fb->mt.fb, fopt[nold].x,
-                      1, f->fb->ms.fb, xa + 2, xe - 2);
-      /* draw the newly selected item */
-      e_pr_str_scan(xa + 3, n + ya + 1, fopt[n].t, f->fb->mz.fb, fopt[n].x, 1,
-                    f->fb->mz.fb, xa + 2, xe - 2);
-      /* save the selection */
-      nold = n;
-    }
+      if (nold != n)
+	{
+	  /* check whether nold is in the range of the available items and unselect it */
+	  if (nold < ye - ya - 1 && nold >= 0)
+	    e_pr_str_scan (xa + 3, nold + ya + 1, fopt[nold].t, f->fb->mt.fb,
+			   fopt[nold].x, 1, f->fb->ms.fb, xa + 2, xe - 2);
+	  /* draw the newly selected item */
+	  e_pr_str_scan (xa + 3, n + ya + 1, fopt[n].t, f->fb->mz.fb,
+			 fopt[n].x, 1, f->fb->mz.fb, xa + 2, xe - 2);
+	  /* save the selection */
+	  nold = n;
+	}
 #if MOUSE
-    if(c != MBKEY)
-    {
-      if((c = toupper(e_getch())) == -1)
-        c = e_m2_mouse(xa, ya, xe, ye, fopt);
-    }
-    else
-      c = WPE_CR;  /* mouse released at a proper place, submenu item accepted */
+      if (c != MBKEY)
+	{
+	  if ((c = toupper (e_getch ())) == -1)
+	    c = e_m2_mouse (xa, ya, xe, ye, fopt);
+	}
+      else
+	c = WPE_CR;		/* mouse released at a proper place, submenu item accepted */
 #else
-    c = toupper(e_getch());
+      c = toupper (e_getch ());
 #endif
 
-    /* check main menu shortcut keys */
-    for(i = 0; i < MENOPT; i++)
-      if(c == opt[i].as)
-      {
-        e_close_view(pic, 1);
-        return(i);
-      }
+      /* check main menu shortcut keys */
+      for (i = 0; i < MENOPT; i++)
+	if (c == opt[i].as)
+	  {
+	    e_close_view (pic, 1);
+	    return (i);
+	  }
 
-    /* check submenu items' shortcut keys */
-    for(i = 0; i < ye - ya - 1; i++)
-      if(c == fopt[i].o)
-      {
-        e_close_view(pic, 1);
-        fopt[i].fkt(f);
-        return(WPE_ESC);
-      }
+      /* check submenu items' shortcut keys */
+      for (i = 0; i < ye - ya - 1; i++)
+	if (c == fopt[i].o)
+	  {
+	    e_close_view (pic, 1);
+	    fopt[i].fkt (f);
+	    return (WPE_ESC);
+	  }
 
-    if(c == Alt0)
-      c = WPE_ESC;
+      if (c == Alt0)
+	c = WPE_ESC;
 
-    if(i > ye - ya)
-      c = WPE_ESC;
-    else if(c == WPE_CR)     /* submenu item accepted */
-    {
-      e_close_view(pic, 1);
-      fopt[n].fkt(f);
-      return(WPE_ESC);
-    }
-    else if(c == CUP || c == CtrlP)     /* going up in the submenu */
-      n = n > 0 ? n - 1 : ye - ya - 2;
-    else if(c == CDO || c == CtrlN)     /* going down in the submenu */
-      n = n < ye - ya - 2 ? n + 1 : 0;
-    else if(c == CLE || c == CtrlB)     /* going left in the main menu */
-    {
-      c = nm > 0 ? nm - 1 : MENOPT - 1;
-      break;
-    }
-    else if(c == CRI || c == CtrlF)     /* going right in the main menu */
-    {
-      c = nm < MENOPT - 1 ? nm + 1 : 0;
-      break;
-    }
-    else if(c == POS1 || c == CtrlA)    /* to the top in the submenu */
-      n = 0;
-    else if(c == ENDE || c == CtrlE)    /* to the bottom in the submenu */
-      n = ye - ya - 2;
-    else
-    {
-      /* this is the anything else case, ESC, keys which are not listed in
-         the submenu */
-      e_close_view(pic, 1);
-      if(c != WPE_ESC && e_tst_dfkt(f, c) == 0)
-        return(WPE_ESC);
+      if (i > ye - ya)
+	c = WPE_ESC;
+      else if (c == WPE_CR)	/* submenu item accepted */
+	{
+	  e_close_view (pic, 1);
+	  fopt[n].fkt (f);
+	  return (WPE_ESC);
+	}
+      else if (c == CUP || c == CtrlP)	/* going up in the submenu */
+	n = n > 0 ? n - 1 : ye - ya - 2;
+      else if (c == CDO || c == CtrlN)	/* going down in the submenu */
+	n = n < ye - ya - 2 ? n + 1 : 0;
+      else if (c == CLE || c == CtrlB)	/* going left in the main menu */
+	{
+	  c = nm > 0 ? nm - 1 : MENOPT - 1;
+	  break;
+	}
+      else if (c == CRI || c == CtrlF)	/* going right in the main menu */
+	{
+	  c = nm < MENOPT - 1 ? nm + 1 : 0;
+	  break;
+	}
+      else if (c == POS1 || c == CtrlA)	/* to the top in the submenu */
+	n = 0;
+      else if (c == ENDE || c == CtrlE)	/* to the bottom in the submenu */
+	n = ye - ya - 2;
+      else
+	{
+	  /* this is the anything else case, ESC, keys which are not listed in
+	     the submenu */
+	  e_close_view (pic, 1);
+	  if (c != WPE_ESC && e_tst_dfkt (f, c) == 0)
+	    return (WPE_ESC);
 #ifdef NEWSTYLE
-      pic = e_open_view(xa + 1, ya, xe - 1, ye, f->fb->mt.fb, 1);
+	  pic = e_open_view (xa + 1, ya, xe - 1, ye, f->fb->mt.fb, 1);
 #else
-      pic = e_open_view(xa, ya, xe, ye, f->fb->mt.fb, 1);
+	  pic = e_open_view (xa, ya, xe, ye, f->fb->mt.fb, 1);
 #endif
-      /* draw the frame for the submenu */
-      e_std_rahmen(xa + 1, ya, xe - 1, ye, NULL, 0, f->fb->mr.fb, 0);
-      /* draw every item in the submenu, unselected */
-      for(i = ya + 1; i < ye; i++)
-        e_pr_str_scan(xa + 3, i, fopt[i - ya - 1].t, f->fb->mt.fb, fopt[i - ya - 1].x, 1,
-                      f->fb->ms.fb, xa + 2, xe - 2);
-      /* draw the selected item */
-      e_pr_str_scan(xa + 3, n + ya + 1, fopt[n].t, f->fb->mz.fb, fopt[n].x, 1,
-                    f->fb->mz.fb, xa + 2, xe - 2);
+	  /* draw the frame for the submenu */
+	  e_std_rahmen (xa + 1, ya, xe - 1, ye, NULL, 0, f->fb->mr.fb, 0);
+	  /* draw every item in the submenu, unselected */
+	  for (i = ya + 1; i < ye; i++)
+	    e_pr_str_scan (xa + 3, i, fopt[i - ya - 1].t, f->fb->mt.fb,
+			   fopt[i - ya - 1].x, 1, f->fb->ms.fb, xa + 2,
+			   xe - 2);
+	  /* draw the selected item */
+	  e_pr_str_scan (xa + 3, n + ya + 1, fopt[n].t, f->fb->mz.fb,
+			 fopt[n].x, 1, f->fb->mz.fb, xa + 2, xe - 2);
+	}
     }
-  }
-  e_close_view(pic, 1);
-  return(c == WPE_ESC ? 255 : c);
+  e_close_view (pic, 1);
+  return (c == WPE_ESC ? 255 : c);
 }
 
 /*      fill "options" struct */
-OPTK WpeFillSubmenuItem(char *t, int x, char o, int(*fkt) ())
+OPTK
+WpeFillSubmenuItem (char *t, int x, char o, int (*fkt) ())
 {
-  OPTK            opt;
+  OPTK opt;
 
   opt.t = t;
   opt.x = x;
   opt.o = o;
   opt.fkt = fkt;
-  return(opt);
+  return (opt);
 }
-

--- a/src/we_menue.h
+++ b/src/we_menue.h
@@ -8,9 +8,9 @@
 #include "we_debug.h"
 
 /*   we_menue.c   */
-int WpeHandleMainmenu(int n, FENSTER *f);
-int WpeHandleSubmenu(int xa, int ya, int xe, int ye, 
-                     int nm, OPTK *fopt, FENSTER *f);
-OPTK WpeFillSubmenuItem(char *t, int x, char o, int (*fkt)());
+int WpeHandleMainmenu (int n, FENSTER * f);
+int WpeHandleSubmenu (int xa, int ya, int xe, int ye,
+		      int nm, OPTK * fopt, FENSTER * f);
+OPTK WpeFillSubmenuItem (char *t, int x, char o, int (*fkt) ());
 
 #endif

--- a/src/we_mouse.c
+++ b/src/we_mouse.c
@@ -18,410 +18,489 @@
 
 #include "makro.h"
 
-int e_mouse_cursor();
+int e_mouse_cursor ();
 
 /*   mouse button pressed (?)     */
-int e_mshit()
+int
+e_mshit ()
 {
- extern struct mouse e_mouse;
- int g[4]; /* = { 3, 0, 0, 0 };  */
- g[0] = 3;  g[1] = 0;
+  extern struct mouse e_mouse;
+  int g[4];			/* = { 3, 0, 0, 0 };  */
+  g[0] = 3;
+  g[1] = 0;
 
- fk_mouse(g);
- e_mouse.x = g[2]/8;
- e_mouse.y = g[3]/8;
- return(g[1]);
+  fk_mouse (g);
+  e_mouse.x = g[2] / 8;
+  e_mouse.y = g[3] / 8;
+  return (g[1]);
 }
 
 /*     mouse main menu control */
-int e_m1_mouse()
+int
+e_m1_mouse ()
 {
- extern struct mouse e_mouse;
- extern OPT opt[];
- extern int e_mn_men;
- int c, n;
+  extern struct mouse e_mouse;
+  extern OPT opt[];
+  extern int e_mn_men;
+  int c, n;
 
- if (e_mouse.y == MAXSLNS-1) c = e_m3_mouse();
- else if (e_mouse.y != 0) c = WPE_ESC;
- else
- {
-  for (n = 1; n < MENOPT; n++)
-   if (e_mouse.x < opt[n].x-e_mn_men) break;
-  c = opt[n-1].as;
- }
- return(c);
+  if (e_mouse.y == MAXSLNS - 1)
+    c = e_m3_mouse ();
+  else if (e_mouse.y != 0)
+    c = WPE_ESC;
+  else
+    {
+      for (n = 1; n < MENOPT; n++)
+	if (e_mouse.x < opt[n].x - e_mn_men)
+	  break;
+      c = opt[n - 1].as;
+    }
+  return (c);
 }
 
 /*   mouse options box control */
-int e_m2_mouse(int xa, int ya, int xe, int ye, OPTK *fopt)
+int
+e_m2_mouse (int xa, int ya, int xe, int ye, OPTK * fopt)
 {
- extern struct mouse e_mouse;
- int c;
+  extern struct mouse e_mouse;
+  int c;
 
- if (e_mouse.y == MAXSLNS) c = e_m3_mouse();
- else if (e_mouse.y == 0) return(e_m1_mouse());
- else if (e_mouse.x <= xa || e_mouse.x >= xe || e_mouse.y <= ya ||
-   e_mouse.y >= ye)
-  c = WPE_ESC;
- else  c = fopt[e_mouse.y-ya-1].o;
- while (e_mshit())
-  ;
- return(c);
+  if (e_mouse.y == MAXSLNS)
+    c = e_m3_mouse ();
+  else if (e_mouse.y == 0)
+    return (e_m1_mouse ());
+  else if (e_mouse.x <= xa || e_mouse.x >= xe || e_mouse.y <= ya ||
+	   e_mouse.y >= ye)
+    c = WPE_ESC;
+  else
+    c = fopt[e_mouse.y - ya - 1].o;
+  while (e_mshit ())
+    ;
+  return (c);
 }
 
 /*      Mouse assistant bar control       */
-int e_m3_mouse()
+int
+e_m3_mouse ()
 {
- extern WOPT *blst;
- extern struct mouse e_mouse;
- extern int nblst;
- int i;
+  extern WOPT *blst;
+  extern struct mouse e_mouse;
+  extern int nblst;
+  int i;
 
- if (e_mouse.y != MAXSLNS-1) return(WPE_ESC);
- while (e_mshit())
-  ;
- for(i = 1; i < nblst; i++)
-  if(e_mouse.x < blst[i].x) return(blst[i-1].as);
- return(blst[nblst-1].as);
+  if (e_mouse.y != MAXSLNS - 1)
+    return (WPE_ESC);
+  while (e_mshit ())
+    ;
+  for (i = 1; i < nblst; i++)
+    if (e_mouse.x < blst[i].x)
+      return (blst[i - 1].as);
+  return (blst[nblst - 1].as);
 }
 
 /*   mouse errors box control */
-int e_er_mouse(int x, int y, int xx, int yy)
+int
+e_er_mouse (int x, int y, int xx, int yy)
 {
- extern struct mouse e_mouse;
+  extern struct mouse e_mouse;
 
- while (e_mshit() != 0)
-  ;
- if (y == e_mouse.y && x == e_mouse.x) return (WPE_CR);
- if (yy == e_mouse.y && xx-1 <= e_mouse.x && xx+4 >= e_mouse.x)
-  return (WPE_CR);
- return(0);
+  while (e_mshit () != 0)
+    ;
+  if (y == e_mouse.y && x == e_mouse.x)
+    return (WPE_CR);
+  if (yy == e_mouse.y && xx - 1 <= e_mouse.x && xx + 4 >= e_mouse.x)
+    return (WPE_CR);
+  return (0);
 }
 
 /*   mouse messages box control */
-int e_msg_mouse(int x, int y, int x1, int x2, int yy)
-{
- extern struct mouse e_mouse;
-
- while (e_mshit() != 0)
-  ;
- if (y == e_mouse.y && x == e_mouse.x) return (WPE_CR);
- if (yy == e_mouse.y)
- {
-  if (x1-1 <= e_mouse.x && x1+5 >= e_mouse.x) return ('Y');
-  if (x2-1 <= e_mouse.x && x2+5 >= e_mouse.x) return (WPE_ESC);
-  if ((x1=(x1+x2)/2 - 1) <= e_mouse.x && x1+5 >= e_mouse.x) return ('N');
- }
- return(0);
-}
-
-int e_rahmen_mouse(FENSTER *f)
-{
- extern struct mouse e_mouse;
- int c = 1;
-
- if (e_mouse.x == f->a.x+3 && e_mouse.y == f->a.y) c = WPE_ESC;
- else if (e_mouse.x == f->e.x-3 && e_mouse.y == f->a.y) e_ed_zoom(f);
- else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y) e_eck_mouse(f, 1);
- else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y) e_eck_mouse(f, 2);
- else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y) e_eck_mouse(f, 3);
- else if (e_mouse.x == f->a.x && e_mouse.y == f->e.y) e_eck_mouse(f, 4);
- else if (e_mouse.y == f->a.y && e_mouse.x > f->a.x && e_mouse.x < f->e.x)
-  e_eck_mouse(f, 0);
- else c = 0;
- while (e_mshit() != 0)
-  ;
- return(c);
-}
-
-int WpeMngMouseInFileManager(FENSTER * f)
+int
+e_msg_mouse (int x, int y, int x1, int x2, int yy)
 {
   extern struct mouse e_mouse;
-  ECNT           *cn = f->ed;
-  FLBFFR         *b = (FLBFFR *) f->b;
-  int             i, c = 0, by = 4;
 
-  if(e_mouse.y == 0)
-    return(AltBl);
-  else if(e_mouse.y == MAXSLNS - 1)
-    return(e_m3_mouse());
-  else if(e_mouse.x < f->a.x || e_mouse.x > f->e.x
-          || e_mouse.y < f->a.y || e_mouse.y > f->e.y)
-  {
-    for(i = cn->mxedt; i > 0; i--)
+  while (e_mshit () != 0)
+    ;
+  if (y == e_mouse.y && x == e_mouse.x)
+    return (WPE_CR);
+  if (yy == e_mouse.y)
     {
-      if(e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x
-         && e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
-      {
-        while(e_mshit() != 0);
-        return(cn->edt[i] < 10 ? Alt1 - 1 + cn->edt[i] : 1014 + cn->edt[i]);
-      }
+      if (x1 - 1 <= e_mouse.x && x1 + 5 >= e_mouse.x)
+	return ('Y');
+      if (x2 - 1 <= e_mouse.x && x2 + 5 >= e_mouse.x)
+	return (WPE_ESC);
+      if ((x1 = (x1 + x2) / 2 - 1) <= e_mouse.x && x1 + 5 >= e_mouse.x)
+	return ('N');
     }
-  }
-  else if(e_mouse.x == f->a.x + 3 && e_mouse.y == f->a.y)
+  return (0);
+}
+
+int
+e_rahmen_mouse (FENSTER * f)
+{
+  extern struct mouse e_mouse;
+  int c = 1;
+
+  if (e_mouse.x == f->a.x + 3 && e_mouse.y == f->a.y)
     c = WPE_ESC;
-  else if(e_mouse.x == f->e.x - 3 && e_mouse.y == f->a.y)
-    e_ed_zoom(f);
-  else if(e_mouse.x == f->a.x && e_mouse.y == f->a.y)
-    e_eck_mouse(f, 1);
-  else if(e_mouse.x == f->e.x && e_mouse.y == f->a.y)
-    e_eck_mouse(f, 2);
-  else if(e_mouse.x == f->e.x && e_mouse.y == f->e.y)
-    e_eck_mouse(f, 3);
-  else if(e_mouse.x == f->a.x && e_mouse.y == f->e.y)
-    e_eck_mouse(f, 4);
-  else if(e_mouse.y == f->a.y && e_mouse.x > f->a.x
-          && e_mouse.x < f->e.x)
-    e_eck_mouse(f, 0);
+  else if (e_mouse.x == f->e.x - 3 && e_mouse.y == f->a.y)
+    e_ed_zoom (f);
+  else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y)
+    e_eck_mouse (f, 1);
+  else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y)
+    e_eck_mouse (f, 2);
+  else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y)
+    e_eck_mouse (f, 3);
+  else if (e_mouse.x == f->a.x && e_mouse.y == f->e.y)
+    e_eck_mouse (f, 4);
+  else if (e_mouse.y == f->a.y && e_mouse.x > f->a.x && e_mouse.x < f->e.x)
+    e_eck_mouse (f, 0);
   else
-  {
-    if(NUM_LINES_ON_SCREEN <= 17)
-      by = -1;
-    else if(b->sw != 0 || NUM_LINES_ON_SCREEN <= 19)
-      by = 2;
-
-    if(NUM_LINES_ON_SCREEN > 17)
-    {
-      if(e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 3
-         && e_mouse.x <= f->a.x + 10)
-        c = WPE_ESC;
-      else if(e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 13
-              && e_mouse.x <= f->a.x + 24)
-        c = AltC;
-      else if(b->sw == 1 && NUM_COLS_ON_SCREEN >= 34 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 27 && e_mouse.x <= f->a.x + 32)
-        c = AltR;
-      else if(b->sw == 2 && NUM_COLS_ON_SCREEN >= 35 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 27 && e_mouse.x <= f->a.x + 33)
-        c = AltW;
-      else if(b->sw == 4 && NUM_COLS_ON_SCREEN >= 34 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 27 && e_mouse.x <= f->a.x + 32)
-        c = AltS;
-      else if(b->sw == 4 && NUM_COLS_ON_SCREEN >= 48 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 35 && e_mouse.x <= f->a.x + 46)
-        c = AltY;
-      else if(b->sw == 3 && NUM_COLS_ON_SCREEN >= 37 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 27 && e_mouse.x <= f->a.x + 35)
-        c = AltE;
-      else if(b->sw == 5 && NUM_COLS_ON_SCREEN >= 33 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 27 && e_mouse.x <= f->a.x + 31)
-        c = AltA;
-      else if(b->sw == 0 && NUM_COLS_ON_SCREEN >= 35 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 27 && e_mouse.x <= f->a.x + 33)
-        c = AltK;
-      else if(b->sw == 0 && NUM_COLS_ON_SCREEN >= 49 && e_mouse.y == f->e.y - by
-              && e_mouse.x >= f->a.x + 36 && e_mouse.x <= f->a.x + 47)
-        c = AltA;
-    }
-    if(b->sw == 0 && NUM_LINES_ON_SCREEN > 19)
-    {
-      if(e_mouse.y == f->e.y - 2 && e_mouse.x >= f->a.x + 3
-         && e_mouse.x <= f->a.x + 8)
-        c = AltM;
-      else if(e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 21 &&
-              e_mouse.x >= f->a.x + 12 && e_mouse.x <= f->a.x + 19)
-        c = AltR;
-      else if(e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 30 &&
-              e_mouse.x >= f->a.x + 23 && e_mouse.x <= f->a.x + 28)
-        c = AltL;
-      else if(e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 39 &&
-              e_mouse.x >= f->a.x + 32 && e_mouse.x <= f->a.x + 37)
-        c = AltO;
-      else if(e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 48 &&
-              e_mouse.x >= f->a.x + 41 && e_mouse.x <= f->a.x + 46)
-        c = AltE;
-    }
-
-    if(e_mouse.y == f->a.y + 3 && e_mouse.x >= f->a.x + b->xfa
-       && e_mouse.x <= f->a.x + b->xfa + b->xfd)
-      c = AltN;
-    else if(e_mouse.y == f->a.y + 3 && e_mouse.x >= f->a.x + b->xda
-            && e_mouse.x <= f->a.x + b->xda + b->xdd)
-      c = AltD;
-    else if(e_mouse.y >= b->fw->ya && e_mouse.y <= b->fw->ye
-            && e_mouse.x >= b->fw->xa && e_mouse.x <= b->fw->xe)
-      c = AltF;
-    else if(e_mouse.y >= b->dw->ya && e_mouse.y <= b->dw->ye
-            && e_mouse.x >= b->dw->xa && e_mouse.x <= b->dw->xe)
-      c = AltT;
-  }
-  while(e_mshit() != 0);
-  return(c);
+    c = 0;
+  while (e_mshit () != 0)
+    ;
+  return (c);
 }
 
-int WpeMouseInFileDirList(int k, int sw, FENSTER * f)
+int
+WpeMngMouseInFileManager (FENSTER * f)
 {
   extern struct mouse e_mouse;
-  ECNT           *cn = f->ed;
-  FLBFFR         *b = (FLBFFR *) f->b;
-  int             i;
-  char            tmp[256];
+  ECNT *cn = f->ed;
+  FLBFFR *b = (FLBFFR *) f->b;
+  int i, c = 0, by = 4;
 
-  if(e_mouse.x >= f->a.x && e_mouse.x <= f->e.x
-     && e_mouse.y >= f->a.y && e_mouse.y <= f->e.y)
-    return(0);
-  for(i = cn->mxedt - 1; i > 0; i--)
-  {
-    if(e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x
-       && e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
-      break;
-  }
-  if(i <= 0)
-    return(0);
-  if(sw)
-  {
-    if(cn->f[i]->dirct[strlen(cn->f[i]->dirct) - 1] == DIRC)
-      sprintf(tmp, "%s%s", cn->f[i]->dirct, b->dd->name[b->dw->nf - b->cd->anz]);
-    else
-      sprintf(tmp, "%s/%s", cn->f[i]->dirct, b->dd->name[b->dw->nf - b->cd->anz]);
-    if(k == -2)
-      e_copy(b->dd->name[b->dw->nf - b->cd->anz], tmp, f);
-    else if(k == -4)
-      e_link(b->dd->name[b->dw->nf - b->cd->anz], tmp, f);
-    else
-      e_rename(b->dd->name[b->dw->nf - b->cd->anz], tmp, f);
-    freedf(b->cd);
-    freedf(b->dw->df);
-    freedf(b->dd);
-    b->dd = e_find_dir(SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-    b->cd = WpeCreateWorkingDirTree(f->save, cn);  /* ??? cn */
-    b->dw->df = WpeGraphicalDirTree(b->cd, b->dd, cn);
-    b->dw->nf = b->cd->anz - 1;
-    b->dw->ia = b->dw->ja = 0;
-    e_pr_file_window(b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
-  }
+  if (e_mouse.y == 0)
+    return (AltBl);
+  else if (e_mouse.y == MAXSLNS - 1)
+    return (e_m3_mouse ());
+  else if (e_mouse.x < f->a.x || e_mouse.x > f->e.x
+	   || e_mouse.y < f->a.y || e_mouse.y > f->e.y)
+    {
+      for (i = cn->mxedt; i > 0; i--)
+	{
+	  if (e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x
+	      && e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
+	    {
+	      while (e_mshit () != 0);
+	      return (cn->edt[i] <
+		      10 ? Alt1 - 1 + cn->edt[i] : 1014 + cn->edt[i]);
+	    }
+	}
+    }
+  else if (e_mouse.x == f->a.x + 3 && e_mouse.y == f->a.y)
+    c = WPE_ESC;
+  else if (e_mouse.x == f->e.x - 3 && e_mouse.y == f->a.y)
+    e_ed_zoom (f);
+  else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y)
+    e_eck_mouse (f, 1);
+  else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y)
+    e_eck_mouse (f, 2);
+  else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y)
+    e_eck_mouse (f, 3);
+  else if (e_mouse.x == f->a.x && e_mouse.y == f->e.y)
+    e_eck_mouse (f, 4);
+  else if (e_mouse.y == f->a.y && e_mouse.x > f->a.x && e_mouse.x < f->e.x)
+    e_eck_mouse (f, 0);
   else
-  {
-    if(cn->f[i]->dirct[strlen(cn->f[i]->dirct) - 1] == DIRC)
-      sprintf(tmp, "%s%s", cn->f[i]->dirct, b->df->name[b->fw->nf]);
-    else
-      sprintf(tmp, "%s/%s", cn->f[i]->dirct, b->df->name[b->fw->nf]);
-    if(k == -2)
-      e_copy(b->df->name[b->fw->nf], tmp, f);
-    else if(k == -4)
-      e_link(b->df->name[b->fw->nf], tmp, f);
-    else
-      e_rename(b->df->name[b->fw->nf], tmp, f);
-    freedf(b->df);
-    freedf(b->fw->df);
-    b->df = e_find_files(b->rdfile, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
-    b->fw->df = WpeGraphicalFileList(b->df, f->ed->flopt >> 9, cn);
-    b->fw->ia = b->fw->nf = 0;
-    b->fw->ja = b->fw->srcha;
-    e_pr_file_window(b->fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb, f->fb->frft.fb);
-  }
-  return(cn->edt[i] < 10 ? Alt1 - 1 + cn->edt[i] : 1014 + cn->edt[i]);
+    {
+      if (NUM_LINES_ON_SCREEN <= 17)
+	by = -1;
+      else if (b->sw != 0 || NUM_LINES_ON_SCREEN <= 19)
+	by = 2;
+
+      if (NUM_LINES_ON_SCREEN > 17)
+	{
+	  if (e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 3
+	      && e_mouse.x <= f->a.x + 10)
+	    c = WPE_ESC;
+	  else if (e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 13
+		   && e_mouse.x <= f->a.x + 24)
+	    c = AltC;
+	  else if (b->sw == 1 && NUM_COLS_ON_SCREEN >= 34
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 27
+		   && e_mouse.x <= f->a.x + 32)
+	    c = AltR;
+	  else if (b->sw == 2 && NUM_COLS_ON_SCREEN >= 35
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 27
+		   && e_mouse.x <= f->a.x + 33)
+	    c = AltW;
+	  else if (b->sw == 4 && NUM_COLS_ON_SCREEN >= 34
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 27
+		   && e_mouse.x <= f->a.x + 32)
+	    c = AltS;
+	  else if (b->sw == 4 && NUM_COLS_ON_SCREEN >= 48
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 35
+		   && e_mouse.x <= f->a.x + 46)
+	    c = AltY;
+	  else if (b->sw == 3 && NUM_COLS_ON_SCREEN >= 37
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 27
+		   && e_mouse.x <= f->a.x + 35)
+	    c = AltE;
+	  else if (b->sw == 5 && NUM_COLS_ON_SCREEN >= 33
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 27
+		   && e_mouse.x <= f->a.x + 31)
+	    c = AltA;
+	  else if (b->sw == 0 && NUM_COLS_ON_SCREEN >= 35
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 27
+		   && e_mouse.x <= f->a.x + 33)
+	    c = AltK;
+	  else if (b->sw == 0 && NUM_COLS_ON_SCREEN >= 49
+		   && e_mouse.y == f->e.y - by && e_mouse.x >= f->a.x + 36
+		   && e_mouse.x <= f->a.x + 47)
+	    c = AltA;
+	}
+      if (b->sw == 0 && NUM_LINES_ON_SCREEN > 19)
+	{
+	  if (e_mouse.y == f->e.y - 2 && e_mouse.x >= f->a.x + 3
+	      && e_mouse.x <= f->a.x + 8)
+	    c = AltM;
+	  else if (e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 21 &&
+		   e_mouse.x >= f->a.x + 12 && e_mouse.x <= f->a.x + 19)
+	    c = AltR;
+	  else if (e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 30 &&
+		   e_mouse.x >= f->a.x + 23 && e_mouse.x <= f->a.x + 28)
+	    c = AltL;
+	  else if (e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 39 &&
+		   e_mouse.x >= f->a.x + 32 && e_mouse.x <= f->a.x + 37)
+	    c = AltO;
+	  else if (e_mouse.y == f->e.y - 2 && NUM_COLS_ON_SCREEN >= 48 &&
+		   e_mouse.x >= f->a.x + 41 && e_mouse.x <= f->a.x + 46)
+	    c = AltE;
+	}
+
+      if (e_mouse.y == f->a.y + 3 && e_mouse.x >= f->a.x + b->xfa
+	  && e_mouse.x <= f->a.x + b->xfa + b->xfd)
+	c = AltN;
+      else if (e_mouse.y == f->a.y + 3 && e_mouse.x >= f->a.x + b->xda
+	       && e_mouse.x <= f->a.x + b->xda + b->xdd)
+	c = AltD;
+      else if (e_mouse.y >= b->fw->ya && e_mouse.y <= b->fw->ye
+	       && e_mouse.x >= b->fw->xa && e_mouse.x <= b->fw->xe)
+	c = AltF;
+      else if (e_mouse.y >= b->dw->ya && e_mouse.y <= b->dw->ye
+	       && e_mouse.x >= b->dw->xa && e_mouse.x <= b->dw->xe)
+	c = AltT;
+    }
+  while (e_mshit () != 0);
+  return (c);
+}
+
+int
+WpeMouseInFileDirList (int k, int sw, FENSTER * f)
+{
+  extern struct mouse e_mouse;
+  ECNT *cn = f->ed;
+  FLBFFR *b = (FLBFFR *) f->b;
+  int i;
+  char tmp[256];
+
+  if (e_mouse.x >= f->a.x && e_mouse.x <= f->e.x
+      && e_mouse.y >= f->a.y && e_mouse.y <= f->e.y)
+    return (0);
+  for (i = cn->mxedt - 1; i > 0; i--)
+    {
+      if (e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x
+	  && e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
+	break;
+    }
+  if (i <= 0)
+    return (0);
+  if (sw)
+    {
+      if (cn->f[i]->dirct[strlen (cn->f[i]->dirct) - 1] == DIRC)
+	sprintf (tmp, "%s%s", cn->f[i]->dirct,
+		 b->dd->name[b->dw->nf - b->cd->anz]);
+      else
+	sprintf (tmp, "%s/%s", cn->f[i]->dirct,
+		 b->dd->name[b->dw->nf - b->cd->anz]);
+      if (k == -2)
+	e_copy (b->dd->name[b->dw->nf - b->cd->anz], tmp, f);
+      else if (k == -4)
+	e_link (b->dd->name[b->dw->nf - b->cd->anz], tmp, f);
+      else
+	e_rename (b->dd->name[b->dw->nf - b->cd->anz], tmp, f);
+      freedf (b->cd);
+      freedf (b->dw->df);
+      freedf (b->dd);
+      b->dd = e_find_dir (SUDIR, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+      b->cd = WpeCreateWorkingDirTree (f->save, cn);	/* ??? cn */
+      b->dw->df = WpeGraphicalDirTree (b->cd, b->dd, cn);
+      b->dw->nf = b->cd->anz - 1;
+      b->dw->ia = b->dw->ja = 0;
+      e_pr_file_window (b->dw, 0, 1, f->fb->ft.fb, f->fb->fz.fb,
+			f->fb->frft.fb);
+    }
+  else
+    {
+      if (cn->f[i]->dirct[strlen (cn->f[i]->dirct) - 1] == DIRC)
+	sprintf (tmp, "%s%s", cn->f[i]->dirct, b->df->name[b->fw->nf]);
+      else
+	sprintf (tmp, "%s/%s", cn->f[i]->dirct, b->df->name[b->fw->nf]);
+      if (k == -2)
+	e_copy (b->df->name[b->fw->nf], tmp, f);
+      else if (k == -4)
+	e_link (b->df->name[b->fw->nf], tmp, f);
+      else
+	e_rename (b->df->name[b->fw->nf], tmp, f);
+      freedf (b->df);
+      freedf (b->fw->df);
+      b->df =
+	e_find_files (b->rdfile, f->ed->flopt & FM_SHOW_HIDDEN_DIRS ? 1 : 0);
+      b->fw->df = WpeGraphicalFileList (b->df, f->ed->flopt >> 9, cn);
+      b->fw->ia = b->fw->nf = 0;
+      b->fw->ja = b->fw->srcha;
+      e_pr_file_window (b->fw, 0, 1, f->fb->ft.fb, f->fb->fz.fb,
+			f->fb->frft.fb);
+    }
+  return (cn->edt[i] < 10 ? Alt1 - 1 + cn->edt[i] : 1014 + cn->edt[i]);
 }
 
 
 /*  File Window  */
-char *e_gt_btstr(int x, int y, int n, char *buffer)
+char *
+e_gt_btstr (int x, int y, int n, char *buffer)
 {
- int i;
+  int i;
 
- for (i = 0; i < n; i++) buffer[i] = e_gt_byte(2*x + i, y)
-  ;
- return(buffer);
+  for (i = 0; i < n; i++)
+    buffer[i] = e_gt_byte (2 * x + i, y);
+  return (buffer);
 }
 
-char *e_pt_btstr(int x, int y, int n, char *buffer)
+char *
+e_pt_btstr (int x, int y, int n, char *buffer)
 {
- int i;
+  int i;
 
- for(i = 0; i < n; i++) e_pt_byte(2*x + i, y, buffer[i])
-  ;
- return(buffer);
+  for (i = 0; i < n; i++)
+    e_pt_byte (2 * x + i, y, buffer[i]);
+  return (buffer);
 }
 
-int fl_wnd_mouse(sw, k, fw)
+int
+fl_wnd_mouse (sw, k, fw)
      int sw;
      int k;
      FLWND *fw;
 {
-   extern struct mouse e_mouse;
-   int MLEN, i, c, xa, ya, xn, yn, xdif;
-   char *file, *bgrd;
-   if(e_mouse.x == fw->xe && e_mouse.y >= fw->ya && e_mouse.y < fw->ye)
-   {  fw->nf = e_lst_mouse(fw->xe, fw->ya, fw->ye-fw->ya, 0,
-						fw->df->anz, fw->nf);
-      return(0);
-   }
-   else if(e_mouse.y == fw->ye && e_mouse.x >= fw->xa && e_mouse.x < fw->xe)
-   {  fw->ja = e_lst_mouse(fw->xa, fw->ye, fw->xe-fw->xa, 1,
-				strlen(*(fw->df->name+fw->nf)),	fw->ja);
-      return(0);
-   }
-   else if(e_mouse.y >= fw->ya && e_mouse.y < fw->ye &&
-			 e_mouse.x >= fw->xa && e_mouse.x < fw->xe)
-   {  if(fw->nf == e_mouse.y - fw->ya + fw->ia
-		 && e_mouse.y - fw->ya + fw->ia < fw->df->anz)
-      {  /*  if(k == -2) {  while (e_mshit() != 0);  return(AltU);  }
-	 else if(k == -4) {  while (e_mshit() != 0);  return(AltM);  }
-	 else   */
-	 {  xa = e_mouse.x; ya = e_mouse.y; xdif = e_mouse.x - fw->xa;
-	    if(fw->srcha >= 0) c = fw->srcha;
+  extern struct mouse e_mouse;
+  int MLEN, i, c, xa, ya, xn, yn, xdif;
+  char *file, *bgrd;
+  if (e_mouse.x == fw->xe && e_mouse.y >= fw->ya && e_mouse.y < fw->ye)
+    {
+      fw->nf = e_lst_mouse (fw->xe, fw->ya, fw->ye - fw->ya, 0,
+			    fw->df->anz, fw->nf);
+      return (0);
+    }
+  else if (e_mouse.y == fw->ye && e_mouse.x >= fw->xa && e_mouse.x < fw->xe)
+    {
+      fw->ja = e_lst_mouse (fw->xa, fw->ye, fw->xe - fw->xa, 1,
+			    strlen (*(fw->df->name + fw->nf)), fw->ja);
+      return (0);
+    }
+  else if (e_mouse.y >= fw->ya && e_mouse.y < fw->ye &&
+	   e_mouse.x >= fw->xa && e_mouse.x < fw->xe)
+    {
+      if (fw->nf == e_mouse.y - fw->ya + fw->ia
+	  && e_mouse.y - fw->ya + fw->ia < fw->df->anz)
+	{			/*  if(k == -2) {  while (e_mshit() != 0);  return(AltU);  }
+				   else if(k == -4) {  while (e_mshit() != 0);  return(AltM);  }
+				   else   */
+	  {
+	    xa = e_mouse.x;
+	    ya = e_mouse.y;
+	    xdif = e_mouse.x - fw->xa;
+	    if (fw->srcha >= 0)
+	      c = fw->srcha;
 	    else
-	    {  for(c = 0; *(fw->df->name[fw->nf]+c)
-			&& ( *(fw->df->name[fw->nf]+c) <= 32
-			  || *(fw->df->name[fw->nf]+c) >= 127); c++) {
-			;
-		}
-	       if(!WpeIsXwin()) c += 3;
-	    }
-	    for(MLEN = 1; *(fw->df->name[fw->nf]+c+MLEN)
-			&& *(fw->df->name[fw->nf]+c+MLEN) != ' '; MLEN++);
-	    MLEN *= 2;
-	    file = malloc(MLEN * sizeof(char));
-	    bgrd = malloc(MLEN * sizeof(char));
-	    while (e_mshit() != 0)
-	    if(sw && (e_mouse.x != xa || e_mouse.y != ya))
-	    {  xn = e_mouse.x;  yn = e_mouse.y;
-	       if(fw->srcha < 0)
-	       {  FLBFFR *b = (FLBFFR *)fw->f->b;
-		  if(b->cd->anz > fw->nf)
-		  {  while (e_mshit() != 0) {
-			;
-		     }
-		     free (file);  free (bgrd);  return(WPE_CR);
+	      {
+		for (c = 0; *(fw->df->name[fw->nf] + c)
+		     && (*(fw->df->name[fw->nf] + c) <= 32
+			 || *(fw->df->name[fw->nf] + c) >= 127); c++)
+		  {
+		    ;
 		  }
-		  for(c = 0; *(fw->df->name[fw->nf]+c)
-			&& ( *(fw->df->name[fw->nf]+c) <= 32
-			  || *(fw->df->name[fw->nf]+c) >= 127); c++);
-		  if(!WpeIsXwin()) c += 3;
-		  xdif -= (c + 1);
-	       }
-	       for (i = 0; i < MLEN/2; i++)
-	       {  file[2*i] = *(fw->df->name[fw->nf]+c+i);
-		  file[2*i+1] = fw->f->fb->fz.fb;
-	       }
-	       e_gt_btstr(e_mouse.x-xdif, e_mouse.y, MLEN, bgrd);
-	       while (e_mshit() != 0)
-	       {  e_pt_btstr(xn-xdif, yn, MLEN, bgrd);
-		  xn = e_mouse.x;  yn = e_mouse.y;
-		  e_gt_btstr(e_mouse.x-xdif, e_mouse.y, MLEN, bgrd);
-		  e_pt_btstr(e_mouse.x-xdif, e_mouse.y, MLEN, file);
-		  e_refresh();
-	       }
-	       e_pt_btstr(xn-xdif, yn, MLEN, bgrd);
-	       free (file);  free (bgrd);
-	       return(k);
-	    }
-	    free (file);  free (bgrd);
-	    if(sw && k == -2) return(AltU);
-	    else if(sw && k == -4) return(AltM);
-	    else return(WPE_CR);
-	 }
-      }
-      else {  while (e_mshit() != 0) {
-		;
+		if (!WpeIsXwin ())
+		  c += 3;
 	      }
-	      fw->nf = e_mouse.y - fw->ya + fw->ia;  return(0);  }
-   }
-   else return(MBKEY);
+	    for (MLEN = 1; *(fw->df->name[fw->nf] + c + MLEN)
+		 && *(fw->df->name[fw->nf] + c + MLEN) != ' '; MLEN++);
+	    MLEN *= 2;
+	    file = malloc (MLEN * sizeof (char));
+	    bgrd = malloc (MLEN * sizeof (char));
+	    while (e_mshit () != 0)
+	      if (sw && (e_mouse.x != xa || e_mouse.y != ya))
+		{
+		  xn = e_mouse.x;
+		  yn = e_mouse.y;
+		  if (fw->srcha < 0)
+		    {
+		      FLBFFR *b = (FLBFFR *) fw->f->b;
+		      if (b->cd->anz > fw->nf)
+			{
+			  while (e_mshit () != 0)
+			    {
+			      ;
+			    }
+			  free (file);
+			  free (bgrd);
+			  return (WPE_CR);
+			}
+		      for (c = 0; *(fw->df->name[fw->nf] + c)
+			   && (*(fw->df->name[fw->nf] + c) <= 32
+			       || *(fw->df->name[fw->nf] + c) >= 127); c++);
+		      if (!WpeIsXwin ())
+			c += 3;
+		      xdif -= (c + 1);
+		    }
+		  for (i = 0; i < MLEN / 2; i++)
+		    {
+		      file[2 * i] = *(fw->df->name[fw->nf] + c + i);
+		      file[2 * i + 1] = fw->f->fb->fz.fb;
+		    }
+		  e_gt_btstr (e_mouse.x - xdif, e_mouse.y, MLEN, bgrd);
+		  while (e_mshit () != 0)
+		    {
+		      e_pt_btstr (xn - xdif, yn, MLEN, bgrd);
+		      xn = e_mouse.x;
+		      yn = e_mouse.y;
+		      e_gt_btstr (e_mouse.x - xdif, e_mouse.y, MLEN, bgrd);
+		      e_pt_btstr (e_mouse.x - xdif, e_mouse.y, MLEN, file);
+		      e_refresh ();
+		    }
+		  e_pt_btstr (xn - xdif, yn, MLEN, bgrd);
+		  free (file);
+		  free (bgrd);
+		  return (k);
+		}
+	    free (file);
+	    free (bgrd);
+	    if (sw && k == -2)
+	      return (AltU);
+	    else if (sw && k == -4)
+	      return (AltM);
+	    else
+	      return (WPE_CR);
+	  }
+	}
+      else
+	{
+	  while (e_mshit () != 0)
+	    {
+	      ;
+	    }
+	  fw->nf = e_mouse.y - fw->ya + fw->ia;
+	  return (0);
+	}
+    }
+  else
+    return (MBKEY);
 }
 
 /*   mouse slider bar control */
-int e_lst_mouse(x, y, n, sw, max, nf)
+int
+e_lst_mouse (x, y, n, sw, max, nf)
      int x;
      int y;
      int n;
@@ -429,710 +508,926 @@ int e_lst_mouse(x, y, n, sw, max, nf)
      int max;
      int nf;
 {
-   extern struct mouse e_mouse;
-   int g[4];  /*  = { 1, 0, 0, 0 };  */
-   int inew, iold, nret, frb = e_gt_col(x, y);
-   double d;
-   if(n < 2) return(nf);
-   d = ((double)max)/((double)(n-2));
-   g[0] = 1;
-   if(sw == 0)
-   {  if(e_mouse.x != x) return(nf);
-      if(e_mouse.y < y || e_mouse.y >= y+n) return(nf);
-      if(e_mouse.y == y) nret= (nf < 1) ? nf : nf-1;
-      else if(e_mouse.y == y+n-1) nret= (nf >= max-1) ? nf : nf+1;
+  extern struct mouse e_mouse;
+  int g[4];			/*  = { 1, 0, 0, 0 };  */
+  int inew, iold, nret, frb = e_gt_col (x, y);
+  double d;
+  if (n < 2)
+    return (nf);
+  d = ((double) max) / ((double) (n - 2));
+  g[0] = 1;
+  if (sw == 0)
+    {
+      if (e_mouse.x != x)
+	return (nf);
+      if (e_mouse.y < y || e_mouse.y >= y + n)
+	return (nf);
+      if (e_mouse.y == y)
+	nret = (nf < 1) ? nf : nf - 1;
+      else if (e_mouse.y == y + n - 1)
+	nret = (nf >= max - 1) ? nf : nf + 1;
       else
-      {  nret = (int) ((e_mouse.y-y-1)*d);
-	 if(e_gt_char(e_mouse.x, e_mouse.y) == MCA )
-	 {  iold = e_mouse.y;
+	{
+	  nret = (int) ((e_mouse.y - y - 1) * d);
+	  if (e_gt_char (e_mouse.x, e_mouse.y) == MCA)
+	    {
+	      iold = e_mouse.y;
 #ifdef NEWSTYLE
-	    e_make_xrect_abs(x, iold, x, iold, 1);
-	    e_refresh();
+	      e_make_xrect_abs (x, iold, x, iold, 1);
+	      e_refresh ();
 #endif
-	    fk_mouse(g);
-	    for(g[1]=1; g[1] != 0; fk_mouse(g), g[0]=3)
-	    {  if((inew = g[3]/8) < y+1) inew = y+1;
-	       if(inew > y+n-2) inew = y+n-2;
-	       if(iold != inew)
-	       {  g[0] = 2; fk_mouse(g);
-		  e_pr_char(x, iold, MCI, frb);
-		  e_pr_char(x, inew, MCA, frb);
+	      fk_mouse (g);
+	      for (g[1] = 1; g[1] != 0; fk_mouse (g), g[0] = 3)
+		{
+		  if ((inew = g[3] / 8) < y + 1)
+		    inew = y + 1;
+		  if (inew > y + n - 2)
+		    inew = y + n - 2;
+		  if (iold != inew)
+		    {
+		      g[0] = 2;
+		      fk_mouse (g);
+		      e_pr_char (x, iold, MCI, frb);
+		      e_pr_char (x, inew, MCA, frb);
 #ifdef NEWSTYLE
-		  e_make_xrect(x, y+1, x, y+n-2, 0);
-		  e_make_xrect_abs(x, inew, x, inew, 1);
+		      e_make_xrect (x, y + 1, x, y + n - 2, 0);
+		      e_make_xrect_abs (x, inew, x, inew, 1);
 #endif
-		  e_refresh();
-		  iold = inew;
-		  g[0] = 1; fk_mouse(g);
-	       };
+		      e_refresh ();
+		      iold = inew;
+		      g[0] = 1;
+		      fk_mouse (g);
+		    };
+		}
+	      g[0] = 2;
+	      fk_mouse (g);
+	      e_pr_char (x, inew, MCI, frb);
+	      if (inew - y < 2)
+		nret = 0;
+	      else if (inew - y > n - 3)
+		nret = max - 1;
+	      else
+		nret = (int) ((inew - y - 0.5) * d);
 	    }
-	    g[0] = 2;
-	    fk_mouse(g);
-	    e_pr_char(x, inew, MCI, frb);
-	    if(inew-y < 2) nret = 0;
-	    else if(inew-y > n - 3) nret = max - 1;
-	    else nret = (int) ((inew-y-0.5)*d);
-	 }
-	 else if(nf < nret)
-	 {  nret = (nf+n > max) ? max : nf+n-1;
-	    while (e_mshit() != 0);
-	 }
-	 else
-	 {  nret = (nf-n < 0) ? 0 : nf-n+1;
-	    while (e_mshit() != 0);
-	 }
-      }
-   }
-   else
-   {  if(e_mouse.y != y) return(nf);
-      if(e_mouse.x < x || e_mouse.x >= x+n) return(nf);
-      if(e_mouse.x == x) nret= (nf < 1) ? nf : nf-1;
-      else if(e_mouse.x == x+n-1) nret= (nf >= max-1) ? nf : nf+1;
+	  else if (nf < nret)
+	    {
+	      nret = (nf + n > max) ? max : nf + n - 1;
+	      while (e_mshit () != 0);
+	    }
+	  else
+	    {
+	      nret = (nf - n < 0) ? 0 : nf - n + 1;
+	      while (e_mshit () != 0);
+	    }
+	}
+    }
+  else
+    {
+      if (e_mouse.y != y)
+	return (nf);
+      if (e_mouse.x < x || e_mouse.x >= x + n)
+	return (nf);
+      if (e_mouse.x == x)
+	nret = (nf < 1) ? nf : nf - 1;
+      else if (e_mouse.x == x + n - 1)
+	nret = (nf >= max - 1) ? nf : nf + 1;
       else
-      {  nret = (int) ((e_mouse.x-x-1)*d);
-	 if( e_gt_char(e_mouse.x, e_mouse.y) == MCA )
-	 {  iold = e_mouse.x;
+	{
+	  nret = (int) ((e_mouse.x - x - 1) * d);
+	  if (e_gt_char (e_mouse.x, e_mouse.y) == MCA)
+	    {
+	      iold = e_mouse.x;
 #ifdef NEWSTYLE
-	    e_make_xrect_abs(iold, y, iold, y, 1);
-	    e_refresh();
+	      e_make_xrect_abs (iold, y, iold, y, 1);
+	      e_refresh ();
 #endif
-	    fk_mouse(g);
-	    for(g[1]=1; g[1] != 0; fk_mouse(g), g[0]=3)
-	    {  if((inew = g[2]/8) < x+1) inew = x+1;
-	       if(inew > x+n-2) inew = x+n-2;
-	       if(iold != inew)
-	       {  g[0] = 2; fk_mouse(g);
-		  e_pr_char(iold, y, MCI, frb);
-		  e_pr_char(inew, y, MCA, frb);
+	      fk_mouse (g);
+	      for (g[1] = 1; g[1] != 0; fk_mouse (g), g[0] = 3)
+		{
+		  if ((inew = g[2] / 8) < x + 1)
+		    inew = x + 1;
+		  if (inew > x + n - 2)
+		    inew = x + n - 2;
+		  if (iold != inew)
+		    {
+		      g[0] = 2;
+		      fk_mouse (g);
+		      e_pr_char (iold, y, MCI, frb);
+		      e_pr_char (inew, y, MCA, frb);
 #ifdef NEWSTYLE
-		  e_make_xrect(x+1, y, x+n-2, y, 0);
-		  e_make_xrect_abs(inew, y, inew, y, 1);
+		      e_make_xrect (x + 1, y, x + n - 2, y, 0);
+		      e_make_xrect_abs (inew, y, inew, y, 1);
 #endif
-		  e_refresh();
-		  iold = inew;
-		  g[0] = 1; fk_mouse(g);
-	       };
+		      e_refresh ();
+		      iold = inew;
+		      g[0] = 1;
+		      fk_mouse (g);
+		    };
+		}
+	      g[0] = 2;
+	      fk_mouse (g);
+	      e_pr_char (inew, y, MCI, frb);
+	      if (inew - y < 2)
+		nret = 0;
+	      else if (inew - y > n - 3)
+		nret = max - 1;
+	      else
+		nret = (int) ((inew - y - 0.5) * d);
 	    }
-	    g[0] = 2;
-	    fk_mouse(g);
-	    e_pr_char(inew, y, MCI, frb);
-	    if(inew-y < 2) nret = 0;
-	    else if(inew-y > n - 3) nret = max - 1;
-	    else nret = (int) ((inew-y-0.5)*d);
-	 }
-	 else if(nf < nret)
-	 {  nret = (nf+n > max) ? max : nf+n-1;
-	    while (e_mshit() != 0);
-	 }
-	 else
-	 {  nret = (nf-n < 0) ? 0 : nf-n+1;
-	    while (e_mshit() != 0);
-	 }
-      }
-   }
-   return(nret);
+	  else if (nf < nret)
+	    {
+	      nret = (nf + n > max) ? max : nf + n - 1;
+	      while (e_mshit () != 0);
+	    }
+	  else
+	    {
+	      nret = (nf - n < 0) ? 0 : nf - n + 1;
+	      while (e_mshit () != 0);
+	    }
+	}
+    }
+  return (nret);
 }
 
 /*   mouse window resizer control */
-void e_eck_mouse(FENSTER *f, int sw)
+void
+e_eck_mouse (FENSTER * f, int sw)
 {
- int g[4];  /*  = { 3, 1, 0, 0 };  */
- int xold, yold, x, y, xa, xmin = 26, ymin = 3;
- POINT fa, fe;
+  int g[4];			/*  = { 3, 1, 0, 0 };  */
+  int xold, yold, x, y, xa, xmin = 26, ymin = 3;
+  POINT fa, fe;
 
- e_ed_rahmen(f, 0);
- memcpy(&fa, &f->a, sizeof(POINT));
- memcpy(&fe, &f->e, sizeof(POINT));
- g[0] = 3;
- g[1] = 1;
- fk_mouse(g);
- xold = g[2]/8;
- yold = g[3]/8;
- xa = xold - f->a.x;
- if (f->dtmd == DTMD_FILEDROPDOWN)
-  xmin = 15;
- else if (!DTMD_ISTEXT(f->dtmd))
-  ymin = 9;
- while(g[1] != 0)
- {
-  x = g[2]/8;
-  y = g[3]/8;
-  if (y < 1)
-   y = 1;
-  else if (y > MAXSLNS-2)
-   y = MAXSLNS-2;
-  if (x < 0)
-   x = 0;
-  else if (x > MAXSCOL-1)
-   x = MAXSCOL-1;
-  if (xold != x || yold != y)
-  {
-   xold = x;
-   yold = y;
-   if (sw == 0)
-   {
-    x -= xa;
-    if (x < 0)
-     x = 0;
-    else if (x + NUM_COLS_ON_SCREEN > MAXSCOL-1)
-     x = MAXSCOL - f->e.x + f->a.x - 1;
-    if (f->e.y + y - f->a.y > MAXSLNS-2)
-     y = MAXSLNS - f->e.y + f->a.y - 2;
-    f->e.x = NUM_COLS_ON_SCREEN + x;
-    f->a.x = x;
-    f->e.y = f->e.y + y - f->a.y;
-    f->a.y = y;
-   }
-   else if (sw == 1)
-   {
-    if (x > f->e.x - xmin)
-     x = f->e.x - xmin;
-    if (y > f->e.y - ymin)
-     y = f->e.y - ymin;
-    f->a.x = x;
-    f->a.y = y;
-   }
-   else if (sw == 2)
-   {
-    if (x < f->a.x + xmin)
-     x = f->a.x + xmin;
-    if (y > f->e.y - ymin)
-     y = f->e.y - ymin;
-    f->e.x = x;
-    f->a.y = y;
-   }
-   else if (sw == 3)
-   {
-    if (x < f->a.x + xmin)
-     x = f->a.x + xmin;
-    if (y < f->a.y + ymin)
-     y = f->a.y + ymin;
-    f->e.x = x;
-    f->e.y = y;
-   }
-   else if (sw == 4)
-   {
-    if (x > f->e.x - xmin)
-     x = f->e.x - xmin;
-    if (y < f->a.y + ymin)
-     y = f->a.y + ymin;
-    f->a.x = x;
-    f->e.y = y;
-   }
-   g[0] = 2;
-   fk_mouse(g);
-   f->pic = e_ed_kst(f, f->pic, 0);
-   if (f->pic == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-   if (f->dtmd == DTMD_FILEDROPDOWN)
-   {
-    FLWND *fw = (FLWND*) f->b;
-    fw->xa = f->a.x+1;
-    fw->xe = f->e.x;
-    fw->ya = f->a.y+1;
-    fw->ye = f->e.y;
-   }
-   g[0] = 1;
-   fk_mouse(g);
-   e_cursor(f, 0);
-   e_schirm(f, 0);
-   e_refresh();
-  }
+  e_ed_rahmen (f, 0);
+  memcpy (&fa, &f->a, sizeof (POINT));
+  memcpy (&fe, &f->e, sizeof (POINT));
   g[0] = 3;
-  fk_mouse(g);
- }
- if ((memcmp(&fa, &f->a, sizeof(POINT))) ||
-   (memcmp(&fe, &f->e, sizeof(POINT))))
-  f->zoom = 0;
- e_ed_rahmen(f, 1);
+  g[1] = 1;
+  fk_mouse (g);
+  xold = g[2] / 8;
+  yold = g[3] / 8;
+  xa = xold - f->a.x;
+  if (f->dtmd == DTMD_FILEDROPDOWN)
+    xmin = 15;
+  else if (!DTMD_ISTEXT (f->dtmd))
+    ymin = 9;
+  while (g[1] != 0)
+    {
+      x = g[2] / 8;
+      y = g[3] / 8;
+      if (y < 1)
+	y = 1;
+      else if (y > MAXSLNS - 2)
+	y = MAXSLNS - 2;
+      if (x < 0)
+	x = 0;
+      else if (x > MAXSCOL - 1)
+	x = MAXSCOL - 1;
+      if (xold != x || yold != y)
+	{
+	  xold = x;
+	  yold = y;
+	  if (sw == 0)
+	    {
+	      x -= xa;
+	      if (x < 0)
+		x = 0;
+	      else if (x + NUM_COLS_ON_SCREEN > MAXSCOL - 1)
+		x = MAXSCOL - f->e.x + f->a.x - 1;
+	      if (f->e.y + y - f->a.y > MAXSLNS - 2)
+		y = MAXSLNS - f->e.y + f->a.y - 2;
+	      f->e.x = NUM_COLS_ON_SCREEN + x;
+	      f->a.x = x;
+	      f->e.y = f->e.y + y - f->a.y;
+	      f->a.y = y;
+	    }
+	  else if (sw == 1)
+	    {
+	      if (x > f->e.x - xmin)
+		x = f->e.x - xmin;
+	      if (y > f->e.y - ymin)
+		y = f->e.y - ymin;
+	      f->a.x = x;
+	      f->a.y = y;
+	    }
+	  else if (sw == 2)
+	    {
+	      if (x < f->a.x + xmin)
+		x = f->a.x + xmin;
+	      if (y > f->e.y - ymin)
+		y = f->e.y - ymin;
+	      f->e.x = x;
+	      f->a.y = y;
+	    }
+	  else if (sw == 3)
+	    {
+	      if (x < f->a.x + xmin)
+		x = f->a.x + xmin;
+	      if (y < f->a.y + ymin)
+		y = f->a.y + ymin;
+	      f->e.x = x;
+	      f->e.y = y;
+	    }
+	  else if (sw == 4)
+	    {
+	      if (x > f->e.x - xmin)
+		x = f->e.x - xmin;
+	      if (y < f->a.y + ymin)
+		y = f->a.y + ymin;
+	      f->a.x = x;
+	      f->e.y = y;
+	    }
+	  g[0] = 2;
+	  fk_mouse (g);
+	  f->pic = e_ed_kst (f, f->pic, 0);
+	  if (f->pic == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+	  if (f->dtmd == DTMD_FILEDROPDOWN)
+	    {
+	      FLWND *fw = (FLWND *) f->b;
+	      fw->xa = f->a.x + 1;
+	      fw->xe = f->e.x;
+	      fw->ya = f->a.y + 1;
+	      fw->ye = f->e.y;
+	    }
+	  g[0] = 1;
+	  fk_mouse (g);
+	  e_cursor (f, 0);
+	  e_schirm (f, 0);
+	  e_refresh ();
+	}
+      g[0] = 3;
+      fk_mouse (g);
+    }
+  if ((memcmp (&fa, &f->a, sizeof (POINT))) ||
+      (memcmp (&fe, &f->e, sizeof (POINT))))
+    f->zoom = 0;
+  e_ed_rahmen (f, 1);
 }
 
 /*       Mouse edit window control   */
-int e_edt_mouse(int c, FENSTER *f)
+int
+e_edt_mouse (int c, FENSTER * f)
 {
- int i, ret = 0;
- extern struct mouse e_mouse;
- ECNT *cn = f->ed;
+  int i, ret = 0;
+  extern struct mouse e_mouse;
+  ECNT *cn = f->ed;
 
- if (e_mouse.y == 0) return(e_m1_mouse());
- else if (e_mouse.y == MAXSLNS-1) return(e_m3_mouse());
- else if (e_mouse.x >= f->a.x && e_mouse.x <= f->e.x &&
-   e_mouse.y >= f->a.y && e_mouse.y <= f->e.y)
- {
-  if (e_mouse.x == f->a.x+3 && e_mouse.y == f->a.y) ret = f->ed->edopt & ED_CUA_STYLE ? CF4 : AF3;
-  else if (e_mouse.x == f->e.x-3 && e_mouse.y == f->a.y) e_ed_zoom(f);
-  else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y) e_eck_mouse(f, 1);
-  else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y) e_eck_mouse(f, 2);
-  else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y) e_eck_mouse(f, 3);
-  else if (e_mouse.x == f->a.x && e_mouse.y == f->e.y) e_eck_mouse(f, 4);
-  else if (e_mouse.y == f->a.y) e_eck_mouse(f, 0);
-  else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y+2) ret = f->ed->edopt & ED_CUA_STYLE ? AF3 : F4;
-  else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y+4) ret = f->ed->edopt & ED_CUA_STYLE ? CF3 : AF4;
-  else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y+6) ret = f->ed->edopt & ED_CUA_STYLE ? F3 : CF4;
-  else if (f->ins != 8 && e_mouse.x == f->a.x &&
-    e_mouse.y == f->a.y+8) ret = f->ed->edopt & ED_CUA_STYLE ? AF2 : F2;
-  else if (e_mouse.y == f->e.y && e_mouse.x > f->a.x + 4 &&
-    e_mouse.x < f->a.x + 14) ret = AltG;
-  else if (e_mouse.y == f->e.y && e_mouse.x == f->a.x + 15 && f->ins != 8)
-  {
-   if (f->ins & 1) f->ins &= ~1;
-   else f->ins |= 1;
-   e_pr_filetype(f);
-  }
-  else if (e_mouse.y == f->e.y && e_mouse.x == f->a.x + 16 && f->ins != 8)
-  {
-   if (f->ins & 2) f->ins &= ~2;
-   else f->ins |= 2;
-   e_pr_filetype(f);
-  }
-  else if (e_mouse.x > f->a.x && e_mouse.x < f->e.x &&
-    e_mouse.y > f->a.y && e_mouse.y < f->e.y)
-  {
-   if (c < -1) ret = e_ccp_mouse(c, f);
-   else if (f->dtmd == DTMD_HELP && f->ins == 8 &&
-     f->b->b.y == e_mouse.y-f->a.y+NUM_LINES_OFF_SCREEN_TOP-1 &&
-     ((i = f->b->b.x) == e_mouse_cursor(f->b, f->s, f)))
-    ret = WPE_CR;
-   else
+  if (e_mouse.y == 0)
+    return (e_m1_mouse ());
+  else if (e_mouse.y == MAXSLNS - 1)
+    return (e_m3_mouse ());
+  else if (e_mouse.x >= f->a.x && e_mouse.x <= f->e.x &&
+	   e_mouse.y >= f->a.y && e_mouse.y <= f->e.y)
+    {
+      if (e_mouse.x == f->a.x + 3 && e_mouse.y == f->a.y)
+	ret = f->ed->edopt & ED_CUA_STYLE ? CF4 : AF3;
+      else if (e_mouse.x == f->e.x - 3 && e_mouse.y == f->a.y)
+	e_ed_zoom (f);
+      else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y)
+	e_eck_mouse (f, 1);
+      else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y)
+	e_eck_mouse (f, 2);
+      else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y)
+	e_eck_mouse (f, 3);
+      else if (e_mouse.x == f->a.x && e_mouse.y == f->e.y)
+	e_eck_mouse (f, 4);
+      else if (e_mouse.y == f->a.y)
+	e_eck_mouse (f, 0);
+      else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y + 2)
+	ret = f->ed->edopt & ED_CUA_STYLE ? AF3 : F4;
+      else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y + 4)
+	ret = f->ed->edopt & ED_CUA_STYLE ? CF3 : AF4;
+      else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y + 6)
+	ret = f->ed->edopt & ED_CUA_STYLE ? F3 : CF4;
+      else if (f->ins != 8 && e_mouse.x == f->a.x && e_mouse.y == f->a.y + 8)
+	ret = f->ed->edopt & ED_CUA_STYLE ? AF2 : F2;
+      else if (e_mouse.y == f->e.y && e_mouse.x > f->a.x + 4 &&
+	       e_mouse.x < f->a.x + 14)
+	ret = AltG;
+      else if (e_mouse.y == f->e.y && e_mouse.x == f->a.x + 15 && f->ins != 8)
+	{
+	  if (f->ins & 1)
+	    f->ins &= ~1;
+	  else
+	    f->ins |= 1;
+	  e_pr_filetype (f);
+	}
+      else if (e_mouse.y == f->e.y && e_mouse.x == f->a.x + 16 && f->ins != 8)
+	{
+	  if (f->ins & 2)
+	    f->ins &= ~2;
+	  else
+	    f->ins |= 2;
+	  e_pr_filetype (f);
+	}
+      else if (e_mouse.x > f->a.x && e_mouse.x < f->e.x &&
+	       e_mouse.y > f->a.y && e_mouse.y < f->e.y)
+	{
+	  if (c < -1)
+	    ret = e_ccp_mouse (c, f);
+	  else if (f->dtmd == DTMD_HELP && f->ins == 8 &&
+		   f->b->b.y ==
+		   e_mouse.y - f->a.y + NUM_LINES_OFF_SCREEN_TOP - 1
+		   && ((i = f->b->b.x) == e_mouse_cursor (f->b, f->s, f)))
+	    ret = WPE_CR;
+	  else
 #ifdef PROG
 #ifdef DEBUGGER
-   {
-    if (WpeIsProg() && (!strcmp(f->datnam, "Watches") ||
-      !strcmp(f->datnam, "Messages") ||
-      !strcmp(f->datnam, "Stack")))
-     ret = e_d_car_mouse(f);
-    else
-     e_cur_mouse(f);
-   }
+	    {
+	      if (WpeIsProg () && (!strcmp (f->datnam, "Watches") ||
+				   !strcmp (f->datnam, "Messages") ||
+				   !strcmp (f->datnam, "Stack")))
+		ret = e_d_car_mouse (f);
+	      else
+		e_cur_mouse (f);
+	    }
 #else
-   {
-    if (WpeIsProg() && !strcmp(f->datnam, "Messages"))
-     ret = e_d_car_mouse(f);
-    else
-     e_cur_mouse(f);
-   }
+	    {
+	      if (WpeIsProg () && !strcmp (f->datnam, "Messages"))
+		ret = e_d_car_mouse (f);
+	      else
+		e_cur_mouse (f);
+	    }
 #endif
 #else
-    e_cur_mouse(f);
+	    e_cur_mouse (f);
 #endif
-  }
-  else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y+1)
-  {
-   /*changed the while()... to a do...while();  :Mark L*/
-   do
-   {
-    f->b->b.y = f->b->b.y > 0 ? f->b->b.y - 1 : 0;
-    f->b->b.x = e_chr_sp(f->b->clsv, f->b, f);
-    e_cursor(f, 1);
-    e_refresh();
-   } while(e_mshit());
-  }
-  else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y-1)
-  {
-   /*changed the while()... to a do...while();  :Mark L*/
-   do
-   {
-    f->b->b.y = f->b->b.y < f->b->mxlines - 1 ?
-      f->b->b.y + 1 : f->b->mxlines - 1;
-    f->b->b.x = e_chr_sp(f->b->clsv, f->b, f);
-    e_cursor(f, 1);
-    e_refresh();
-   } while(e_mshit());
-  }
-  else if (e_mouse.x == f->e.x &&
-    e_mouse.y > f->a.y+1 && e_mouse.y < f->e.y-1)
-  {
-   f->b->b.y = e_lst_mouse(f->e.x, f->a.y+1, f->e.y-f->a.y-1, 0,
-     f->b->mxlines, f->b->b.y);
-   e_cursor(f, 1);
-   e_refresh();
-  }
-  else if (e_mouse.y == f->e.y && e_mouse.x == f->a.x+19)
-  {
-   while (e_mshit())
-   {
-    f->b->b.x = f->b->b.x > 0 ? f->b->b.x - 1 : 0;
-    e_cursor(f, 1);
-    e_refresh();
-   }
-  }
-  else if (e_mouse.y == f->e.y && e_mouse.x == f->e.x-2)
-  {
-   while (e_mshit())
-   {
-    f->b->b.x = f->b->b.x < f->b->bf[f->b->b.y].len ?
-      f->b->b.x + 1 : f->b->bf[f->b->b.y].len;
-    e_cursor(f, 1);
-    e_refresh();
-   }
-  }
-  else if (e_mouse.y == f->e.y &&
-    e_mouse.x > f->a.x+19 && e_mouse.x < f->e.x-2)
-  {
-   f->b->b.x = e_lst_mouse(f->a.x+19, f->e.y, f->e.x-f->a.x-20, 1,
-     f->b->mx.x, NUM_COLS_OFF_SCREEN_LEFT);
-   e_cursor(f, 1);
-   e_refresh();
-  }
- }
- else
- {
-  for (i = cn->mxedt; i > 0; i--)
-  {
-   if (e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x &&
-     e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
-   {
-    ret = cn->edt[i] < 10 ? Alt1-1+cn->edt[i] : 1014+cn->edt[i];
-    break;
-   }
-  }
- }
- while (e_mshit()!= 0)
-  ;
- return(ret);
+	}
+      else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y + 1)
+	{
+	  /*changed the while()... to a do...while();  :Mark L */
+	  do
+	    {
+	      f->b->b.y = f->b->b.y > 0 ? f->b->b.y - 1 : 0;
+	      f->b->b.x = e_chr_sp (f->b->clsv, f->b, f);
+	      e_cursor (f, 1);
+	      e_refresh ();
+	    }
+	  while (e_mshit ());
+	}
+      else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y - 1)
+	{
+	  /*changed the while()... to a do...while();  :Mark L */
+	  do
+	    {
+	      f->b->b.y = f->b->b.y < f->b->mxlines - 1 ?
+		f->b->b.y + 1 : f->b->mxlines - 1;
+	      f->b->b.x = e_chr_sp (f->b->clsv, f->b, f);
+	      e_cursor (f, 1);
+	      e_refresh ();
+	    }
+	  while (e_mshit ());
+	}
+      else if (e_mouse.x == f->e.x &&
+	       e_mouse.y > f->a.y + 1 && e_mouse.y < f->e.y - 1)
+	{
+	  f->b->b.y = e_lst_mouse (f->e.x, f->a.y + 1, f->e.y - f->a.y - 1, 0,
+				   f->b->mxlines, f->b->b.y);
+	  e_cursor (f, 1);
+	  e_refresh ();
+	}
+      else if (e_mouse.y == f->e.y && e_mouse.x == f->a.x + 19)
+	{
+	  while (e_mshit ())
+	    {
+	      f->b->b.x = f->b->b.x > 0 ? f->b->b.x - 1 : 0;
+	      e_cursor (f, 1);
+	      e_refresh ();
+	    }
+	}
+      else if (e_mouse.y == f->e.y && e_mouse.x == f->e.x - 2)
+	{
+	  while (e_mshit ())
+	    {
+	      f->b->b.x = f->b->b.x < f->b->bf[f->b->b.y].len ?
+		f->b->b.x + 1 : f->b->bf[f->b->b.y].len;
+	      e_cursor (f, 1);
+	      e_refresh ();
+	    }
+	}
+      else if (e_mouse.y == f->e.y &&
+	       e_mouse.x > f->a.x + 19 && e_mouse.x < f->e.x - 2)
+	{
+	  f->b->b.x =
+	    e_lst_mouse (f->a.x + 19, f->e.y, f->e.x - f->a.x - 20, 1,
+			 f->b->mx.x, NUM_COLS_OFF_SCREEN_LEFT);
+	  e_cursor (f, 1);
+	  e_refresh ();
+	}
+    }
+  else
+    {
+      for (i = cn->mxedt; i > 0; i--)
+	{
+	  if (e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x &&
+	      e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
+	    {
+	      ret =
+		cn->edt[i] < 10 ? Alt1 - 1 + cn->edt[i] : 1014 + cn->edt[i];
+	      break;
+	    }
+	}
+    }
+  while (e_mshit () != 0)
+    ;
+  return (ret);
 }
 
-int e_mouse_cursor(BUFFER *b, SCHIRM *s, FENSTER *f)
+int
+e_mouse_cursor (BUFFER * b, SCHIRM * s, FENSTER * f)
 {
- extern struct mouse e_mouse;
+  extern struct mouse e_mouse;
 
- b->b.x = e_mouse.x-f->a.x+s->c.x-1;
- b->b.y = e_mouse.y-f->a.y+s->c.y-1;
- if (b->b.y < 0) b->b.y = 0;
- else if (b->b.y >= b->mxlines) b->b.y = b->mxlines - 1;
- return(b->b.x = e_chr_sp(b->b.x, b, f));
+  b->b.x = e_mouse.x - f->a.x + s->c.x - 1;
+  b->b.y = e_mouse.y - f->a.y + s->c.y - 1;
+  if (b->b.y < 0)
+    b->b.y = 0;
+  else if (b->b.y >= b->mxlines)
+    b->b.y = b->mxlines - 1;
+  return (b->b.x = e_chr_sp (b->b.x, b, f));
 }
 
 /*  Copy, Cut and Paste functions    */
-int e_ccp_mouse(int c, FENSTER *f)
+int
+e_ccp_mouse (int c, FENSTER * f)
 {
- BUFFER *b = f->ed->f[f->ed->mxedt]->b;
- SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
 
- while (e_mshit() != 0)
-  ;
- if (c == -2)
- {
-  e_mouse_cursor(b, s, f);
-  return((bioskey() & 8) ? AltEin : ShiftEin);
- }
- else if (c == -4)
- {
-  return((bioskey() & 3) ? ShiftDel : ((bioskey() & 8) ? AltDel : CEINFG));
- }
- else return(0);
+  while (e_mshit () != 0)
+    ;
+  if (c == -2)
+    {
+      e_mouse_cursor (b, s, f);
+      return ((bioskey () & 8) ? AltEin : ShiftEin);
+    }
+  else if (c == -4)
+    {
+      return ((bioskey () & 3) ? ShiftDel
+	      : ((bioskey () & 8) ? AltDel : CEINFG));
+    }
+  else
+    return (0);
 }
 
 /*       Mouse cursor in edit window control   */
-void e_cur_mouse(f)
+void
+e_cur_mouse (f)
      FENSTER *f;
 {
-   BUFFER *b = f->ed->f[f->ed->mxedt]->b;
-   SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
-   POINT bs;
-   bs.x = b->b.x;  bs.y = b->b.y;
-   e_mouse_cursor(b, s, f);
-   if((bioskey() & 3) == 0)
-   {  if(b->b.x == bs.x && b->b.y == bs.y && f->dtmd != DTMD_HELP)
-      {  if(s->mark_begin.y == b->b.y && s->mark_end.y == b->b.y
-		&& s->mark_begin.x <= b->b.x && s->mark_end.x > b->b.x)
-	 {  s->mark_begin.x = 0;  s->mark_end.x = b->bf[b->b.y].len;  }
-	 else
-	 {  s->mark_begin.y = s->mark_end.y = b->b.y;
-	    for(s->mark_begin.x = b->b.x; s->mark_begin.x > 0
-			&& isalnum1(b->bf[b->b.y].s[s->mark_begin.x-1]); s->mark_begin.x--);
-	    for(s->mark_end.x = b->b.x; s->mark_end.x < b->bf[b->b.y].len
-			&& isalnum1(b->bf[b->b.y].s[s->mark_end.x]); s->mark_end.x++);
-	 }
-	 e_schirm(f, 1);
-      }
-      s->ks.x = b->b.x;  s->ks.y = b->b.y;
-   }
-   else
-   {  if(s->mark_end.y < b->b.y || ( s->mark_end.y == b->b.y && s->mark_end.x <= b->b.x))
-      {  s->mark_end.x = b->b.x;  s->mark_end.y = b->b.y;
-	 s->ks.x = s->mark_begin.x;  s->ks.y = s->mark_begin.y;
-      }
-      else if(s->mark_begin.y > b->b.y || ( s->mark_begin.y == b->b.y && s->mark_begin.x >= b->b.x))
-      {  s->mark_begin.x = b->b.x;  s->mark_begin.y = b->b.y;
-	 s->ks.x = s->mark_end.x;  s->ks.y = s->mark_end.y;
-      }
-      else if(s->mark_end.y < bs.y || ( s->mark_end.y == bs.y && s->mark_end.x <= bs.x))
-      {  s->mark_begin.x = b->b.x;  s->mark_begin.y = b->b.y;
-	 s->ks.x = s->mark_end.x;  s->ks.y = s->mark_end.y;
-      }
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
+  POINT bs;
+  bs.x = b->b.x;
+  bs.y = b->b.y;
+  e_mouse_cursor (b, s, f);
+  if ((bioskey () & 3) == 0)
+    {
+      if (b->b.x == bs.x && b->b.y == bs.y && f->dtmd != DTMD_HELP)
+	{
+	  if (s->mark_begin.y == b->b.y && s->mark_end.y == b->b.y
+	      && s->mark_begin.x <= b->b.x && s->mark_end.x > b->b.x)
+	    {
+	      s->mark_begin.x = 0;
+	      s->mark_end.x = b->bf[b->b.y].len;
+	    }
+	  else
+	    {
+	      s->mark_begin.y = s->mark_end.y = b->b.y;
+	      for (s->mark_begin.x = b->b.x; s->mark_begin.x > 0
+		   && isalnum1 (b->bf[b->b.y].s[s->mark_begin.x - 1]);
+		   s->mark_begin.x--);
+	      for (s->mark_end.x = b->b.x;
+		   s->mark_end.x < b->bf[b->b.y].len
+		   && isalnum1 (b->bf[b->b.y].s[s->mark_end.x]);
+		   s->mark_end.x++);
+	    }
+	  e_schirm (f, 1);
+	}
+      s->ks.x = b->b.x;
+      s->ks.y = b->b.y;
+    }
+  else
+    {
+      if (s->mark_end.y < b->b.y
+	  || (s->mark_end.y == b->b.y && s->mark_end.x <= b->b.x))
+	{
+	  s->mark_end.x = b->b.x;
+	  s->mark_end.y = b->b.y;
+	  s->ks.x = s->mark_begin.x;
+	  s->ks.y = s->mark_begin.y;
+	}
+      else if (s->mark_begin.y > b->b.y
+	       || (s->mark_begin.y == b->b.y && s->mark_begin.x >= b->b.x))
+	{
+	  s->mark_begin.x = b->b.x;
+	  s->mark_begin.y = b->b.y;
+	  s->ks.x = s->mark_end.x;
+	  s->ks.y = s->mark_end.y;
+	}
+      else if (s->mark_end.y < bs.y
+	       || (s->mark_end.y == bs.y && s->mark_end.x <= bs.x))
+	{
+	  s->mark_begin.x = b->b.x;
+	  s->mark_begin.y = b->b.y;
+	  s->ks.x = s->mark_end.x;
+	  s->ks.y = s->mark_end.y;
+	}
       else
-      {  s->mark_end.x = b->b.x;  s->mark_end.y = b->b.y;
-	 s->ks.x = s->mark_begin.x;  s->ks.y = s->mark_begin.y;
-      }
-   }
-   WpeMouseChangeShape(WpeSelectionShape);
-   while(e_mshit() != 0)
-   {  bs.x = b->b.x;  bs.y = b->b.y;
-      e_mouse_cursor(b, s, f);
-      if(b->b.x < 0) b->b.x = 0;
-      else if(b->b.x > b->bf[b->b.y].len) b->b.x = b->bf[b->b.y].len;
-      if(b->b.x != bs.x || b->b.y != bs.y)
-      {  if(s->ks.y < b->b.y || ( s->ks.y == b->b.y && s->ks.x <= b->b.x))
-	 {  s->mark_end.x = b->b.x;  s->mark_end.y = b->b.y;
-	    s->mark_begin.x = s->ks.x;  s->mark_begin.y = s->ks.y;
-	 }
-	 else
-	 {  s->mark_begin.x = b->b.x;  s->mark_begin.y = b->b.y;
-	    s->mark_end.x = s->ks.x;  s->mark_end.y = s->ks.y;
-	 }
-      }
-      e_cursor(f, 1);
-      e_schirm(f, 1);
-      e_refresh();
-   }
-   s->ks.x = b->b.x;  s->ks.y = b->b.y;
-   WpeMouseRestoreShape();
-   e_cursor(f, 1);
+	{
+	  s->mark_end.x = b->b.x;
+	  s->mark_end.y = b->b.y;
+	  s->ks.x = s->mark_begin.x;
+	  s->ks.y = s->mark_begin.y;
+	}
+    }
+  WpeMouseChangeShape (WpeSelectionShape);
+  while (e_mshit () != 0)
+    {
+      bs.x = b->b.x;
+      bs.y = b->b.y;
+      e_mouse_cursor (b, s, f);
+      if (b->b.x < 0)
+	b->b.x = 0;
+      else if (b->b.x > b->bf[b->b.y].len)
+	b->b.x = b->bf[b->b.y].len;
+      if (b->b.x != bs.x || b->b.y != bs.y)
+	{
+	  if (s->ks.y < b->b.y || (s->ks.y == b->b.y && s->ks.x <= b->b.x))
+	    {
+	      s->mark_end.x = b->b.x;
+	      s->mark_end.y = b->b.y;
+	      s->mark_begin.x = s->ks.x;
+	      s->mark_begin.y = s->ks.y;
+	    }
+	  else
+	    {
+	      s->mark_begin.x = b->b.x;
+	      s->mark_begin.y = b->b.y;
+	      s->mark_end.x = s->ks.x;
+	      s->mark_end.y = s->ks.y;
+	    }
+	}
+      e_cursor (f, 1);
+      e_schirm (f, 1);
+      e_refresh ();
+    }
+  s->ks.x = b->b.x;
+  s->ks.y = b->b.y;
+  WpeMouseRestoreShape ();
+  e_cursor (f, 1);
 }
 
-int e_opt_ck_mouse(xa, ya, md)
+int
+e_opt_ck_mouse (xa, ya, md)
      int xa;
      int ya;
      int md;
 {
-   UNUSED(md);
-   extern struct mouse e_mouse;
-   if(e_mouse.x < xa-2 || e_mouse.x > xa+25
-			|| e_mouse.y < ya-1 || e_mouse.y > ya+18) return(WPE_CR);
-   if(e_mouse.x >= xa && e_mouse.x < xa+24
-			&& e_mouse.y > ya && e_mouse.y < ya+17)
-   return(1000+(e_mouse.y-ya-1)*16 + (e_mouse.x - xa)/3);
-   else
-   return(0);
+  UNUSED (md);
+  extern struct mouse e_mouse;
+  if (e_mouse.x < xa - 2 || e_mouse.x > xa + 25
+      || e_mouse.y < ya - 1 || e_mouse.y > ya + 18)
+    return (WPE_CR);
+  if (e_mouse.x >= xa && e_mouse.x < xa + 24
+      && e_mouse.y > ya && e_mouse.y < ya + 17)
+    return (1000 + (e_mouse.y - ya - 1) * 16 + (e_mouse.x - xa) / 3);
+  else
+    return (0);
 }
 
-int e_opt_cw_mouse(xa, ya, md)
+int
+e_opt_cw_mouse (xa, ya, md)
      int xa;
      int ya;
      int md;
 {
-   extern struct mouse e_mouse;
-   if(e_mouse.y == 0 || e_mouse.y == MAXSLNS-1) return(WPE_ESC);
-   if(e_mouse.y == 1 && e_mouse.x == 3) return(WPE_ESC);
-   if(e_mouse.x >= xa-30 && e_mouse.x <= xa-3
-			&& e_mouse.y >= ya && e_mouse.y <= ya+19) return(WPE_CR);
-   if(e_mouse.x >= 1 && e_mouse.x <= 33
-			&& e_mouse.y >= 2 && e_mouse.y <= 21)
-   {  if(md == 1) return(e_opt_bs_mouse_1());
-      else if(md == 2) return(e_opt_bs_mouse_2());
-      else if(md == 3) return(e_opt_bs_mouse_3());
-      else return(e_opt_bs_mouse());
-   }
-   if(e_mouse.x > xa && e_mouse.x < xa+12
-			&& e_mouse.y > ya && e_mouse.y < ya+20)
-   return(374+e_mouse.y-ya);
-   else
-   return(0);
+  extern struct mouse e_mouse;
+  if (e_mouse.y == 0 || e_mouse.y == MAXSLNS - 1)
+    return (WPE_ESC);
+  if (e_mouse.y == 1 && e_mouse.x == 3)
+    return (WPE_ESC);
+  if (e_mouse.x >= xa - 30 && e_mouse.x <= xa - 3
+      && e_mouse.y >= ya && e_mouse.y <= ya + 19)
+    return (WPE_CR);
+  if (e_mouse.x >= 1 && e_mouse.x <= 33 && e_mouse.y >= 2 && e_mouse.y <= 21)
+    {
+      if (md == 1)
+	return (e_opt_bs_mouse_1 ());
+      else if (md == 2)
+	return (e_opt_bs_mouse_2 ());
+      else if (md == 3)
+	return (e_opt_bs_mouse_3 ());
+      else
+	return (e_opt_bs_mouse ());
+    }
+  if (e_mouse.x > xa && e_mouse.x < xa + 12
+      && e_mouse.y > ya && e_mouse.y < ya + 20)
+    return (374 + e_mouse.y - ya);
+  else
+    return (0);
 }
 
-int e_opt_bs_mouse_1()
+int
+e_opt_bs_mouse_1 ()
 {
-   extern struct mouse e_mouse;  /*  return = sw + 375;  */
-   int sw = 0;
-   if(e_mouse.y < 2 || e_mouse.y > 21 ||
-	   e_mouse.x < 2 || e_mouse.x > 33) return(0);
-   else if(e_mouse.y == 2 && e_mouse.x == 6) sw = 1;
-   else if(e_mouse.y == 2 && e_mouse.x >= 17 && e_mouse.x <= 28) sw = 3;
-   else if(e_mouse.y == 21 && e_mouse.x >= 5 && e_mouse.x <= 10) sw = 1;
-   else if(e_mouse.y == 2 || e_mouse.y == 21) sw = 2;
-   else if((e_mouse.y == 3 || e_mouse.y == 5)
-		&& e_mouse.x >= 18 && e_mouse.x <= 27) sw = 0;
-   else if(e_mouse.y == 4 && (e_mouse.x == 18 || e_mouse.x == 27)) sw = 0;
-   else if(e_mouse.y == 4 && e_mouse.x == 20) sw = 1;
-   else if(e_mouse.y == 4 && e_mouse.x > 18 && e_mouse.x < 27) sw = 2;
-   else sw = 4;
-   return(sw + 375);
+  extern struct mouse e_mouse;	/*  return = sw + 375;  */
+  int sw = 0;
+  if (e_mouse.y < 2 || e_mouse.y > 21 || e_mouse.x < 2 || e_mouse.x > 33)
+    return (0);
+  else if (e_mouse.y == 2 && e_mouse.x == 6)
+    sw = 1;
+  else if (e_mouse.y == 2 && e_mouse.x >= 17 && e_mouse.x <= 28)
+    sw = 3;
+  else if (e_mouse.y == 21 && e_mouse.x >= 5 && e_mouse.x <= 10)
+    sw = 1;
+  else if (e_mouse.y == 2 || e_mouse.y == 21)
+    sw = 2;
+  else if ((e_mouse.y == 3 || e_mouse.y == 5)
+	   && e_mouse.x >= 18 && e_mouse.x <= 27)
+    sw = 0;
+  else if (e_mouse.y == 4 && (e_mouse.x == 18 || e_mouse.x == 27))
+    sw = 0;
+  else if (e_mouse.y == 4 && e_mouse.x == 20)
+    sw = 1;
+  else if (e_mouse.y == 4 && e_mouse.x > 18 && e_mouse.x < 27)
+    sw = 2;
+  else
+    sw = 4;
+  return (sw + 375);
 }
 
-int e_opt_bs_mouse_2()
+int
+e_opt_bs_mouse_2 ()
 {
-   extern struct mouse e_mouse;  /*  return = sw + 375;  */
-   int sw = 0;
-   if(e_mouse.y < 2 || e_mouse.y > 21 ||
-	   e_mouse.x < 1 || e_mouse.x > 32) return(0);
-   else if(e_mouse.y == 2 && e_mouse.x == 4) sw = 1;
-   else if(e_mouse.y == 2 || e_mouse.y == 21 ||
-	   	e_mouse.x == 1 || e_mouse.x == 32) sw = 0;
-   else if(e_mouse.y == 4 && e_mouse.x == 5) sw = 3;
-   else if(e_mouse.y == 5 && e_mouse.x >= 5 && e_mouse.x <= 24 ) sw = 5;
-   else if(e_mouse.y == 7 && e_mouse.x == 5) sw = 3;
-   else if(e_mouse.y == 8 && e_mouse.x >= 5 && e_mouse.x <= 24 ) sw = 4;
-   else if(e_mouse.y == 10 && e_mouse.x == 5) sw = 3;
-   else if(e_mouse.y == 11 && e_mouse.x >= 5 && e_mouse.x <= 20 ) sw = 7;
-   else if(e_mouse.y == 12 && e_mouse.x >= 5 && e_mouse.x <= 20 ) sw = 8;
-   else if(e_mouse.y == 13 && e_mouse.x >= 5 && e_mouse.x <= 20 ) sw = 6;
-   else if(e_mouse.y == 15 && e_mouse.x == 5) sw = 3;
-   else if(e_mouse.y == 16 && e_mouse.x >= 5 && e_mouse.x <= 24 ) sw = 11;
-   else if(e_mouse.y == 17 && e_mouse.x == 10) sw = 10;
-   else if(e_mouse.y == 17 && e_mouse.x >= 5 && e_mouse.x <= 24 ) sw = 9;
-   else if(e_mouse.y == 19 && e_mouse.x == 7) sw = 13;
-   else if(e_mouse.y == 19 && e_mouse.x >= 6 && e_mouse.x <= 13 ) sw = 12;
-   else if(e_mouse.y == 19 && e_mouse.x >= 19 && e_mouse.x <= 26 ) sw = 14;
-   else sw = 2;
-   return(sw + 375);
+  extern struct mouse e_mouse;	/*  return = sw + 375;  */
+  int sw = 0;
+  if (e_mouse.y < 2 || e_mouse.y > 21 || e_mouse.x < 1 || e_mouse.x > 32)
+    return (0);
+  else if (e_mouse.y == 2 && e_mouse.x == 4)
+    sw = 1;
+  else if (e_mouse.y == 2 || e_mouse.y == 21 ||
+	   e_mouse.x == 1 || e_mouse.x == 32)
+    sw = 0;
+  else if (e_mouse.y == 4 && e_mouse.x == 5)
+    sw = 3;
+  else if (e_mouse.y == 5 && e_mouse.x >= 5 && e_mouse.x <= 24)
+    sw = 5;
+  else if (e_mouse.y == 7 && e_mouse.x == 5)
+    sw = 3;
+  else if (e_mouse.y == 8 && e_mouse.x >= 5 && e_mouse.x <= 24)
+    sw = 4;
+  else if (e_mouse.y == 10 && e_mouse.x == 5)
+    sw = 3;
+  else if (e_mouse.y == 11 && e_mouse.x >= 5 && e_mouse.x <= 20)
+    sw = 7;
+  else if (e_mouse.y == 12 && e_mouse.x >= 5 && e_mouse.x <= 20)
+    sw = 8;
+  else if (e_mouse.y == 13 && e_mouse.x >= 5 && e_mouse.x <= 20)
+    sw = 6;
+  else if (e_mouse.y == 15 && e_mouse.x == 5)
+    sw = 3;
+  else if (e_mouse.y == 16 && e_mouse.x >= 5 && e_mouse.x <= 24)
+    sw = 11;
+  else if (e_mouse.y == 17 && e_mouse.x == 10)
+    sw = 10;
+  else if (e_mouse.y == 17 && e_mouse.x >= 5 && e_mouse.x <= 24)
+    sw = 9;
+  else if (e_mouse.y == 19 && e_mouse.x == 7)
+    sw = 13;
+  else if (e_mouse.y == 19 && e_mouse.x >= 6 && e_mouse.x <= 13)
+    sw = 12;
+  else if (e_mouse.y == 19 && e_mouse.x >= 19 && e_mouse.x <= 26)
+    sw = 14;
+  else
+    sw = 2;
+  return (sw + 375);
 }
 
-int e_opt_bs_mouse_3()
+int
+e_opt_bs_mouse_3 ()
 {
-   extern struct mouse e_mouse;  /*  return = sw + 375;  */
-   int sw = 0;
-   if(e_mouse.y < 2 || e_mouse.y > 21 ||
-	   e_mouse.x < 1 || e_mouse.x > 32) return(0);
-   else if(e_mouse.y == 5) sw = 3;
-   else if(e_mouse.y == 9) sw = 1;
-   else if(e_mouse.y == 11) sw = 2;
-   else if(e_mouse.y == 13) sw = 4;
-   return(sw+375);
+  extern struct mouse e_mouse;	/*  return = sw + 375;  */
+  int sw = 0;
+  if (e_mouse.y < 2 || e_mouse.y > 21 || e_mouse.x < 1 || e_mouse.x > 32)
+    return (0);
+  else if (e_mouse.y == 5)
+    sw = 3;
+  else if (e_mouse.y == 9)
+    sw = 1;
+  else if (e_mouse.y == 11)
+    sw = 2;
+  else if (e_mouse.y == 13)
+    sw = 4;
+  return (sw + 375);
 }
 
-int e_opt_bs_mouse()
+int
+e_opt_bs_mouse ()
 {
-   extern struct mouse e_mouse;
-   int sw = 0;
-   if(e_mouse.y < 2 || e_mouse.y > 21 ||
-	   e_mouse.x < 1 || e_mouse.x > 32) return(0);
-   else if(e_mouse.y == 2 && (e_mouse.x == 4 || e_mouse.x == 29 )) sw = 1;
-   else if(e_mouse.x == 32 && e_mouse.y > 2 && e_mouse.y < 21 ) sw = 5;
-   else if(e_mouse.y == 21 && e_mouse.x > 20 && e_mouse.y < 32 ) sw = 5;
-   else if(e_mouse.y == 2 || e_mouse.y == 21 ||
-	   e_mouse.x == 1 || e_mouse.x == 32) sw = 0;
-   else if(e_mouse.y == 6 && e_mouse.x >= 4 && e_mouse.x <= 30 ) sw = 3;
-   else if(e_mouse.y == 7 && e_mouse.x >= 14 && e_mouse.x <= 21 ) sw = 4;
-   else if(e_mouse.y == 10 && e_mouse.x >= 4 && e_mouse.x <= 16 ) sw = 6;
-   else if(e_mouse.y == 11 && e_mouse.x >= 15 && e_mouse.x <= 20 ) sw = 8;
-   else if(e_mouse.y == 13 && e_mouse.x >= 4 && e_mouse.x <= 17 ) sw = 7;
-   else if(e_mouse.y == 16 && e_mouse.x >= 4 && e_mouse.x <= 25 ) sw = 9;
-   else if(e_mouse.y == 17 && e_mouse.x >= 4 && e_mouse.x <= 23 ) sw = 10;
-   else sw = 2;
-   return(sw+375);
+  extern struct mouse e_mouse;
+  int sw = 0;
+  if (e_mouse.y < 2 || e_mouse.y > 21 || e_mouse.x < 1 || e_mouse.x > 32)
+    return (0);
+  else if (e_mouse.y == 2 && (e_mouse.x == 4 || e_mouse.x == 29))
+    sw = 1;
+  else if (e_mouse.x == 32 && e_mouse.y > 2 && e_mouse.y < 21)
+    sw = 5;
+  else if (e_mouse.y == 21 && e_mouse.x > 20 && e_mouse.y < 32)
+    sw = 5;
+  else if (e_mouse.y == 2 || e_mouse.y == 21 ||
+	   e_mouse.x == 1 || e_mouse.x == 32)
+    sw = 0;
+  else if (e_mouse.y == 6 && e_mouse.x >= 4 && e_mouse.x <= 30)
+    sw = 3;
+  else if (e_mouse.y == 7 && e_mouse.x >= 14 && e_mouse.x <= 21)
+    sw = 4;
+  else if (e_mouse.y == 10 && e_mouse.x >= 4 && e_mouse.x <= 16)
+    sw = 6;
+  else if (e_mouse.y == 11 && e_mouse.x >= 15 && e_mouse.x <= 20)
+    sw = 8;
+  else if (e_mouse.y == 13 && e_mouse.x >= 4 && e_mouse.x <= 17)
+    sw = 7;
+  else if (e_mouse.y == 16 && e_mouse.x >= 4 && e_mouse.x <= 25)
+    sw = 9;
+  else if (e_mouse.y == 17 && e_mouse.x >= 4 && e_mouse.x <= 23)
+    sw = 10;
+  else
+    sw = 2;
+  return (sw + 375);
 }
 
-int e_data_ein_mouse(f)
+int
+e_data_ein_mouse (f)
      FENSTER *f;
 {
-   extern struct mouse e_mouse;
-   FLWND *fw = (FLWND *)f->b;
-   ECNT *cn = f->ed;
-   int i, c = 0;
-   if(e_mouse.y == 0) return(AltBl);
-   else if(e_mouse.y == MAXSLNS-1) return(e_m3_mouse());
-   else if(e_mouse.x < f->a.x || e_mouse.x > f->e.x
+  extern struct mouse e_mouse;
+  FLWND *fw = (FLWND *) f->b;
+  ECNT *cn = f->ed;
+  int i, c = 0;
+  if (e_mouse.y == 0)
+    return (AltBl);
+  else if (e_mouse.y == MAXSLNS - 1)
+    return (e_m3_mouse ());
+  else if (e_mouse.x < f->a.x || e_mouse.x > f->e.x
 	   || e_mouse.y < f->a.y || e_mouse.y > f->e.y)
-   {  for(i = cn->mxedt; i > 0; i--)
-      {  if(e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x
-	  && e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
-	 return(cn->edt[i] < 10 ? Alt1-1+cn->edt[i] : 1014+cn->edt[i]);
-      }
-   }
-   else if(e_mouse.x == f->a.x+3 && e_mouse.y == f->a.y) c = WPE_ESC;
-   else if(e_mouse.x == f->e.x-3 && e_mouse.y == f->a.y) e_ed_zoom(f);
-   else if(e_mouse.x == f->a.x && e_mouse.y == f->a.y) e_eck_mouse(f, 1);
-   else if(e_mouse.x == f->e.x && e_mouse.y == f->a.y) e_eck_mouse(f, 2);
-   else if(e_mouse.x == f->e.x && e_mouse.y == f->e.y) e_eck_mouse(f, 3);
-   else if(e_mouse.x == f->a.x && e_mouse.y == f->e.y) e_eck_mouse(f, 4);
-   else if(e_mouse.y == f->a.y && e_mouse.x > f->a.x
-				&& e_mouse.x < f->e.x) e_eck_mouse(f, 0);
-   else if(e_mouse.y >= fw->ya && e_mouse.y <= fw->ye &&
-	e_mouse.x >= fw->xa && e_mouse.x <= fw->xe)  c = AltF;
-   else if(e_mouse.y == f->e.y-2 && e_mouse.x >= f->e.x-9
-			&& e_mouse.x <= f->e.x-3) c = WPE_ESC;
-   else if((f->ins < 4 || f->ins == 7) && e_mouse.y == f->e.y-4
-	    && e_mouse.x >= f->e.x-9 && e_mouse.x <= f->e.x-3) c = AltS;
-   else if(f->ins > 3 && e_mouse.y == f->e.y-8 && e_mouse.x >= f->e.x-9
-			&& e_mouse.x <= f->e.x-3) c = AltA;
-   else if(f->ins > 3 && e_mouse.y == f->e.y-6 && e_mouse.x >= f->e.x-9
-			&& e_mouse.x <= f->e.x-3) c = AltE;
-   else if(f->ins > 3 && e_mouse.y == f->e.y-4 && e_mouse.x >= f->e.x-9
-			&& e_mouse.x <= f->e.x-3) c = AltD;
-   else if(f->ins == 4 && e_mouse.y == f->e.y-10 && e_mouse.x >= f->e.x-9
-			&& e_mouse.x <= f->e.x-3) c = AltO;
-   else c = AltF;
-   while (e_mshit() != 0);
-   return(c);
+    {
+      for (i = cn->mxedt; i > 0; i--)
+	{
+	  if (e_mouse.x >= cn->f[i]->a.x && e_mouse.x <= cn->f[i]->e.x
+	      && e_mouse.y >= cn->f[i]->a.y && e_mouse.y <= cn->f[i]->e.y)
+	    return (cn->edt[i] <
+		    10 ? Alt1 - 1 + cn->edt[i] : 1014 + cn->edt[i]);
+	}
+    }
+  else if (e_mouse.x == f->a.x + 3 && e_mouse.y == f->a.y)
+    c = WPE_ESC;
+  else if (e_mouse.x == f->e.x - 3 && e_mouse.y == f->a.y)
+    e_ed_zoom (f);
+  else if (e_mouse.x == f->a.x && e_mouse.y == f->a.y)
+    e_eck_mouse (f, 1);
+  else if (e_mouse.x == f->e.x && e_mouse.y == f->a.y)
+    e_eck_mouse (f, 2);
+  else if (e_mouse.x == f->e.x && e_mouse.y == f->e.y)
+    e_eck_mouse (f, 3);
+  else if (e_mouse.x == f->a.x && e_mouse.y == f->e.y)
+    e_eck_mouse (f, 4);
+  else if (e_mouse.y == f->a.y && e_mouse.x > f->a.x && e_mouse.x < f->e.x)
+    e_eck_mouse (f, 0);
+  else if (e_mouse.y >= fw->ya && e_mouse.y <= fw->ye &&
+	   e_mouse.x >= fw->xa && e_mouse.x <= fw->xe)
+    c = AltF;
+  else if (e_mouse.y == f->e.y - 2 && e_mouse.x >= f->e.x - 9
+	   && e_mouse.x <= f->e.x - 3)
+    c = WPE_ESC;
+  else if ((f->ins < 4 || f->ins == 7) && e_mouse.y == f->e.y - 4
+	   && e_mouse.x >= f->e.x - 9 && e_mouse.x <= f->e.x - 3)
+    c = AltS;
+  else if (f->ins > 3 && e_mouse.y == f->e.y - 8 && e_mouse.x >= f->e.x - 9
+	   && e_mouse.x <= f->e.x - 3)
+    c = AltA;
+  else if (f->ins > 3 && e_mouse.y == f->e.y - 6 && e_mouse.x >= f->e.x - 9
+	   && e_mouse.x <= f->e.x - 3)
+    c = AltE;
+  else if (f->ins > 3 && e_mouse.y == f->e.y - 4 && e_mouse.x >= f->e.x - 9
+	   && e_mouse.x <= f->e.x - 3)
+    c = AltD;
+  else if (f->ins == 4 && e_mouse.y == f->e.y - 10 && e_mouse.x >= f->e.x - 9
+	   && e_mouse.x <= f->e.x - 3)
+    c = AltO;
+  else
+    c = AltF;
+  while (e_mshit () != 0);
+  return (c);
 }
 
-void e_opt_eck_mouse(o)
+void
+e_opt_eck_mouse (o)
      W_OPTSTR *o;
 {
-   int g[4];
-   int xold, yold, x, y, xa;
-   view *pic;
-   e_std_rahmen(o->xa, o->ya, o->xe, o->ye, o->name, 0, o->frt, o->frs);
+  int g[4];
+  int xold, yold, x, y, xa;
+  view *pic;
+  e_std_rahmen (o->xa, o->ya, o->xe, o->ye, o->name, 0, o->frt, o->frs);
 #ifndef NEWSTYLE
-   if(!WpeIsXwin()) pic = e_open_view(o->xa, o->ya, o->xe, o->ye, 0, 2);
-   else
-	pic = e_open_view(o->xa, o->ya, o->xe-2, o->ye-1, 0, 2);
+  if (!WpeIsXwin ())
+    pic = e_open_view (o->xa, o->ya, o->xe, o->ye, 0, 2);
+  else
+    pic = e_open_view (o->xa, o->ya, o->xe - 2, o->ye - 1, 0, 2);
 #else
-   pic = e_open_view(o->xa, o->ya, o->xe, o->ye, 0, 2);
+  pic = e_open_view (o->xa, o->ya, o->xe, o->ye, 0, 2);
 #endif
-   g[0] = 3;  g[1] = 1;
-   fk_mouse(g);
-   xold = g[2]/8;
-   yold = g[3]/8;
-   xa = xold - o->xa;
-   while(g[1] != 0)
-   {  x = g[2]/8;
-      y = g[3]/8;
-      if(y < 1) y = 1;
-      else if(y > MAXSLNS-2) y = MAXSLNS-2;
-      if(x < 0) x = 0;
-      else if(x > MAXSCOL-1) x = MAXSCOL-1;
-      if(xold != x || yold != y)
-      {  xold = x;  yold = y;
-	 x -= xa;
-	 if(x < 0) x = 0;
-	 else if(x + o->xe - o->xa > MAXSCOL-1)
-	 x = MAXSCOL - o->xe + o->xa - 1;
-	 if(o->ye + y - o->ya > MAXSLNS-2)
-	 y = MAXSLNS - o->ye + o->ya - 2;
-	 o->xe = o->xe - o->xa + x; o->xa = x;
-	 o->ye = o->ye + y - o->ya;  o->ya = y;
-	 g[0] = 2;  fk_mouse(g);
-	 o->pic = e_change_pic(o->xa, o->ya, o->xe, o->ye, o->pic, 1, o->frt);
-	 if(o->pic == NULL)  e_error(e_msg[ERR_LOWMEM], 1, o->f->fb);
-	 g[0] = 1;  fk_mouse(g);
-	 pic->a.x = o->xa;  pic->a.y = o->ya;
-	 pic->e.x = o->xe;  pic->e.y = o->ye;
-	 e_close_view(pic, 2);
-      }
-      g[0] = 3;  fk_mouse(g);
-   }
-   pic->a.x = o->xa;  pic->a.y = o->ya;
-   pic->e.x = o->xe;  pic->e.y = o->ye;
-   e_close_view(pic, 1);
-   e_std_rahmen(o->xa, o->ya, o->xe, o->ye, o->name, 1, o->frt, o->frs);
+  g[0] = 3;
+  g[1] = 1;
+  fk_mouse (g);
+  xold = g[2] / 8;
+  yold = g[3] / 8;
+  xa = xold - o->xa;
+  while (g[1] != 0)
+    {
+      x = g[2] / 8;
+      y = g[3] / 8;
+      if (y < 1)
+	y = 1;
+      else if (y > MAXSLNS - 2)
+	y = MAXSLNS - 2;
+      if (x < 0)
+	x = 0;
+      else if (x > MAXSCOL - 1)
+	x = MAXSCOL - 1;
+      if (xold != x || yold != y)
+	{
+	  xold = x;
+	  yold = y;
+	  x -= xa;
+	  if (x < 0)
+	    x = 0;
+	  else if (x + o->xe - o->xa > MAXSCOL - 1)
+	    x = MAXSCOL - o->xe + o->xa - 1;
+	  if (o->ye + y - o->ya > MAXSLNS - 2)
+	    y = MAXSLNS - o->ye + o->ya - 2;
+	  o->xe = o->xe - o->xa + x;
+	  o->xa = x;
+	  o->ye = o->ye + y - o->ya;
+	  o->ya = y;
+	  g[0] = 2;
+	  fk_mouse (g);
+	  o->pic =
+	    e_change_pic (o->xa, o->ya, o->xe, o->ye, o->pic, 1, o->frt);
+	  if (o->pic == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, o->f->fb);
+	  g[0] = 1;
+	  fk_mouse (g);
+	  pic->a.x = o->xa;
+	  pic->a.y = o->ya;
+	  pic->e.x = o->xe;
+	  pic->e.y = o->ye;
+	  e_close_view (pic, 2);
+	}
+      g[0] = 3;
+      fk_mouse (g);
+    }
+  pic->a.x = o->xa;
+  pic->a.y = o->ya;
+  pic->e.x = o->xe;
+  pic->e.y = o->ye;
+  e_close_view (pic, 1);
+  e_std_rahmen (o->xa, o->ya, o->xe, o->ye, o->name, 1, o->frt, o->frs);
 }
 
-int e_opt_mouse(W_OPTSTR *o)
+int
+e_opt_mouse (W_OPTSTR * o)
 {
- extern struct mouse e_mouse;
- int c;
+  extern struct mouse e_mouse;
+  int c;
 
- if (e_mouse.y < o->ya || e_mouse.y >= o->ye ||
-   e_mouse.x <= o->xa || e_mouse.x >= o->xe)
-  return(-1);
- else if (e_mouse.y == o->ya)
- {
-  if (e_mouse.x == o->xa+3) {
-	 while(e_mshit()) {
-		;
-     	}
-     	return(WPE_ESC);
-  } else {
-	e_opt_eck_mouse(o);  return(-1);  }
-  }
- while (e_mshit()) {
-  ;
- }
- if ((c = e_get_opt_sw(0, e_mouse.x, e_mouse.y, o))) return(c);
- else return(-1);
+  if (e_mouse.y < o->ya || e_mouse.y >= o->ye ||
+      e_mouse.x <= o->xa || e_mouse.x >= o->xe)
+    return (-1);
+  else if (e_mouse.y == o->ya)
+    {
+      if (e_mouse.x == o->xa + 3)
+	{
+	  while (e_mshit ())
+	    {
+	      ;
+	    }
+	  return (WPE_ESC);
+	}
+      else
+	{
+	  e_opt_eck_mouse (o);
+	  return (-1);
+	}
+    }
+  while (e_mshit ())
+    {
+      ;
+    }
+  if ((c = e_get_opt_sw (0, e_mouse.x, e_mouse.y, o)))
+    return (c);
+  else
+    return (-1);
 }
 
 #endif // #if MOUSE
-

--- a/src/we_mouse.h
+++ b/src/we_mouse.h
@@ -5,31 +5,31 @@
 
 /*   we_mouse.c   */
 #if  MOUSE
-int e_mshit(void);
-int e_m1_mouse(void);
-int e_m2_mouse(int xa, int ya, int xe, int ye, OPTK *fopt);
-int e_m3_mouse(void);
-int e_er_mouse(int x, int y, int xx, int yy);
-int e_msg_mouse(int x, int y, int x1, int x2, int yy);
-int WpeMngMouseInFileManager(FENSTER *f);
-int WpeMouseInFileDirList(int k, int sw, FENSTER *f);
-int fl_wnd_mouse(int sw, int k, FLWND *fw);
-int e_lst_mouse(int x, int y, int n, int sw, int max, int nf);
-void e_eck_mouse(FENSTER *f, int sw);
-int e_edt_mouse(int c, FENSTER *f);
-int e_ccp_mouse(int c, FENSTER *f);
-void e_cur_mouse(FENSTER *f);
-int e_opt_ck_mouse(int xa, int ya, int md);
-int e_opt_cw_mouse(int xa, int ya, int md);
-int e_opt_bs_mouse(void);
-void e_opt_eck_mouse(W_OPTSTR *o);
-int e_opt_mouse(W_OPTSTR *o);
+int e_mshit (void);
+int e_m1_mouse (void);
+int e_m2_mouse (int xa, int ya, int xe, int ye, OPTK * fopt);
+int e_m3_mouse (void);
+int e_er_mouse (int x, int y, int xx, int yy);
+int e_msg_mouse (int x, int y, int x1, int x2, int yy);
+int WpeMngMouseInFileManager (FENSTER * f);
+int WpeMouseInFileDirList (int k, int sw, FENSTER * f);
+int fl_wnd_mouse (int sw, int k, FLWND * fw);
+int e_lst_mouse (int x, int y, int n, int sw, int max, int nf);
+void e_eck_mouse (FENSTER * f, int sw);
+int e_edt_mouse (int c, FENSTER * f);
+int e_ccp_mouse (int c, FENSTER * f);
+void e_cur_mouse (FENSTER * f);
+int e_opt_ck_mouse (int xa, int ya, int md);
+int e_opt_cw_mouse (int xa, int ya, int md);
+int e_opt_bs_mouse (void);
+void e_opt_eck_mouse (W_OPTSTR * o);
+int e_opt_mouse (W_OPTSTR * o);
 
-int e_data_ein_mouse(FENSTER *f);
-int e_opt_bs_mouse_1(void);
-int e_opt_bs_mouse_2(void);
-int e_opt_bs_mouse_3(void);
-int e_rahmen_mouse(FENSTER *f);
+int e_data_ein_mouse (FENSTER * f);
+int e_opt_bs_mouse_1 (void);
+int e_opt_bs_mouse_2 (void);
+int e_opt_bs_mouse_3 (void);
+int e_rahmen_mouse (FENSTER * f);
 #endif // #if MOUSE
 
 #endif

--- a/src/we_opt.c
+++ b/src/we_opt.c
@@ -20,14 +20,14 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-int WpeReadGeneral(ECNT *cn, char *section, char *option, char *value);
-int WpeWriteGeneral(ECNT *cn, char *section, FILE *opt_file);
-int WpeReadColor(ECNT *cn, char *section, char *option, char *value);
-int WpeWriteColor(ECNT *cn, char *section, FILE *opt_file);
-int WpeReadProgramming(ECNT *cn, char *section, char *option, char *value);
-int WpeWriteProgramming(ECNT *cn, char *section, FILE *opt_file);
-int WpeReadLanguage(ECNT *cn, char *section, char *option, char *value);
-int WpeWriteLanguage(ECNT *cn, char *section, FILE *opt_file);
+int WpeReadGeneral (ECNT * cn, char *section, char *option, char *value);
+int WpeWriteGeneral (ECNT * cn, char *section, FILE * opt_file);
+int WpeReadColor (ECNT * cn, char *section, char *option, char *value);
+int WpeWriteColor (ECNT * cn, char *section, FILE * opt_file);
+int WpeReadProgramming (ECNT * cn, char *section, char *option, char *value);
+int WpeWriteProgramming (ECNT * cn, char *section, FILE * opt_file);
+int WpeReadLanguage (ECNT * cn, char *section, char *option, char *value);
+int WpeWriteLanguage (ECNT * cn, char *section, FILE * opt_file);
 
 #define E_HLP_NUM 26
 char *e_hlp_str[E_HLP_NUM];
@@ -45,1863 +45,2244 @@ extern FARBE *u_fb, *x_fb;
 #define OPT_SECTION_LANGUAGE    "Language"
 
 WpeOptionSection WpeSectionRead[] = {
- {OPT_SECTION_GENERAL, WpeReadGeneral},
- {OPT_SECTION_COLOR, WpeReadColor},
- {OPT_SECTION_PROGRAMMING, WpeReadProgramming},
- {OPT_SECTION_LANGUAGE, WpeReadLanguage}
+  {OPT_SECTION_GENERAL, WpeReadGeneral},
+  {OPT_SECTION_COLOR, WpeReadColor},
+  {OPT_SECTION_PROGRAMMING, WpeReadProgramming},
+  {OPT_SECTION_LANGUAGE, WpeReadLanguage}
 };
 
 /*    About WE      */
-int e_about_WE(FENSTER *f)
+int
+e_about_WE (FENSTER * f)
 {
- view *pic = NULL;
- int xa = 10, ya = 4, xe = xa + 50, ye = ya + 13;
- char tmp[40];
+  view *pic = NULL;
+  int xa = 10, ya = 4, xe = xa + 50, ye = ya + 13;
+  char tmp[40];
 
- fk_cursor(0);
- pic = e_std_kst(xa, ya, xe, ye, NULL, 1, f->fb->nr.fb, f->fb->nt.fb, f->fb->ne.fb);
- if (pic == NULL)
- {
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  return(WPE_ESC);
- }
-   
- sprintf(tmp, "          Version %s          ", VERSION);
+  fk_cursor (0);
+  pic =
+    e_std_kst (xa, ya, xe, ye, NULL, 1, f->fb->nr.fb, f->fb->nt.fb,
+	       f->fb->ne.fb);
+  if (pic == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+      return (WPE_ESC);
+    }
+
+  sprintf (tmp, "          Version %s          ", VERSION);
 #ifdef UNIX
- if (WpeIsXwin() && WpeIsProg())
- {
-  e_pr_str(xa+7, ya+3, "  XWindow Programming Environment  ", f->fb->et.fb, 0, 0, 0, 0);
-  e_pr_str(xa+7, ya+4, "             ( XWPE )              ", f->fb->et.fb, 0, 0, 0, 0);
- }
- else if (WpeIsProg())
- {
-  e_pr_str(xa+7, ya+3, "   Window Programming Environment  ", f->fb->et.fb, 0, 0, 0, 0);
-  e_pr_str(xa+7, ya+4, "              ( WPE )              ", f->fb->et.fb, 0, 0, 0, 0);
- }
- else if (WpeIsXwin())
- {
-  e_pr_str(xa+7, ya+3, "          XWindow Editor           ", f->fb->et.fb, 0, 0, 0, 0);
-  e_pr_str(xa+7, ya+4, "              ( XWE )              ", f->fb->et.fb, 0, 0, 0, 0);
- }
- else
+  if (WpeIsXwin () && WpeIsProg ())
+    {
+      e_pr_str (xa + 7, ya + 3, "  XWindow Programming Environment  ",
+		f->fb->et.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 7, ya + 4, "             ( XWPE )              ",
+		f->fb->et.fb, 0, 0, 0, 0);
+    }
+  else if (WpeIsProg ())
+    {
+      e_pr_str (xa + 7, ya + 3, "   Window Programming Environment  ",
+		f->fb->et.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 7, ya + 4, "              ( WPE )              ",
+		f->fb->et.fb, 0, 0, 0, 0);
+    }
+  else if (WpeIsXwin ())
+    {
+      e_pr_str (xa + 7, ya + 3, "          XWindow Editor           ",
+		f->fb->et.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 7, ya + 4, "              ( XWE )              ",
+		f->fb->et.fb, 0, 0, 0, 0);
+    }
+  else
 #endif
- {
-  e_pr_str(xa+7, ya+3, "           Window Editor           ", f->fb->et.fb, 0, 0, 0, 0);
-  e_pr_str(xa+7, ya+4, "               ( WE )              ", f->fb->et.fb, 0, 0, 0, 0);
- }
- e_pr_str(xa+7, ya+5, tmp, f->fb->et.fb, 0, 0, 0, 0);
- e_pr_str(xa+2, ya+8, "Copyright (C) 1993 Fred Kruse", f->fb->nt.fb, 0, 0, 0, 0);
- e_pr_str(xa+2, ya+9, "This Sofware comes with ABSOLUTELY NO WARRANTY;", f->fb->nt.fb, 0, 0, 0, 0);
- e_pr_str(xa+2, ya+10, "This is free software, and you are welcome to", f->fb->nt.fb, 0, 0, 0, 0);
- e_pr_str(xa+2, ya+11, "redistribute it under certain conditions;", f->fb->nt.fb, 0, 0, 0, 0);
- e_pr_str(xa+2, ya+12, "See \'Help\\Editor\\GNU Pub...\' for details.", f->fb->nt.fb, 0, 0, 0, 0);
+    {
+      e_pr_str (xa + 7, ya + 3, "           Window Editor           ",
+		f->fb->et.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 7, ya + 4, "               ( WE )              ",
+		f->fb->et.fb, 0, 0, 0, 0);
+    }
+  e_pr_str (xa + 7, ya + 5, tmp, f->fb->et.fb, 0, 0, 0, 0);
+  e_pr_str (xa + 2, ya + 8, "Copyright (C) 1993 Fred Kruse", f->fb->nt.fb, 0,
+	    0, 0, 0);
+  e_pr_str (xa + 2, ya + 9, "This Sofware comes with ABSOLUTELY NO WARRANTY;",
+	    f->fb->nt.fb, 0, 0, 0, 0);
+  e_pr_str (xa + 2, ya + 10, "This is free software, and you are welcome to",
+	    f->fb->nt.fb, 0, 0, 0, 0);
+  e_pr_str (xa + 2, ya + 11, "redistribute it under certain conditions;",
+	    f->fb->nt.fb, 0, 0, 0, 0);
+  e_pr_str (xa + 2, ya + 12, "See \'Help\\Editor\\GNU Pub...\' for details.",
+	    f->fb->nt.fb, 0, 0, 0, 0);
 #if  MOUSE
- while (e_mshit() != 0)
-  ;
- e_getch();
- while (e_mshit() != 0)
-  ;
+  while (e_mshit () != 0)
+    ;
+  e_getch ();
+  while (e_mshit () != 0)
+    ;
 #else
- e_getch();
+  e_getch ();
 #endif
- e_close_view(pic, 1);
- return(0);
+  e_close_view (pic, 1);
+  return (0);
 }
 
 /*    delete everything    */
-int e_clear_desk(FENSTER *f)
+int
+e_clear_desk (FENSTER * f)
 {
- int i;
- ECNT *cn = f->ed;
+  int i;
+  ECNT *cn = f->ed;
 #if  MOUSE
- int g[4]; /*  = { 2, 0, 0, 0, };  */
-   
- g[0] = 2;
+  int g[4];			/*  = { 2, 0, 0, 0, };  */
+
+  g[0] = 2;
 #endif
- fk_cursor(0);
- for (i = cn->mxedt; i > 0; i--)
- {
-  f = cn->f[cn->mxedt];
-  if( e_close_window(f) == WPE_ESC )
-   return(WPE_ESC);
- }
- cn->mxedt = 0;
+  fk_cursor (0);
+  for (i = cn->mxedt; i > 0; i--)
+    {
+      f = cn->f[cn->mxedt];
+      if (e_close_window (f) == WPE_ESC)
+	return (WPE_ESC);
+    }
+  cn->mxedt = 0;
 #if  MOUSE
- fk_mouse(g);
+  fk_mouse (g);
 #endif
- e_ini_desk(cn);
+  e_ini_desk (cn);
 #if  MOUSE
- g[0] = 1;
- fk_mouse(g);
+  g[0] = 1;
+  fk_mouse (g);
 #endif
- return(0);
+  return (0);
 }
 
 /*    redraw everything */
-int e_repaint_desk(FENSTER *f)
+int
+e_repaint_desk (FENSTER * f)
 {
- /* int j; */
- ECNT *cn = f->ed;
- int i, g[4];
+  /* int j; */
+  ECNT *cn = f->ed;
+  int i, g[4];
 #ifndef NO_XWINDOWS
- extern view *e_X_l_pic;
- view *sv_pic = NULL, *nw_pic = NULL;
+  extern view *e_X_l_pic;
+  view *sv_pic = NULL, *nw_pic = NULL;
 
- if (WpeIsXwin())
- {
-  if (e_X_l_pic && e_X_l_pic != cn->f[cn->mxedt]->pic)
-  {
-   sv_pic = e_X_l_pic;
-   nw_pic = e_open_view(e_X_l_pic->a.x, e_X_l_pic->a.y,
-     e_X_l_pic->e.x, e_X_l_pic->e.y, 0, 2);
-  }
-  (*e_u_ini_size)();
- }
+  if (WpeIsXwin ())
+    {
+      if (e_X_l_pic && e_X_l_pic != cn->f[cn->mxedt]->pic)
+	{
+	  sv_pic = e_X_l_pic;
+	  nw_pic = e_open_view (e_X_l_pic->a.x, e_X_l_pic->a.y,
+				e_X_l_pic->e.x, e_X_l_pic->e.y, 0, 2);
+	}
+      (*e_u_ini_size) ();
+    }
 #endif
- if (cn->mxedt < 1)
- {
-  e_cls(f->fb->df.fb, f->fb->dc);
-  e_ini_desk(f->ed);
+  if (cn->mxedt < 1)
+    {
+      e_cls (f->fb->df.fb, f->fb->dc);
+      e_ini_desk (f->ed);
 #ifndef NO_XWINDOWS
-  if ((WpeIsXwin()) && nw_pic)
-  {
-   e_close_view(nw_pic, 1);
-   e_X_l_pic = sv_pic;
-  }
+      if ((WpeIsXwin ()) && nw_pic)
+	{
+	  e_close_view (nw_pic, 1);
+	  e_X_l_pic = sv_pic;
+	}
 #endif
-  return(0);
- }
- cn->curedt = cn->mxedt;
- ini_repaint(cn);
- e_abs_refr();
- for (i = 1; i < cn->mxedt; i++)
- {
-  e_firstl(cn->f[i], 0);
-  e_schirm(cn->f[i], 0);
- }
- e_firstl(cn->f[i], 1);
- e_schirm(cn->f[i], 1);
+      return (0);
+    }
+  cn->curedt = cn->mxedt;
+  ini_repaint (cn);
+  e_abs_refr ();
+  for (i = 1; i < cn->mxedt; i++)
+    {
+      e_firstl (cn->f[i], 0);
+      e_schirm (cn->f[i], 0);
+    }
+  e_firstl (cn->f[i], 1);
+  e_schirm (cn->f[i], 1);
 #ifndef NO_XWINDOWS
- if (WpeIsXwin() && nw_pic)
- {
-  e_close_view(nw_pic, 1);
-  e_X_l_pic = sv_pic;
- }
+  if (WpeIsXwin () && nw_pic)
+    {
+      e_close_view (nw_pic, 1);
+      e_X_l_pic = sv_pic;
+    }
 #endif
 #if  MOUSE
- g[0] = 2; fk_mouse(g);
+  g[0] = 2;
+  fk_mouse (g);
 #endif
- end_repaint();
- e_cursor(cn->f[i], 1);
+  end_repaint ();
+  e_cursor (cn->f[i], 1);
 #if  MOUSE
- g[0] = 0; fk_mouse(g);
- g[0] = 1; fk_mouse(g);
+  g[0] = 0;
+  fk_mouse (g);
+  g[0] = 1;
+  fk_mouse (g);
 #endif
- return(0);
+  return (0);
 }
 
 /*    write system information   */
-int e_sys_info(FENSTER *f)
+int
+e_sys_info (FENSTER * f)
 {
- view *pic = NULL;
- char tmp[80];
- int xa = 10, ya = 5, xe = xa + 60, ye = ya + 8;
+  view *pic = NULL;
+  char tmp[80];
+  int xa = 10, ya = 5, xe = xa + 60, ye = ya + 8;
 
- fk_cursor(0);
- pic = e_std_kst(xa, ya, xe, ye, " Information ", 1, f->fb->nr.fb, f->fb->nt.fb, f->fb->ne.fb);
- if (pic == NULL) {  e_error(e_msg[ERR_LOWMEM], 1, f->fb); return(WPE_ESC);  }
- e_pr_str(xa+3, ya+2, " Current File: ", f->fb->nt.fb, 0, 0, 0, 0);
- e_pr_str(xa+3, ya+4, " Current Directory: ", f->fb->nt.fb, 0, 0, 0, 0);
- e_pr_str(xa+3, ya+6, " Number of Files: ", f->fb->nt.fb, 0, 0, 0, 0);
- if(strcmp(f->datnam, "Clipboard") != 0) {
-	 if(strcmp(f->dirct, f->ed->dirct) == 0)
-	  e_pr_str(xa+23, ya+2, f->datnam, f->fb->nt.fb, 0, 0, 0, 0);
-	 else
-	 {
-	  strcpy(tmp, f->dirct);
-	  strcat(tmp, DIRS);
-	  strcat(tmp, f->datnam);
-	  e_pr_str(xa+23, ya+2, tmp, f->fb->nt.fb, 0, 0, 0, 0);
-	 }
+  fk_cursor (0);
+  pic =
+    e_std_kst (xa, ya, xe, ye, " Information ", 1, f->fb->nr.fb, f->fb->nt.fb,
+	       f->fb->ne.fb);
+  if (pic == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+      return (WPE_ESC);
+    }
+  e_pr_str (xa + 3, ya + 2, " Current File: ", f->fb->nt.fb, 0, 0, 0, 0);
+  e_pr_str (xa + 3, ya + 4, " Current Directory: ", f->fb->nt.fb, 0, 0, 0, 0);
+  e_pr_str (xa + 3, ya + 6, " Number of Files: ", f->fb->nt.fb, 0, 0, 0, 0);
+  if (strcmp (f->datnam, "Clipboard") != 0)
+    {
+      if (strcmp (f->dirct, f->ed->dirct) == 0)
+	e_pr_str (xa + 23, ya + 2, f->datnam, f->fb->nt.fb, 0, 0, 0, 0);
+      else
+	{
+	  strcpy (tmp, f->dirct);
+	  strcat (tmp, DIRS);
+	  strcat (tmp, f->datnam);
+	  e_pr_str (xa + 23, ya + 2, tmp, f->fb->nt.fb, 0, 0, 0, 0);
 	}
- e_pr_str(xa+23, ya+4, f->ed->dirct, f->fb->nt.fb, 0, 0, 0, 0);
- e_pr_str(xa+23, ya+6,
-   WpeNumberToString(f->ed->mxedt, WpeNumberOfPlaces(f->ed->mxedt), tmp),
-   f->fb->nt.fb, 0, 0, 0, 0);
+    }
+  e_pr_str (xa + 23, ya + 4, f->ed->dirct, f->fb->nt.fb, 0, 0, 0, 0);
+  e_pr_str (xa + 23, ya + 6,
+	    WpeNumberToString (f->ed->mxedt, WpeNumberOfPlaces (f->ed->mxedt),
+			       tmp), f->fb->nt.fb, 0, 0, 0, 0);
 #if  MOUSE
- while(e_mshit() != 0);
- e_getch();
- while(e_mshit() != 0);
+  while (e_mshit () != 0);
+  e_getch ();
+  while (e_mshit () != 0);
 #else
- e_getch();
+  e_getch ();
 #endif
- e_close_view(pic, 1);
- return(0);
+  e_close_view (pic, 1);
+  return (0);
 }
 
 /*   color adjustments  */
-int e_ad_colors(FENSTER *f)
+int
+e_ad_colors (FENSTER * f)
 {
- int n, xa = 48, ya = 2, num = 4;
- OPTK *opt = malloc(num * sizeof(OPTK));
+  int n, xa = 48, ya = 2, num = 4;
+  OPTK *opt = malloc (num * sizeof (OPTK));
 
- opt[0].t = "Editor Colors";     opt[0].x = 0;  opt[0].o = 'E';
- opt[1].t = "Desk Colors";       opt[1].x = 0;  opt[1].o = 'D';
- opt[2].t = "Option Colors";     opt[2].x = 0;  opt[2].o = 'O';
- opt[3].t = "Progr. Colors";     opt[3].x = 0;  opt[3].o = 'P';
+  opt[0].t = "Editor Colors";
+  opt[0].x = 0;
+  opt[0].o = 'E';
+  opt[1].t = "Desk Colors";
+  opt[1].x = 0;
+  opt[1].o = 'D';
+  opt[2].t = "Option Colors";
+  opt[2].x = 0;
+  opt[2].o = 'O';
+  opt[3].t = "Progr. Colors";
+  opt[3].x = 0;
+  opt[3].o = 'P';
 
- n = e_opt_sec_box(xa, ya, num, opt, f, 1);
+  n = e_opt_sec_box (xa, ya, num, opt, f, 1);
 
- free(opt);
- if (n < 0)
-  return(WPE_ESC);
+  free (opt);
+  if (n < 0)
+    return (WPE_ESC);
 
- return(e_ad_colors_md(f, n));
+  return (e_ad_colors_md (f, n));
 }
 
-int e_ad_colors_md(FENSTER *f, int md)
+int
+e_ad_colors_md (FENSTER * f, int md)
 {
- int sw = 0, xa = 0, ya = 1, xe = xa + 79, ye = ya + 22;
- view *pic;
+  int sw = 0, xa = 0, ya = 1, xe = xa + 79, ye = ya + 22;
+  view *pic;
 
- pic = e_std_kst(xa, ya, xe, ye, "Adjust Colors", 1, f->fb->er.fb,
-   f->fb->et.fb, f->fb->es.fb);
- if (pic == NULL)
- {
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  return(WPE_ESC);
- }
- sw = e_dif_colors(sw, xe-13, ya+1, f, md);
- e_close_view(pic, 1);
- e_repaint_desk(f);
- return(sw);
+  pic = e_std_kst (xa, ya, xe, ye, "Adjust Colors", 1, f->fb->er.fb,
+		   f->fb->et.fb, f->fb->es.fb);
+  if (pic == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+      return (WPE_ESC);
+    }
+  sw = e_dif_colors (sw, xe - 13, ya + 1, f, md);
+  e_close_view (pic, 1);
+  e_repaint_desk (f);
+  return (sw);
 }
 
 /*   install/execute color adjustments */
-int e_dif_colors(int sw, int xa, int ya, FENSTER *f, int md)
+int
+e_dif_colors (int sw, int xa, int ya, FENSTER * f, int md)
 {
- COLOR *frb = &(f->fb->er);
- int c = 0, bg, num;
+  COLOR *frb = &(f->fb->er);
+  int c = 0, bg, num;
 
- if (md == 1)
- {
-  bg = 11;
-  num = 5;
- }
- else if (md == 2)
- {
-  bg = 16;
-  num = 15;
- }
- else if (md == 3)
- {
-  bg = 32;
-  num = 5;
- }
- else
- {
-  bg = 0;
-  num = 11;
- }
- while (c != WPE_ESC && c > -2)
- {
-  e_pr_dif_colors(sw, xa, ya, f, 1, md);
-  e_pr_col_kasten(xa-28, ya+1, frb[sw+bg].f, frb[sw+bg].b , f, 0);
-  e_pr_ed_beispiel(1, 2, f, sw, md);
+  if (md == 1)
+    {
+      bg = 11;
+      num = 5;
+    }
+  else if (md == 2)
+    {
+      bg = 16;
+      num = 15;
+    }
+  else if (md == 3)
+    {
+      bg = 32;
+      num = 5;
+    }
+  else
+    {
+      bg = 0;
+      num = 11;
+    }
+  while (c != WPE_ESC && c > -2)
+    {
+      e_pr_dif_colors (sw, xa, ya, f, 1, md);
+      e_pr_col_kasten (xa - 28, ya + 1, frb[sw + bg].f, frb[sw + bg].b, f, 0);
+      e_pr_ed_beispiel (1, 2, f, sw, md);
 #if  MOUSE
-  if ((c = e_getch()) == -1)
-   c = e_opt_cw_mouse(xa, ya, md);
+      if ((c = e_getch ()) == -1)
+	c = e_opt_cw_mouse (xa, ya, md);
 #else
-  c = e_getch();
+      c = e_getch ();
 #endif
-  if (c >= 375 && c <= 393)
-   sw = c-375;
-  else if (c == 326)
-   sw = 0;
-  else if (c == 334)
-   sw = num-1;
-  else if (c == 327)
-   sw = (sw == 0) ? num-1 : sw-1;
-  else if (c == 335)
-   sw = (sw == num-1) ? 0 : sw+1;
-  else if (c == WPE_CR || c == 285 || c == 330)
-  {
-   e_pr_dif_colors(sw, xa, ya, f, 0, md);
-   *(frb+sw+bg) = e_n_clr(e_frb_menue(sw, xa-28, ya+1, f, md));
-  }
- }
- return(c);
+      if (c >= 375 && c <= 393)
+	sw = c - 375;
+      else if (c == 326)
+	sw = 0;
+      else if (c == 334)
+	sw = num - 1;
+      else if (c == 327)
+	sw = (sw == 0) ? num - 1 : sw - 1;
+      else if (c == 335)
+	sw = (sw == num - 1) ? 0 : sw + 1;
+      else if (c == WPE_CR || c == 285 || c == 330)
+	{
+	  e_pr_dif_colors (sw, xa, ya, f, 0, md);
+	  *(frb + sw + bg) =
+	    e_n_clr (e_frb_menue (sw, xa - 28, ya + 1, f, md));
+	}
+    }
+  return (c);
 }
 
-char *text[] = {  "Border", "Bord. Bt.", "Text", "Txt Mrk.1", "Txt Mrk.2",
-		  "Scrollbar", "Help Hdr.", "Help Btt.", "Help Mrk.",
-		  "Breakpnt.", "Stop Brk.",
-		  "Border", "Bord. Bt.", "Text", "Txt Mrk.", "Backgrnd.",
-		  "Border", "Bord. Bt.", "Text", "Text Sw.",
-		  "Write",  "Wrt. Mrk.", "Data", "Data M.A", "Data M.P",
-		  "Switch", "Swtch. S.", "Swtch. A.", "Button",
-		  "Bttn. Sw.", "Bttn. Ak.",
-		  "Text", "Res. Wrd.", "Constants", "Pre-Proc.", "Comments"
-	       };
+char *text[] = { "Border", "Bord. Bt.", "Text", "Txt Mrk.1", "Txt Mrk.2",
+  "Scrollbar", "Help Hdr.", "Help Btt.", "Help Mrk.",
+  "Breakpnt.", "Stop Brk.",
+  "Border", "Bord. Bt.", "Text", "Txt Mrk.", "Backgrnd.",
+  "Border", "Bord. Bt.", "Text", "Text Sw.",
+  "Write", "Wrt. Mrk.", "Data", "Data M.A", "Data M.P",
+  "Switch", "Swtch. S.", "Swtch. A.", "Button",
+  "Bttn. Sw.", "Bttn. Ak.",
+  "Text", "Res. Wrd.", "Constants", "Pre-Proc.", "Comments"
+};
 
 /*   draw color box */
-void e_pr_dif_colors(int sw, int xa, int ya, FENSTER *f, int sw2, int md)
+void
+e_pr_dif_colors (int sw, int xa, int ya, FENSTER * f, int sw2, int md)
 {
- int i, rfrb, cfrb, xe = xa + 12, ye, bg;
- char *header;
+  int i, rfrb, cfrb, xe = xa + 12, ye, bg;
+  char *header;
 
- if (md == 1)
- {
-  ye = ya + 6;
-  bg = 11;
-  header = "Desk";
- }
- else if (md == 2)
- {
-  ye = ya + 16;
-  bg = 16;
-  header = "Options";
- }
- else if (md == 3)
- {
-  ye = ya + 6;
-  bg = 31;
-  header = "C-Prog.";
- }
- else
- {
-  ye = ya + 12;
-  bg = 0;
-  header = "Editor";
- }
- rfrb = sw2 == 0 ? f->fb->nt.fb : f->fb->fs.fb;
- e_std_rahmen(xa, ya, xe, ye, header, 0, rfrb, 0);
- for (i = 0; i < ye-ya-1; i++)
- {
-  cfrb = i == sw ? f->fb->fz.fb : f->fb->ft.fb;
-  e_pr_str_wsd(xa+2, ya+1+i,  text[i+bg], cfrb, 0, 0, 0, xa+1, xe-1);
- }
+  if (md == 1)
+    {
+      ye = ya + 6;
+      bg = 11;
+      header = "Desk";
+    }
+  else if (md == 2)
+    {
+      ye = ya + 16;
+      bg = 16;
+      header = "Options";
+    }
+  else if (md == 3)
+    {
+      ye = ya + 6;
+      bg = 31;
+      header = "C-Prog.";
+    }
+  else
+    {
+      ye = ya + 12;
+      bg = 0;
+      header = "Editor";
+    }
+  rfrb = sw2 == 0 ? f->fb->nt.fb : f->fb->fs.fb;
+  e_std_rahmen (xa, ya, xe, ye, header, 0, rfrb, 0);
+  for (i = 0; i < ye - ya - 1; i++)
+    {
+      cfrb = i == sw ? f->fb->fz.fb : f->fb->ft.fb;
+      e_pr_str_wsd (xa + 2, ya + 1 + i, text[i + bg], cfrb, 0, 0, 0, xa + 1,
+		    xe - 1);
+    }
 }
 
 /*    color menu  */
-int e_frb_x_menue(int sw, int xa, int ya, FENSTER *f, int md)
+int
+e_frb_x_menue (int sw, int xa, int ya, FENSTER * f, int md)
 {
- COLOR *frb = &(f->fb->er);
- int c = 1, fsv = frb[sw].fb, x, y;
+  COLOR *frb = &(f->fb->er);
+  int c = 1, fsv = frb[sw].fb, x, y;
 
- if (md == 1) sw += 11;
- else if (md == 2) sw += 16;
- else if (md == 3) sw += 32;
- y = frb[sw].b;
- x = frb[sw].f;
- do
- {
-  if (c == CRI && y < 7) y++;
-  else if (c == CLE && y > 0) y--;
-  else if (c == CUP && x > 0) x--;
-  else if (c == CDO && x < 15) x++;
-  else if (c >= 1000 && c < 1256)
-  {
-   x = (c-1000)/16;
-   y = (c-1000)%16;
-  }
-  e_pr_x_col_kasten(xa, ya, x, y, f, 1);
-  frb[sw] = e_s_clr(x, y);
-  e_pr_ed_beispiel(1, 2, f, sw, md);
+  if (md == 1)
+    sw += 11;
+  else if (md == 2)
+    sw += 16;
+  else if (md == 3)
+    sw += 32;
+  y = frb[sw].b;
+  x = frb[sw].f;
+  do
+    {
+      if (c == CRI && y < 7)
+	y++;
+      else if (c == CLE && y > 0)
+	y--;
+      else if (c == CUP && x > 0)
+	x--;
+      else if (c == CDO && x < 15)
+	x++;
+      else if (c >= 1000 && c < 1256)
+	{
+	  x = (c - 1000) / 16;
+	  y = (c - 1000) % 16;
+	}
+      e_pr_x_col_kasten (xa, ya, x, y, f, 1);
+      frb[sw] = e_s_clr (x, y);
+      e_pr_ed_beispiel (1, 2, f, sw, md);
 #if  MOUSE
-  if ((c=e_getch()) == -1) c = e_opt_ck_mouse(xa, ya, md);
+      if ((c = e_getch ()) == -1)
+	c = e_opt_ck_mouse (xa, ya, md);
 #else
-  c = e_getch();
+      c = e_getch ();
 #endif
- } while (c != WPE_ESC && c != WPE_CR && c > -2);
- if (c == WPE_ESC || c < -1)
-  frb[sw] = e_n_clr(fsv);
- return(frb[sw].fb);
+    }
+  while (c != WPE_ESC && c != WPE_CR && c > -2);
+  if (c == WPE_ESC || c < -1)
+    frb[sw] = e_n_clr (fsv);
+  return (frb[sw].fb);
 }
 
 /*   draw color box  */
-void e_pr_x_col_kasten(int xa, int ya, int x, int y, FENSTER *f, int sw)
+void
+e_pr_x_col_kasten (int xa, int ya, int x, int y, FENSTER * f, int sw)
 {
- int i, j, rfrb, ffrb, xe = xa + 25, ye = ya + 18;
+  int i, j, rfrb, ffrb, xe = xa + 25, ye = ya + 18;
 
- rfrb = sw == 0 ? f->fb->nt.fb : f->fb->fs.fb;
- ffrb = rfrb % 16;
- e_std_rahmen(xa-2, ya-1, xe, ye, "Colors", 0, rfrb, 0);
+  rfrb = sw == 0 ? f->fb->nt.fb : f->fb->fs.fb;
+  ffrb = rfrb % 16;
+  e_std_rahmen (xa - 2, ya - 1, xe, ye, "Colors", 0, rfrb, 0);
 /*     e_pr_str((xa+xe-8)/2, ya-1, "Colors", rfrb, 0, 1, 
                                         f->fb->ms.f+16*(rfrb/16), 0);
 */
- for (j = 0; j < 8; j++)
-  for (i = 0; i < 16; i++)
-  {
-   e_pr_char(3*j+xa, i+ya+1, ' ', 16*j+i);
-   e_pr_char(3*j+xa+1, i+ya+1, 'x', 16*j+i);
-   e_pr_char(3*j+xa+2, i+ya+1, ' ', 16*j+i);
-  }
- for (i = 0; i < 18; i++)
- {
-  e_pr_char(xa-1, i+ya, ' ', rfrb);
-  e_pr_char(xe-1, i+ya, ' ', rfrb);
- }
- for (j = 0; j < 25; j++)
- {
-  e_pr_char(j+xa-1, ya, ' ', rfrb);
-  e_pr_char(j+xa-1, ye-1, ' ', rfrb);
- }
+  for (j = 0; j < 8; j++)
+    for (i = 0; i < 16; i++)
+      {
+	e_pr_char (3 * j + xa, i + ya + 1, ' ', 16 * j + i);
+	e_pr_char (3 * j + xa + 1, i + ya + 1, 'x', 16 * j + i);
+	e_pr_char (3 * j + xa + 2, i + ya + 1, ' ', 16 * j + i);
+      }
+  for (i = 0; i < 18; i++)
+    {
+      e_pr_char (xa - 1, i + ya, ' ', rfrb);
+      e_pr_char (xe - 1, i + ya, ' ', rfrb);
+    }
+  for (j = 0; j < 25; j++)
+    {
+      e_pr_char (j + xa - 1, ya, ' ', rfrb);
+      e_pr_char (j + xa - 1, ye - 1, ' ', rfrb);
+    }
 #ifdef NEWSTYLE
- if (!WpeIsXwin())
- {
+  if (!WpeIsXwin ())
+    {
 #endif
-  for (i = 0; i < 3; i++)
-  {
-   e_pr_char(3*y+xa+i, x+ya, RE5, x>0 ? 16*y+ffrb : rfrb );
-   e_pr_char(3*y+xa+i, x+ya+2, RE5, x<15 ? 16*y+ffrb : rfrb );
-  }
-  e_pr_char(3*y+xa-1, x+ya+1, RE6, y<1 ? rfrb  : 16*(y-1)+ffrb);
-  e_pr_char(3*y+xa+3, x+ya+1, RE6, y>6 ? rfrb  : 16*(y+1)+ffrb);
-  e_pr_char(3*y+xa-1, x+ya, RE1, (y<1 || x<1) ? rfrb  : 16*(y-1)+ffrb);
-  e_pr_char(3*y+xa+3, x+ya, RE2, (y>6 || x<1) ? rfrb  : 16*(y+1)+ffrb);
-  e_pr_char(3*y+xa-1, x+ya+2, RE3, (y<1 || x>14) ? rfrb  : 16*(y-1)+ffrb);
-  e_pr_char(3*y+xa+3, x+ya+2, RE4, (y>6 || x>14) ? rfrb  : 16*(y+1)+ffrb);
+      for (i = 0; i < 3; i++)
+	{
+	  e_pr_char (3 * y + xa + i, x + ya, RE5,
+		     x > 0 ? 16 * y + ffrb : rfrb);
+	  e_pr_char (3 * y + xa + i, x + ya + 2, RE5,
+		     x < 15 ? 16 * y + ffrb : rfrb);
+	}
+      e_pr_char (3 * y + xa - 1, x + ya + 1, RE6,
+		 y < 1 ? rfrb : 16 * (y - 1) + ffrb);
+      e_pr_char (3 * y + xa + 3, x + ya + 1, RE6,
+		 y > 6 ? rfrb : 16 * (y + 1) + ffrb);
+      e_pr_char (3 * y + xa - 1, x + ya, RE1,
+		 (y < 1 || x < 1) ? rfrb : 16 * (y - 1) + ffrb);
+      e_pr_char (3 * y + xa + 3, x + ya, RE2,
+		 (y > 6 || x < 1) ? rfrb : 16 * (y + 1) + ffrb);
+      e_pr_char (3 * y + xa - 1, x + ya + 2, RE3,
+		 (y < 1 || x > 14) ? rfrb : 16 * (y - 1) + ffrb);
+      e_pr_char (3 * y + xa + 3, x + ya + 2, RE4,
+		 (y > 6 || x > 14) ? rfrb : 16 * (y + 1) + ffrb);
 #ifdef NEWSTYLE
- }
- else e_make_xrect(3*y+xa, x+ya+1, 3*y+xa+2, x+ya+1, 1);
+    }
+  else
+    e_make_xrect (3 * y + xa, x + ya + 1, 3 * y + xa + 2, x + ya + 1, 1);
 #endif
 }
 
 /*    draw color example   */
-void e_pr_ed_beispiel(int xa, int ya, FENSTER *f, int sw, int md)
+void
+e_pr_ed_beispiel (int xa, int ya, FENSTER * f, int sw, int md)
 {
- COLOR *frb = &(f->fb->er);
- FARBE *fb = f->fb;
- int i, j, xe = xa+31, ye = ya+19;
+  COLOR *frb = &(f->fb->er);
+  FARBE *fb = f->fb;
+  int i, j, xe = xa + 31, ye = ya + 19;
 
- frb[sw] = e_s_clr(frb[sw].f, frb[sw].b);
- if (md == 1)
- {
-  e_blk(xe-xa+1, xa+1, ya, fb->mt.fb);
-  e_pr_str_wsd(xa+5, ya,  "Edit", fb->mt.fb, 0, 1, f->fb->ms.fb,
-    xa+3, xa+11);
-  e_pr_str_wsd(xa+18, ya,  "Options", fb->mz.fb, 0, 0, f->fb->ms.fb,
-    xa+16, xa+27);
-  for (i = ya+1; i < ye; i++)
-   for (j = xa+1; j <= xe+1; j++)
-   {
-    e_pr_char(j, i, fb->dc, fb->df.fb);
-    e_pr_char(j, i, fb->dc, fb->df.fb);
-   }
-  e_std_rahmen(xa+17, ya+1, xa+26, ya+3, NULL, 0, fb->mr.fb, 0);
-  e_pr_str(xa+19, ya+2, "Colors", fb->mt.fb, 0, 1, fb->ms.fb, 0);
-  e_blk(xe-xa+1, xa+1, ye, fb->mt.fb);
-  e_pr_str_wsd(xa+4, ye, "Alt-F3 Close Window",
-    fb->mt.fb, 0, 6, fb->ms.fb, xa+2, xa+25);
- }
- else if (md == 2)
- {
-  e_std_rahmen(xa, ya, xe, ye, "Message", 1, fb->nr.fb, f->fb->ne.fb);
-  for(i = ya+1; i < ye; i++) e_blk(xe-xa-1, xa+1, i, fb->nt.fb)
-   ;
-  e_pr_str(xa+4, ya+2, "Name:", f->fb->nt.fb, 0, 1,
-    f->fb->nsnt.fb, f->fb->nt.fb);
-  e_pr_str(xa+5, ya+3, "Active Write-Line ", fb->fa.fb, 0, 0, 0, 0);
-  e_pr_str(xa+4, ya+5, "Name:", f->fb->nt.fb, 0, 1,
-    f->fb->nsnt.fb, f->fb->nt.fb);
-  e_pr_str(xa+5, ya+6, "Passive Write-Line", fb->fr.fb, 0, 0, 0, 0);
-  e_pr_str(xa+4, ya+8, "Data:", f->fb->nt.fb, 0, 1,
-    f->fb->nsnt.fb, f->fb->nt.fb);
-  e_pr_str(xa+5, ya+9, "Active Marked ", f->fb->fz.fb, 0, 0, 0, 0);
-  e_pr_str(xa+5, ya+10, "Passive Marked", f->fb->frft.fb, 0, 0, 0, 0);
-  e_pr_str(xa+5, ya+11, "Data Text     ", f->fb->ft.fb, 0, 0, 0, 0);
-  e_pr_str(xa+4, ya+13, "Switches:", f->fb->nt.fb, 0, 1,
-    f->fb->nsnt.fb, f->fb->nt.fb);
-  e_pr_str(xa+5, ya+14, "[X] Active Switch ", f->fb->fsm.fb, 0, 0, 0, 0);
-  e_pr_str(xa+5, ya+15, "[ ] Passive Switch", f->fb->fs.fb, 4, 1,
-    f->fb->nsft.fb, f->fb->fs.fb);
-  e_pr_str(xa+6 , ye-2, "Button", f->fb->nz.fb, 0, -1,
-    f->fb->ns.fb, f->fb->nt.fb);
-  e_pr_str(xe-12 , ye-2, "Active", f->fb->nm.fb, 0, -1,
-    f->fb->nm.fb, f->fb->nt.fb);
+  frb[sw] = e_s_clr (frb[sw].f, frb[sw].b);
+  if (md == 1)
+    {
+      e_blk (xe - xa + 1, xa + 1, ya, fb->mt.fb);
+      e_pr_str_wsd (xa + 5, ya, "Edit", fb->mt.fb, 0, 1, f->fb->ms.fb,
+		    xa + 3, xa + 11);
+      e_pr_str_wsd (xa + 18, ya, "Options", fb->mz.fb, 0, 0, f->fb->ms.fb,
+		    xa + 16, xa + 27);
+      for (i = ya + 1; i < ye; i++)
+	for (j = xa + 1; j <= xe + 1; j++)
+	  {
+	    e_pr_char (j, i, fb->dc, fb->df.fb);
+	    e_pr_char (j, i, fb->dc, fb->df.fb);
+	  }
+      e_std_rahmen (xa + 17, ya + 1, xa + 26, ya + 3, NULL, 0, fb->mr.fb, 0);
+      e_pr_str (xa + 19, ya + 2, "Colors", fb->mt.fb, 0, 1, fb->ms.fb, 0);
+      e_blk (xe - xa + 1, xa + 1, ye, fb->mt.fb);
+      e_pr_str_wsd (xa + 4, ye, "Alt-F3 Close Window",
+		    fb->mt.fb, 0, 6, fb->ms.fb, xa + 2, xa + 25);
+    }
+  else if (md == 2)
+    {
+      e_std_rahmen (xa, ya, xe, ye, "Message", 1, fb->nr.fb, f->fb->ne.fb);
+      for (i = ya + 1; i < ye; i++)
+	e_blk (xe - xa - 1, xa + 1, i, fb->nt.fb);
+      e_pr_str (xa + 4, ya + 2, "Name:", f->fb->nt.fb, 0, 1,
+		f->fb->nsnt.fb, f->fb->nt.fb);
+      e_pr_str (xa + 5, ya + 3, "Active Write-Line ", fb->fa.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 4, ya + 5, "Name:", f->fb->nt.fb, 0, 1,
+		f->fb->nsnt.fb, f->fb->nt.fb);
+      e_pr_str (xa + 5, ya + 6, "Passive Write-Line", fb->fr.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 4, ya + 8, "Data:", f->fb->nt.fb, 0, 1,
+		f->fb->nsnt.fb, f->fb->nt.fb);
+      e_pr_str (xa + 5, ya + 9, "Active Marked ", f->fb->fz.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 5, ya + 10, "Passive Marked", f->fb->frft.fb, 0, 0, 0,
+		0);
+      e_pr_str (xa + 5, ya + 11, "Data Text     ", f->fb->ft.fb, 0, 0, 0, 0);
+      e_pr_str (xa + 4, ya + 13, "Switches:", f->fb->nt.fb, 0, 1,
+		f->fb->nsnt.fb, f->fb->nt.fb);
+      e_pr_str (xa + 5, ya + 14, "[X] Active Switch ", f->fb->fsm.fb, 0, 0, 0,
+		0);
+      e_pr_str (xa + 5, ya + 15, "[ ] Passive Switch", f->fb->fs.fb, 4, 1,
+		f->fb->nsft.fb, f->fb->fs.fb);
+      e_pr_str (xa + 6, ye - 2, "Button", f->fb->nz.fb, 0, -1, f->fb->ns.fb,
+		f->fb->nt.fb);
+      e_pr_str (xe - 12, ye - 2, "Active", f->fb->nm.fb, 0, -1, f->fb->nm.fb,
+		f->fb->nt.fb);
 #ifdef NEWSTYLE
-  if (WpeIsXwin())
-  {
-   e_make_xrect(xa+4, ya+3, xa+23, ya+3, 1);
-   e_make_xrect(xa+4, ya+6, xa+23, ya+6, 1);
-   e_make_xrect(xa+4, ya+9, xa+19, ya+11, 1);
-   e_make_xrect_abs(xa+4, ya+9, xa+19, ya+9, 0);
-   e_make_xrect(xa+4, ya+14, xa+23, ya+15, 1);
-   e_make_xrect_abs(xa+4, ya+14, xa+23, ya+14, 0);
-  }
+      if (WpeIsXwin ())
+	{
+	  e_make_xrect (xa + 4, ya + 3, xa + 23, ya + 3, 1);
+	  e_make_xrect (xa + 4, ya + 6, xa + 23, ya + 6, 1);
+	  e_make_xrect (xa + 4, ya + 9, xa + 19, ya + 11, 1);
+	  e_make_xrect_abs (xa + 4, ya + 9, xa + 19, ya + 9, 0);
+	  e_make_xrect (xa + 4, ya + 14, xa + 23, ya + 15, 1);
+	  e_make_xrect_abs (xa + 4, ya + 14, xa + 23, ya + 14, 0);
+	}
 #endif
- }
- else
- {
-  e_std_rahmen(xa, ya, xe, ye, "Filename", 1, fb->er.fb, fb->es.fb);
-  e_mouse_bar(xe, ya+1, ye-ya-1, 0, fb->em.fb);
-  e_mouse_bar(xa+20, ye, 11, 1, fb->em.fb);
-  e_pr_char(xe-3, ya, WZN, fb->es.fb);
-#ifdef NEWSTYLE
-  if (!WpeIsXwin())
-  {
-#endif
-   e_pr_char(xe-4, ya, '[', fb->er.fb);
-   e_pr_char(xe-2, ya, ']', fb->er.fb);
-#ifdef NEWSTYLE
-  }
-  else e_make_xrect(xe-4, ya, xe-2, ya, 0);
-#endif
-  for (i = ya+1; i < ye; i++) e_blk(xe-xa-1, xa+1, i, fb->et.fb);
-  if (md == 3)
-  {
-   e_pr_str(xa+4, ya+3, "#Preprozessor Comands", fb->cp.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+5, "This are C-Text Colors", fb->ct.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+7, "int char {} [] ; ,", fb->cr.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+9, "\"Constants\" 12 0x13", fb->ck.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+11, "/*   Comments    */", fb->cc.fb, 0, 0, 0, 0);
-  }
+    }
   else
-  {
-   e_pr_str(xa+4, ya+3, "This are the Editor Colors", fb->et.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+4, "And this is a marked Line", fb->ez.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+5, "This is a found word", fb->et.fb, 0, 0, 0, 0);
-   e_pr_str(xa+14, ya+5, "found", fb->ek.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+8, "Help Header", fb->hh.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+9, "This is a marked Word", fb->et.fb, 0, 0, 0, 0);
-   e_pr_str(xa+14, ya+9, "marked", fb->hm.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+10, "in the Help File", fb->et.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+11, "Help Button", fb->hb.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+14, "This is a Breakpoint", fb->db.fb, 0, 0, 0, 0);
-   e_pr_str(xa+4, ya+15, "Stop at Breakpoint", fb->dy.fb, 0, 0, 0, 0);
-  }
- }
- frb[sw] = e_s_clr(frb[sw].f, frb[sw].b);
+    {
+      e_std_rahmen (xa, ya, xe, ye, "Filename", 1, fb->er.fb, fb->es.fb);
+      e_mouse_bar (xe, ya + 1, ye - ya - 1, 0, fb->em.fb);
+      e_mouse_bar (xa + 20, ye, 11, 1, fb->em.fb);
+      e_pr_char (xe - 3, ya, WZN, fb->es.fb);
+#ifdef NEWSTYLE
+      if (!WpeIsXwin ())
+	{
+#endif
+	  e_pr_char (xe - 4, ya, '[', fb->er.fb);
+	  e_pr_char (xe - 2, ya, ']', fb->er.fb);
+#ifdef NEWSTYLE
+	}
+      else
+	e_make_xrect (xe - 4, ya, xe - 2, ya, 0);
+#endif
+      for (i = ya + 1; i < ye; i++)
+	e_blk (xe - xa - 1, xa + 1, i, fb->et.fb);
+      if (md == 3)
+	{
+	  e_pr_str (xa + 4, ya + 3, "#Preprozessor Comands", fb->cp.fb, 0, 0,
+		    0, 0);
+	  e_pr_str (xa + 4, ya + 5, "This are C-Text Colors", fb->ct.fb, 0, 0,
+		    0, 0);
+	  e_pr_str (xa + 4, ya + 7, "int char {} [] ; ,", fb->cr.fb, 0, 0, 0,
+		    0);
+	  e_pr_str (xa + 4, ya + 9, "\"Constants\" 12 0x13", fb->ck.fb, 0, 0,
+		    0, 0);
+	  e_pr_str (xa + 4, ya + 11, "/*   Comments    */", fb->cc.fb, 0, 0,
+		    0, 0);
+	}
+      else
+	{
+	  e_pr_str (xa + 4, ya + 3, "This are the Editor Colors", fb->et.fb,
+		    0, 0, 0, 0);
+	  e_pr_str (xa + 4, ya + 4, "And this is a marked Line", fb->ez.fb, 0,
+		    0, 0, 0);
+	  e_pr_str (xa + 4, ya + 5, "This is a found word", fb->et.fb, 0, 0,
+		    0, 0);
+	  e_pr_str (xa + 14, ya + 5, "found", fb->ek.fb, 0, 0, 0, 0);
+	  e_pr_str (xa + 4, ya + 8, "Help Header", fb->hh.fb, 0, 0, 0, 0);
+	  e_pr_str (xa + 4, ya + 9, "This is a marked Word", fb->et.fb, 0, 0,
+		    0, 0);
+	  e_pr_str (xa + 14, ya + 9, "marked", fb->hm.fb, 0, 0, 0, 0);
+	  e_pr_str (xa + 4, ya + 10, "in the Help File", fb->et.fb, 0, 0, 0,
+		    0);
+	  e_pr_str (xa + 4, ya + 11, "Help Button", fb->hb.fb, 0, 0, 0, 0);
+	  e_pr_str (xa + 4, ya + 14, "This is a Breakpoint", fb->db.fb, 0, 0,
+		    0, 0);
+	  e_pr_str (xa + 4, ya + 15, "Stop at Breakpoint", fb->dy.fb, 0, 0, 0,
+		    0);
+	}
+    }
+  frb[sw] = e_s_clr (frb[sw].f, frb[sw].b);
 }
 
 /*   Save - Options - Menu   */
-int e_opt_save(FENSTER *f)
+int
+e_opt_save (FENSTER * f)
 {
- int ret;
- char tmp[256];
+  int ret;
+  char tmp[256];
 
- strcpy(tmp, f->ed->optfile);
- ret = e_add_arguments(tmp, "Save Option File", f, 0, AltS, NULL);
- if (ret)
- {
-  f->ed->optfile = realloc(f->ed->optfile, (strlen(tmp)+1)*sizeof(char));
-  strcpy(f->ed->optfile, tmp);
-  e_save_opt(f);
- }
- return(ret);
+  strcpy (tmp, f->ed->optfile);
+  ret = e_add_arguments (tmp, "Save Option File", f, 0, AltS, NULL);
+  if (ret)
+    {
+      f->ed->optfile =
+	realloc (f->ed->optfile, (strlen (tmp) + 1) * sizeof (char));
+      strcpy (f->ed->optfile, tmp);
+      e_save_opt (f);
+    }
+  return (ret);
 }
 
-char *WpeStringToValue(const char *str)
+char *
+WpeStringToValue (const char *str)
 {
- char *answer, *cur_ans;
- const char *cur_str;
- int i, len;
+  char *answer, *cur_ans;
+  const char *cur_str;
+  int i, len;
 
- len = strlen(str);
- answer = malloc((len * 2) * sizeof(char));
- for (i = strlen(str), cur_ans = answer, cur_str = str; i; i--, cur_str++)
- {
-  if ((*cur_str == '\n') || (*cur_str == '\\'))
-  {
-   len++;
-   cur_ans[0] = '\\';
-   cur_ans[1] = ((*cur_str == '\n') ? 'n' : '\\');
-   cur_ans++;
-  }
-  else
-   *cur_ans = *cur_str;
-  cur_ans++;
- }
- *cur_ans = 0;
- return answer;
+  len = strlen (str);
+  answer = malloc ((len * 2) * sizeof (char));
+  for (i = strlen (str), cur_ans = answer, cur_str = str; i; i--, cur_str++)
+    {
+      if ((*cur_str == '\n') || (*cur_str == '\\'))
+	{
+	  len++;
+	  cur_ans[0] = '\\';
+	  cur_ans[1] = ((*cur_str == '\n') ? 'n' : '\\');
+	  cur_ans++;
+	}
+      else
+	*cur_ans = *cur_str;
+      cur_ans++;
+    }
+  *cur_ans = 0;
+  return answer;
 }
 
-char *WpeValueToString(const char *value)
+char *
+WpeValueToString (const char *value)
 {
- char *answer, *cur_ans;
- const char *cur_val;
- int i;
+  char *answer, *cur_ans;
+  const char *cur_val;
+  int i;
 
- answer = malloc((strlen(value) + 1) * sizeof(char));
- for (i = strlen(value), cur_ans = answer, cur_val = value; i; i--, cur_ans++)
- {
-  if (*cur_val == '\\')
-  {
-   cur_val++;
-   *cur_ans = ((*cur_val == 'n') ? '\n' : '\\');
-  }
-  else
-   *cur_ans = *cur_val;
-  cur_val++;
- }
- *cur_ans = 0;
- return answer;
+  answer = malloc ((strlen (value) + 1) * sizeof (char));
+  for (i = strlen (value), cur_ans = answer, cur_val = value; i;
+       i--, cur_ans++)
+    {
+      if (*cur_val == '\\')
+	{
+	  cur_val++;
+	  *cur_ans = ((*cur_val == 'n') ? '\n' : '\\');
+	}
+      else
+	*cur_ans = *cur_val;
+      cur_val++;
+    }
+  *cur_ans = 0;
+  return answer;
 }
 
-int WpeReadGeneral(ECNT *cn, char *section, char *option, char *value)
+int
+WpeReadGeneral (ECNT * cn, char *section, char *option, char *value)
 {
- UNUSED(section);
- if (WpeStrccmp("Data", option) == 0)
-  cn->dtmd = atoi(value);
- else if (WpeStrccmp("Autosave", option) == 0)
-  cn->autosv = atoi(value);
- else if (WpeStrccmp("MaxColumn", option) == 0)
-  cn->maxcol = atoi(value);
- else if (WpeStrccmp("Tab", option) == 0)
-  cn->tabn = atoi(value);
- else if (WpeStrccmp("MaxChanges", option) == 0)
-  cn->maxchg = atoi(value);
- else if (WpeStrccmp("NumUndo", option) == 0)
-  cn->numundo = atoi(value);
- else if (WpeStrccmp("Options1", option) == 0)
-  cn->flopt = atoi(value);
- else if (WpeStrccmp("Options2", option) == 0)
-  cn->edopt = atoi(value);
- else if (WpeStrccmp("InfoDir", option) == 0)
-  info_file = WpeStrdup(value);
- else if (WpeStrccmp("AutoIndent", option) == 0)
-  cn->autoindent = atoi(value);
- else if (WpeStrccmp("PrintCmd", option) == 0)
-  cn->print_cmd = WpeStrdup(value);
- else if (WpeStrccmp("Version", option) == 0)
- {
-  sscanf(value, "%d.%d.%d", &cn->major, &cn->minor, &cn->patch);
- }
- return 0;
+  UNUSED (section);
+  if (WpeStrccmp ("Data", option) == 0)
+    cn->dtmd = atoi (value);
+  else if (WpeStrccmp ("Autosave", option) == 0)
+    cn->autosv = atoi (value);
+  else if (WpeStrccmp ("MaxColumn", option) == 0)
+    cn->maxcol = atoi (value);
+  else if (WpeStrccmp ("Tab", option) == 0)
+    cn->tabn = atoi (value);
+  else if (WpeStrccmp ("MaxChanges", option) == 0)
+    cn->maxchg = atoi (value);
+  else if (WpeStrccmp ("NumUndo", option) == 0)
+    cn->numundo = atoi (value);
+  else if (WpeStrccmp ("Options1", option) == 0)
+    cn->flopt = atoi (value);
+  else if (WpeStrccmp ("Options2", option) == 0)
+    cn->edopt = atoi (value);
+  else if (WpeStrccmp ("InfoDir", option) == 0)
+    info_file = WpeStrdup (value);
+  else if (WpeStrccmp ("AutoIndent", option) == 0)
+    cn->autoindent = atoi (value);
+  else if (WpeStrccmp ("PrintCmd", option) == 0)
+    cn->print_cmd = WpeStrdup (value);
+  else if (WpeStrccmp ("Version", option) == 0)
+    {
+      sscanf (value, "%d.%d.%d", &cn->major, &cn->minor, &cn->patch);
+    }
+  return 0;
 }
 
-int WpeWriteGeneral(ECNT *cn, char *section, FILE *opt_file)
+int
+WpeWriteGeneral (ECNT * cn, char *section, FILE * opt_file)
 {
- UNUSED(section);
- fprintf(opt_file, "Version : %s\n", VERSION);
- fprintf(opt_file, "Data : %d\n", cn->dtmd);
- fprintf(opt_file, "Autosave : %d\n", cn->autosv);
- fprintf(opt_file, "MaxColumn : %d\n", cn->maxcol);
- fprintf(opt_file, "Tab : %d\n", cn->tabn);
- fprintf(opt_file, "MaxChanges : %d\n", cn->maxchg);
- fprintf(opt_file, "NumUndo : %d\n", cn->numundo);
- fprintf(opt_file, "Options1 : %d\n", cn->flopt);
- fprintf(opt_file, "Options2 : %d\n", cn->edopt);
- fprintf(opt_file, "InfoDir : %s\n", info_file);
- fprintf(opt_file, "AutoIndent : %d\n", cn->autoindent);
- fprintf(opt_file, "PrintCmd : %s\n", cn->print_cmd);
- return 0;
+  UNUSED (section);
+  fprintf (opt_file, "Version : %s\n", VERSION);
+  fprintf (opt_file, "Data : %d\n", cn->dtmd);
+  fprintf (opt_file, "Autosave : %d\n", cn->autosv);
+  fprintf (opt_file, "MaxColumn : %d\n", cn->maxcol);
+  fprintf (opt_file, "Tab : %d\n", cn->tabn);
+  fprintf (opt_file, "MaxChanges : %d\n", cn->maxchg);
+  fprintf (opt_file, "NumUndo : %d\n", cn->numundo);
+  fprintf (opt_file, "Options1 : %d\n", cn->flopt);
+  fprintf (opt_file, "Options2 : %d\n", cn->edopt);
+  fprintf (opt_file, "InfoDir : %s\n", info_file);
+  fprintf (opt_file, "AutoIndent : %d\n", cn->autoindent);
+  fprintf (opt_file, "PrintCmd : %s\n", cn->print_cmd);
+  return 0;
 }
 
-int WpeReadColor(ECNT *cn, char *section, char *option, char *value)
+int
+WpeReadColor (ECNT * cn, char *section, char *option, char *value)
 {
- FARBE *fb = NULL;
- COLOR *c = NULL;
- int convert = 0; /* Convert old X11 colors to new colors */
+  FARBE *fb = NULL;
+  COLOR *c = NULL;
+  int convert = 0;		/* Convert old X11 colors to new colors */
 
- if (WpeStrccmp("Term", section + strlen(OPT_SECTION_COLOR) + 1) == 0)
- {
-  if (!u_fb)
-  {
-   u_fb = malloc(sizeof(FARBE));
-   FARBE_Init(u_fb);
-  }
-  fb = u_fb;
- }
- if (WpeStrccmp("X11", section + strlen(OPT_SECTION_COLOR) + 1) == 0)
- {
-  if (!x_fb)
-  {
-   x_fb = malloc(sizeof(FARBE));
-   FARBE_Init(x_fb);
-  }
-  fb = x_fb;
-  if ((cn->major <= 1) && (cn->minor <= 5) && (cn->patch <= 27))
-   convert = 1;
- }
- if (WpeStrccmp("er", option) == 0)
-  c = &fb->er;
- else if (WpeStrccmp("es", option) == 0)
-  c = &fb->es;
- else if (WpeStrccmp("et", option) == 0)
-  c = &fb->et;
- else if (WpeStrccmp("ez", option) == 0)
-  c = &fb->ez;
- else if (WpeStrccmp("ek", option) == 0)
-  c = &fb->ek;
- else if (WpeStrccmp("em", option) == 0)
-  c = &fb->em;
- else if (WpeStrccmp("hh", option) == 0)
-  c = &fb->hh;
- else if (WpeStrccmp("hb", option) == 0)
-  c = &fb->hb;
- else if (WpeStrccmp("hm", option) == 0)
-  c = &fb->hm;
- else if (WpeStrccmp("db", option) == 0)
-  c = &fb->db;
- else if (WpeStrccmp("dy", option) == 0)
-  c = &fb->dy;
- else if (WpeStrccmp("mr", option) == 0)
-  c = &fb->mr;
- else if (WpeStrccmp("ms", option) == 0)
-  c = &fb->ms;
- else if (WpeStrccmp("mt", option) == 0)
-  c = &fb->mt;
- else if (WpeStrccmp("mz", option) == 0)
-  c = &fb->mz;
- else if (WpeStrccmp("df", option) == 0)
-  c = &fb->df;
- else if (WpeStrccmp("nr", option) == 0)
-  c = &fb->nr;
- else if (WpeStrccmp("ne", option) == 0)
-  c = &fb->ne;
- else if (WpeStrccmp("nt", option) == 0)
-  c = &fb->nt;
- else if (WpeStrccmp("nsnt", option) == 0)
-  c = &fb->nsnt;
- else if (WpeStrccmp("fr", option) == 0)
-  c = &fb->fr;
- else if (WpeStrccmp("fa", option) == 0)
-  c = &fb->fa;
- else if (WpeStrccmp("ft", option) == 0)
-  c = &fb->ft;
- else if (WpeStrccmp("fz", option) == 0)
-  c = &fb->fz;
- else if (WpeStrccmp("frft", option) == 0)
-  c = &fb->frft;
- else if (WpeStrccmp("fs", option) == 0)
-  c = &fb->fs;
- else if (WpeStrccmp("nsft", option) == 0)
-  c = &fb->nsft;
- else if (WpeStrccmp("fsm", option) == 0)
-  c = &fb->fsm;
- else if (WpeStrccmp("nz", option) == 0)
-  c = &fb->nz;
- else if (WpeStrccmp("ns", option) == 0)
-  c = &fb->ns;
- else if (WpeStrccmp("nm", option) == 0)
-  c = &fb->nm;
- else if (WpeStrccmp("of", option) == 0)
-  c = &fb->of;
- else if (WpeStrccmp("ct", option) == 0)
-  c = &fb->ct;
- else if (WpeStrccmp("cr", option) == 0)
-  c = &fb->cr;
- else if (WpeStrccmp("ck", option) == 0)
-  c = &fb->ck;
- else if (WpeStrccmp("cp", option) == 0)
-  c = &fb->cp;
- else if (WpeStrccmp("cc", option) == 0)
-  c = &fb->cc;
- else if (WpeStrccmp("dc", option) == 0)
-  fb->dc = atoi(value);
- else if (WpeStrccmp("ws", option) == 0)
-  fb->ws = atoi(value);
- if (c != NULL)
- {
-  sscanf(value, "%d%d", &c->f, &c->b);
-  if (convert)
-  {
-   switch (c->f)
-   {
-    case 1: c->f = 4; break;
-    case 3: c->f = 6; break;
-    case 4: c->f = 1; break;
-    case 6: c->f = 3; break;
-    case 9: c->f = 12; break;
-    case 11: c->f = 14; break;
-    case 12: c->f = 9; break;
-    case 14: c->f = 11; break;
-    default: break;
-   }
-   switch (c->b)
-   {
-    case 1: c->b = 4; break;
-    case 3: c->b = 6; break;
-    case 4: c->b = 1; break;
-    case 6: c->b = 3; break;
-    case 9: c->b = 12; break;
-    case 11: c->b = 14; break;
-    case 12: c->b = 9; break;
-    case 14: c->b = 11; break;
-    default: break;
-   }
-  }
-  *c = e_s_clr(c->f, c->b);
- }
- return 0;
+  if (WpeStrccmp ("Term", section + strlen (OPT_SECTION_COLOR) + 1) == 0)
+    {
+      if (!u_fb)
+	{
+	  u_fb = malloc (sizeof (FARBE));
+	  FARBE_Init (u_fb);
+	}
+      fb = u_fb;
+    }
+  if (WpeStrccmp ("X11", section + strlen (OPT_SECTION_COLOR) + 1) == 0)
+    {
+      if (!x_fb)
+	{
+	  x_fb = malloc (sizeof (FARBE));
+	  FARBE_Init (x_fb);
+	}
+      fb = x_fb;
+      if ((cn->major <= 1) && (cn->minor <= 5) && (cn->patch <= 27))
+	convert = 1;
+    }
+  if (WpeStrccmp ("er", option) == 0)
+    c = &fb->er;
+  else if (WpeStrccmp ("es", option) == 0)
+    c = &fb->es;
+  else if (WpeStrccmp ("et", option) == 0)
+    c = &fb->et;
+  else if (WpeStrccmp ("ez", option) == 0)
+    c = &fb->ez;
+  else if (WpeStrccmp ("ek", option) == 0)
+    c = &fb->ek;
+  else if (WpeStrccmp ("em", option) == 0)
+    c = &fb->em;
+  else if (WpeStrccmp ("hh", option) == 0)
+    c = &fb->hh;
+  else if (WpeStrccmp ("hb", option) == 0)
+    c = &fb->hb;
+  else if (WpeStrccmp ("hm", option) == 0)
+    c = &fb->hm;
+  else if (WpeStrccmp ("db", option) == 0)
+    c = &fb->db;
+  else if (WpeStrccmp ("dy", option) == 0)
+    c = &fb->dy;
+  else if (WpeStrccmp ("mr", option) == 0)
+    c = &fb->mr;
+  else if (WpeStrccmp ("ms", option) == 0)
+    c = &fb->ms;
+  else if (WpeStrccmp ("mt", option) == 0)
+    c = &fb->mt;
+  else if (WpeStrccmp ("mz", option) == 0)
+    c = &fb->mz;
+  else if (WpeStrccmp ("df", option) == 0)
+    c = &fb->df;
+  else if (WpeStrccmp ("nr", option) == 0)
+    c = &fb->nr;
+  else if (WpeStrccmp ("ne", option) == 0)
+    c = &fb->ne;
+  else if (WpeStrccmp ("nt", option) == 0)
+    c = &fb->nt;
+  else if (WpeStrccmp ("nsnt", option) == 0)
+    c = &fb->nsnt;
+  else if (WpeStrccmp ("fr", option) == 0)
+    c = &fb->fr;
+  else if (WpeStrccmp ("fa", option) == 0)
+    c = &fb->fa;
+  else if (WpeStrccmp ("ft", option) == 0)
+    c = &fb->ft;
+  else if (WpeStrccmp ("fz", option) == 0)
+    c = &fb->fz;
+  else if (WpeStrccmp ("frft", option) == 0)
+    c = &fb->frft;
+  else if (WpeStrccmp ("fs", option) == 0)
+    c = &fb->fs;
+  else if (WpeStrccmp ("nsft", option) == 0)
+    c = &fb->nsft;
+  else if (WpeStrccmp ("fsm", option) == 0)
+    c = &fb->fsm;
+  else if (WpeStrccmp ("nz", option) == 0)
+    c = &fb->nz;
+  else if (WpeStrccmp ("ns", option) == 0)
+    c = &fb->ns;
+  else if (WpeStrccmp ("nm", option) == 0)
+    c = &fb->nm;
+  else if (WpeStrccmp ("of", option) == 0)
+    c = &fb->of;
+  else if (WpeStrccmp ("ct", option) == 0)
+    c = &fb->ct;
+  else if (WpeStrccmp ("cr", option) == 0)
+    c = &fb->cr;
+  else if (WpeStrccmp ("ck", option) == 0)
+    c = &fb->ck;
+  else if (WpeStrccmp ("cp", option) == 0)
+    c = &fb->cp;
+  else if (WpeStrccmp ("cc", option) == 0)
+    c = &fb->cc;
+  else if (WpeStrccmp ("dc", option) == 0)
+    fb->dc = atoi (value);
+  else if (WpeStrccmp ("ws", option) == 0)
+    fb->ws = atoi (value);
+  if (c != NULL)
+    {
+      sscanf (value, "%d%d", &c->f, &c->b);
+      if (convert)
+	{
+	  switch (c->f)
+	    {
+	    case 1:
+	      c->f = 4;
+	      break;
+	    case 3:
+	      c->f = 6;
+	      break;
+	    case 4:
+	      c->f = 1;
+	      break;
+	    case 6:
+	      c->f = 3;
+	      break;
+	    case 9:
+	      c->f = 12;
+	      break;
+	    case 11:
+	      c->f = 14;
+	      break;
+	    case 12:
+	      c->f = 9;
+	      break;
+	    case 14:
+	      c->f = 11;
+	      break;
+	    default:
+	      break;
+	    }
+	  switch (c->b)
+	    {
+	    case 1:
+	      c->b = 4;
+	      break;
+	    case 3:
+	      c->b = 6;
+	      break;
+	    case 4:
+	      c->b = 1;
+	      break;
+	    case 6:
+	      c->b = 3;
+	      break;
+	    case 9:
+	      c->b = 12;
+	      break;
+	    case 11:
+	      c->b = 14;
+	      break;
+	    case 12:
+	      c->b = 9;
+	      break;
+	    case 14:
+	      c->b = 11;
+	      break;
+	    default:
+	      break;
+	    }
+	}
+      *c = e_s_clr (c->f, c->b);
+    }
+  return 0;
 }
 
-int WpeWriteColor(ECNT *cn, char *section, FILE *opt_file)
+int
+WpeWriteColor (ECNT * cn, char *section, FILE * opt_file)
 {
- UNUSED(cn);
- FARBE *fb = 0;
+  UNUSED (cn);
+  FARBE *fb = 0;
 
- if (WpeStrccmp("Term", section + strlen(OPT_SECTION_COLOR) + 1) == 0)
-  fb = u_fb;
- if (WpeStrccmp("X11", section + strlen(OPT_SECTION_COLOR) + 1) == 0)
-  fb = x_fb;
- fprintf(opt_file, "er : %d %d\n", fb->er.f, fb->er.b);
- fprintf(opt_file, "es : %d %d\n", fb->es.f, fb->es.b);
- fprintf(opt_file, "et : %d %d\n", fb->et.f, fb->et.b);
- fprintf(opt_file, "ez : %d %d\n", fb->ez.f, fb->ez.b);
- fprintf(opt_file, "ek : %d %d\n", fb->ek.f, fb->ek.b);
- fprintf(opt_file, "em : %d %d\n", fb->em.f, fb->em.b);
- fprintf(opt_file, "hh : %d %d\n", fb->hh.f, fb->hh.b);
- fprintf(opt_file, "hb : %d %d\n", fb->hb.f, fb->hb.b);
- fprintf(opt_file, "hm : %d %d\n", fb->hm.f, fb->hm.b);
- fprintf(opt_file, "db : %d %d\n", fb->db.f, fb->db.b);
- fprintf(opt_file, "dy : %d %d\n", fb->dy.f, fb->dy.b);
- fprintf(opt_file, "mr : %d %d\n", fb->mr.f, fb->mr.b);
- fprintf(opt_file, "ms : %d %d\n", fb->ms.f, fb->ms.b);
- fprintf(opt_file, "mt : %d %d\n", fb->mt.f, fb->mt.b);
- fprintf(opt_file, "mz : %d %d\n", fb->mz.f, fb->mz.b);
- fprintf(opt_file, "df : %d %d\n", fb->df.f, fb->df.b);
- fprintf(opt_file, "nr : %d %d\n", fb->nr.f, fb->nr.b);
- fprintf(opt_file, "ne : %d %d\n", fb->ne.f, fb->ne.b);
- fprintf(opt_file, "nt : %d %d\n", fb->nt.f, fb->nt.b);
- fprintf(opt_file, "nsnt : %d %d\n", fb->nsnt.f, fb->nsnt.b);
- fprintf(opt_file, "fr : %d %d\n", fb->fr.f, fb->fr.b);
- fprintf(opt_file, "fa : %d %d\n", fb->fa.f, fb->fa.b);
- fprintf(opt_file, "ft : %d %d\n", fb->ft.f, fb->ft.b);
- fprintf(opt_file, "fz : %d %d\n", fb->fz.f, fb->fz.b);
- fprintf(opt_file, "frft : %d %d\n", fb->frft.f, fb->frft.b);
- fprintf(opt_file, "fs : %d %d\n", fb->fs.f, fb->fs.b);
- fprintf(opt_file, "nsft : %d %d\n", fb->nsft.f, fb->nsft.b);
- fprintf(opt_file, "fsm : %d %d\n", fb->fsm.f, fb->fsm.b);
- fprintf(opt_file, "nz : %d %d\n", fb->nz.f, fb->nz.b);
- fprintf(opt_file, "ns : %d %d\n", fb->ns.f, fb->ns.b);
- fprintf(opt_file, "nm : %d %d\n", fb->nm.f, fb->nm.b);
- fprintf(opt_file, "of : %d %d\n", fb->of.f, fb->of.b);
- fprintf(opt_file, "ct : %d %d\n", fb->ct.f, fb->ct.b);
- fprintf(opt_file, "cr : %d %d\n", fb->cr.f, fb->cr.b);
- fprintf(opt_file, "ck : %d %d\n", fb->ck.f, fb->ck.b);
- fprintf(opt_file, "cp : %d %d\n", fb->cp.f, fb->cp.b);
- fprintf(opt_file, "cc : %d %d\n", fb->cc.f, fb->cc.b);
- fprintf(opt_file, "dc : %d\n", fb->dc);
- fprintf(opt_file, "ws : %d\n", fb->ws);
- return 0;
+  if (WpeStrccmp ("Term", section + strlen (OPT_SECTION_COLOR) + 1) == 0)
+    fb = u_fb;
+  if (WpeStrccmp ("X11", section + strlen (OPT_SECTION_COLOR) + 1) == 0)
+    fb = x_fb;
+  fprintf (opt_file, "er : %d %d\n", fb->er.f, fb->er.b);
+  fprintf (opt_file, "es : %d %d\n", fb->es.f, fb->es.b);
+  fprintf (opt_file, "et : %d %d\n", fb->et.f, fb->et.b);
+  fprintf (opt_file, "ez : %d %d\n", fb->ez.f, fb->ez.b);
+  fprintf (opt_file, "ek : %d %d\n", fb->ek.f, fb->ek.b);
+  fprintf (opt_file, "em : %d %d\n", fb->em.f, fb->em.b);
+  fprintf (opt_file, "hh : %d %d\n", fb->hh.f, fb->hh.b);
+  fprintf (opt_file, "hb : %d %d\n", fb->hb.f, fb->hb.b);
+  fprintf (opt_file, "hm : %d %d\n", fb->hm.f, fb->hm.b);
+  fprintf (opt_file, "db : %d %d\n", fb->db.f, fb->db.b);
+  fprintf (opt_file, "dy : %d %d\n", fb->dy.f, fb->dy.b);
+  fprintf (opt_file, "mr : %d %d\n", fb->mr.f, fb->mr.b);
+  fprintf (opt_file, "ms : %d %d\n", fb->ms.f, fb->ms.b);
+  fprintf (opt_file, "mt : %d %d\n", fb->mt.f, fb->mt.b);
+  fprintf (opt_file, "mz : %d %d\n", fb->mz.f, fb->mz.b);
+  fprintf (opt_file, "df : %d %d\n", fb->df.f, fb->df.b);
+  fprintf (opt_file, "nr : %d %d\n", fb->nr.f, fb->nr.b);
+  fprintf (opt_file, "ne : %d %d\n", fb->ne.f, fb->ne.b);
+  fprintf (opt_file, "nt : %d %d\n", fb->nt.f, fb->nt.b);
+  fprintf (opt_file, "nsnt : %d %d\n", fb->nsnt.f, fb->nsnt.b);
+  fprintf (opt_file, "fr : %d %d\n", fb->fr.f, fb->fr.b);
+  fprintf (opt_file, "fa : %d %d\n", fb->fa.f, fb->fa.b);
+  fprintf (opt_file, "ft : %d %d\n", fb->ft.f, fb->ft.b);
+  fprintf (opt_file, "fz : %d %d\n", fb->fz.f, fb->fz.b);
+  fprintf (opt_file, "frft : %d %d\n", fb->frft.f, fb->frft.b);
+  fprintf (opt_file, "fs : %d %d\n", fb->fs.f, fb->fs.b);
+  fprintf (opt_file, "nsft : %d %d\n", fb->nsft.f, fb->nsft.b);
+  fprintf (opt_file, "fsm : %d %d\n", fb->fsm.f, fb->fsm.b);
+  fprintf (opt_file, "nz : %d %d\n", fb->nz.f, fb->nz.b);
+  fprintf (opt_file, "ns : %d %d\n", fb->ns.f, fb->ns.b);
+  fprintf (opt_file, "nm : %d %d\n", fb->nm.f, fb->nm.b);
+  fprintf (opt_file, "of : %d %d\n", fb->of.f, fb->of.b);
+  fprintf (opt_file, "ct : %d %d\n", fb->ct.f, fb->ct.b);
+  fprintf (opt_file, "cr : %d %d\n", fb->cr.f, fb->cr.b);
+  fprintf (opt_file, "ck : %d %d\n", fb->ck.f, fb->ck.b);
+  fprintf (opt_file, "cp : %d %d\n", fb->cp.f, fb->cp.b);
+  fprintf (opt_file, "cc : %d %d\n", fb->cc.f, fb->cc.b);
+  fprintf (opt_file, "dc : %d\n", fb->dc);
+  fprintf (opt_file, "ws : %d\n", fb->ws);
+  return 0;
 }
 
-int WpeReadProgramming(ECNT *cn, char *section, char *option, char *value)
+int
+WpeReadProgramming (ECNT * cn, char *section, char *option, char *value)
 {
- UNUSED(cn);
- UNUSED(section);
- if (WpeStrccmp("Arguments", option) == 0)
-  e_prog.arguments = WpeStrdup(value);
- else if (WpeStrccmp("Project", option) == 0)
-  e_prog.project = WpeStrdup(value);
- else if (WpeStrccmp("Exedir", option) == 0)
-  e_prog.exedir = WpeStrdup(value);
- else if (WpeStrccmp("IncludePath", option) == 0)
-  e_prog.sys_include = WpeStrdup(value);
- else if (WpeStrccmp("Debugger", option) == 0)
-  e_deb_type = atoi(value);
- return 0;
+  UNUSED (cn);
+  UNUSED (section);
+  if (WpeStrccmp ("Arguments", option) == 0)
+    e_prog.arguments = WpeStrdup (value);
+  else if (WpeStrccmp ("Project", option) == 0)
+    e_prog.project = WpeStrdup (value);
+  else if (WpeStrccmp ("Exedir", option) == 0)
+    e_prog.exedir = WpeStrdup (value);
+  else if (WpeStrccmp ("IncludePath", option) == 0)
+    e_prog.sys_include = WpeStrdup (value);
+  else if (WpeStrccmp ("Debugger", option) == 0)
+    e_deb_type = atoi (value);
+  return 0;
 }
 
-int WpeWriteProgramming(ECNT *cn, char *section, FILE *opt_file)
+int
+WpeWriteProgramming (ECNT * cn, char *section, FILE * opt_file)
 {
- UNUSED(cn);
- UNUSED(section);
- fprintf(opt_file, "Arguments : %s\n", e_prog.arguments);
- fprintf(opt_file, "Project : %s\n", e_prog.project);
- fprintf(opt_file, "Exedir : %s\n", e_prog.exedir);
- fprintf(opt_file, "IncludePath : %s\n", e_prog.sys_include);
- fprintf(opt_file, "Debugger : %d\n", e_deb_type);
- return 0;
+  UNUSED (cn);
+  UNUSED (section);
+  fprintf (opt_file, "Arguments : %s\n", e_prog.arguments);
+  fprintf (opt_file, "Project : %s\n", e_prog.project);
+  fprintf (opt_file, "Exedir : %s\n", e_prog.exedir);
+  fprintf (opt_file, "IncludePath : %s\n", e_prog.sys_include);
+  fprintf (opt_file, "Debugger : %d\n", e_deb_type);
+  return 0;
 }
 
-int WpeReadLanguage(ECNT *cn, char *section, char *option, char *value)
+int
+WpeReadLanguage (ECNT * cn, char *section, char *option, char *value)
 {
- UNUSED(cn);
- int i, j;
- char *strtmp;
+  UNUSED (cn);
+  int i, j;
+  char *strtmp;
 
- for (i = 0;
-   (i < e_prog.num) && (WpeStrccmp(e_prog.comp[i]->language, section + strlen(OPT_SECTION_LANGUAGE) + 1) != 0);
-   i++)
-  ;
- if (i == e_prog.num)
- {
-  e_prog.num++;
-  e_prog.comp = realloc(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
-  e_prog.comp[i] = malloc(sizeof(struct e_s_prog));
-  e_prog.comp[i]->language = WpeStrdup(section + strlen(OPT_SECTION_LANGUAGE) + 1);
-  e_prog.comp[i]->compiler = WpeStrdup("");
-  e_prog.comp[i]->comp_str = WpeStrdup("");
-  e_prog.comp[i]->libraries = WpeStrdup("");
-  e_prog.comp[i]->exe_name = WpeStrdup("");
-  e_prog.comp[i]->filepostfix = (char **)WpeExpArrayCreate(0, sizeof(char *), 1);
-  e_prog.comp[i]->intstr = WpeStrdup("");
-  e_prog.comp[i]->key = '\0';
-  e_prog.comp[i]->comp_sw = 0;
-  e_prog.comp[i]->x = 0;
- }
- if (WpeStrccmp("Compiler", option) == 0)
- {
-  if (e_prog.comp[i]->compiler)
-   free(e_prog.comp[i]->compiler);
-  e_prog.comp[i]->compiler = WpeStrdup(value);
- }
- else if (WpeStrccmp("CompilerOptions", option) == 0)
- {
-  if (e_prog.comp[i]->comp_str)
-   free(e_prog.comp[i]->comp_str);
-  e_prog.comp[i]->comp_str = WpeStrdup(value);
- }
- else if (WpeStrccmp("Libraries", option) == 0)
- {
-  if (e_prog.comp[i]->libraries)
-   free(e_prog.comp[i]->libraries);
-  e_prog.comp[i]->libraries = WpeStrdup(value);
- }
- else if (WpeStrccmp("Executable", option) == 0)
- {
-  if (e_prog.comp[i]->exe_name)
-   free(e_prog.comp[i]->exe_name);
-  e_prog.comp[i]->exe_name = WpeStrdup(value);
- }
- else if (WpeStrccmp("FileExtension", option) == 0)
- {
-  for (j = WpeExpArrayGetSize(e_prog.comp[i]->filepostfix); j; j--)
-   if (strcmp(e_prog.comp[i]->filepostfix[j - 1], value) == 0)
-    break;
-  if (j == 0)
-  {
-   strtmp = WpeStrdup(value);
-   WpeExpArrayAdd((void **)&e_prog.comp[i]->filepostfix, &strtmp);
-  }
- }
- else if (WpeStrccmp("MessageString", option) == 0)
- {
-  if (e_prog.comp[i]->intstr)
-   free(e_prog.comp[i]->intstr);
-  e_prog.comp[i]->intstr = WpeValueToString(value);
- }
- else if (WpeStrccmp("Key", option) == 0)
-  e_prog.comp[i]->key = value[0];
- else if (WpeStrccmp("CompilerSwitch", option) == 0)
-  e_prog.comp[i]->comp_sw = atoi(value);
- else if (WpeStrccmp("X", option) == 0)
-  e_prog.comp[i]->x = atoi(value);
- return 0;
+  for (i = 0;
+       (i < e_prog.num)
+       &&
+       (WpeStrccmp
+	(e_prog.comp[i]->language,
+	 section + strlen (OPT_SECTION_LANGUAGE) + 1) != 0); i++)
+    ;
+  if (i == e_prog.num)
+    {
+      e_prog.num++;
+      e_prog.comp =
+	realloc (e_prog.comp, e_prog.num * sizeof (struct e_s_prog *));
+      e_prog.comp[i] = malloc (sizeof (struct e_s_prog));
+      e_prog.comp[i]->language =
+	WpeStrdup (section + strlen (OPT_SECTION_LANGUAGE) + 1);
+      e_prog.comp[i]->compiler = WpeStrdup ("");
+      e_prog.comp[i]->comp_str = WpeStrdup ("");
+      e_prog.comp[i]->libraries = WpeStrdup ("");
+      e_prog.comp[i]->exe_name = WpeStrdup ("");
+      e_prog.comp[i]->filepostfix =
+	(char **) WpeExpArrayCreate (0, sizeof (char *), 1);
+      e_prog.comp[i]->intstr = WpeStrdup ("");
+      e_prog.comp[i]->key = '\0';
+      e_prog.comp[i]->comp_sw = 0;
+      e_prog.comp[i]->x = 0;
+    }
+  if (WpeStrccmp ("Compiler", option) == 0)
+    {
+      if (e_prog.comp[i]->compiler)
+	free (e_prog.comp[i]->compiler);
+      e_prog.comp[i]->compiler = WpeStrdup (value);
+    }
+  else if (WpeStrccmp ("CompilerOptions", option) == 0)
+    {
+      if (e_prog.comp[i]->comp_str)
+	free (e_prog.comp[i]->comp_str);
+      e_prog.comp[i]->comp_str = WpeStrdup (value);
+    }
+  else if (WpeStrccmp ("Libraries", option) == 0)
+    {
+      if (e_prog.comp[i]->libraries)
+	free (e_prog.comp[i]->libraries);
+      e_prog.comp[i]->libraries = WpeStrdup (value);
+    }
+  else if (WpeStrccmp ("Executable", option) == 0)
+    {
+      if (e_prog.comp[i]->exe_name)
+	free (e_prog.comp[i]->exe_name);
+      e_prog.comp[i]->exe_name = WpeStrdup (value);
+    }
+  else if (WpeStrccmp ("FileExtension", option) == 0)
+    {
+      for (j = WpeExpArrayGetSize (e_prog.comp[i]->filepostfix); j; j--)
+	if (strcmp (e_prog.comp[i]->filepostfix[j - 1], value) == 0)
+	  break;
+      if (j == 0)
+	{
+	  strtmp = WpeStrdup (value);
+	  WpeExpArrayAdd ((void **) &e_prog.comp[i]->filepostfix, &strtmp);
+	}
+    }
+  else if (WpeStrccmp ("MessageString", option) == 0)
+    {
+      if (e_prog.comp[i]->intstr)
+	free (e_prog.comp[i]->intstr);
+      e_prog.comp[i]->intstr = WpeValueToString (value);
+    }
+  else if (WpeStrccmp ("Key", option) == 0)
+    e_prog.comp[i]->key = value[0];
+  else if (WpeStrccmp ("CompilerSwitch", option) == 0)
+    e_prog.comp[i]->comp_sw = atoi (value);
+  else if (WpeStrccmp ("X", option) == 0)
+    e_prog.comp[i]->x = atoi (value);
+  return 0;
 }
 
-int WpeWriteLanguage(ECNT *cn, char *section, FILE *opt_file)
+int
+WpeWriteLanguage (ECNT * cn, char *section, FILE * opt_file)
 {
- UNUSED(cn);
- int i, j;
- char *str_tmp;
+  UNUSED (cn);
+  int i, j;
+  char *str_tmp;
 
- for (i = 0;
-   (i < e_prog.num) && (WpeStrccmp(e_prog.comp[i]->language, section + strlen(OPT_SECTION_LANGUAGE) + 1) != 0);
-   i++)
-  ;
- if (i < e_prog.num)
- {
-  fprintf(opt_file, "Compiler : %s\n", e_prog.comp[i]->compiler);
-  fprintf(opt_file, "CompilerOptions : %s\n", e_prog.comp[i]->comp_str);
-  fprintf(opt_file, "Libraries : %s\n", e_prog.comp[i]->libraries);
-  fprintf(opt_file, "Executable : %s\n", e_prog.comp[i]->exe_name);
-  for (j = WpeExpArrayGetSize(e_prog.comp[i]->filepostfix); j; j--)
-   fprintf(opt_file, "FileExtension : %s\n", e_prog.comp[i]->filepostfix[j - 1]);
-  str_tmp = WpeStringToValue(e_prog.comp[i]->intstr);
-  fprintf(opt_file, "MessageString : %s\n", str_tmp);
-  free(str_tmp);
-  fprintf(opt_file, "CompilerSwitch : %d\n", e_prog.comp[i]->comp_sw);
-  fprintf(opt_file, "Key : %c\n", e_prog.comp[i]->key);
-  fprintf(opt_file, "X : %d\n", e_prog.comp[i]->x);
- }
- return 0;
+  for (i = 0;
+       (i < e_prog.num)
+       &&
+       (WpeStrccmp
+	(e_prog.comp[i]->language,
+	 section + strlen (OPT_SECTION_LANGUAGE) + 1) != 0); i++)
+    ;
+  if (i < e_prog.num)
+    {
+      fprintf (opt_file, "Compiler : %s\n", e_prog.comp[i]->compiler);
+      fprintf (opt_file, "CompilerOptions : %s\n", e_prog.comp[i]->comp_str);
+      fprintf (opt_file, "Libraries : %s\n", e_prog.comp[i]->libraries);
+      fprintf (opt_file, "Executable : %s\n", e_prog.comp[i]->exe_name);
+      for (j = WpeExpArrayGetSize (e_prog.comp[i]->filepostfix); j; j--)
+	fprintf (opt_file, "FileExtension : %s\n",
+		 e_prog.comp[i]->filepostfix[j - 1]);
+      str_tmp = WpeStringToValue (e_prog.comp[i]->intstr);
+      fprintf (opt_file, "MessageString : %s\n", str_tmp);
+      free (str_tmp);
+      fprintf (opt_file, "CompilerSwitch : %d\n", e_prog.comp[i]->comp_sw);
+      fprintf (opt_file, "Key : %c\n", e_prog.comp[i]->key);
+      fprintf (opt_file, "X : %d\n", e_prog.comp[i]->x);
+    }
+  return 0;
 }
 
 /*   save options    */
-int e_save_opt(FENSTER *f)
+int
+e_save_opt (FENSTER * f)
 {
- ECNT *cn = f->ed;
- FILE *fp;
- int i;
- char *str_line;
+  ECNT *cn = f->ed;
+  FILE *fp;
+  int i;
+  char *str_line;
 
- str_line = malloc((strlen(cn->optfile)+1)*sizeof(char));
- strcpy(str_line, cn->optfile);
- for (i = strlen(str_line); i > 0 && str_line[i] != DIRC; i--);
- str_line[i] = '\0';
- if (access(str_line, F_OK)) mkdir(str_line, 0700);
- free(str_line);
- fp = fopen(cn->optfile, "w");
- if (fp == NULL)
- {
-  e_error(e_msg[ERR_OPEN_OPF], 0, f->fb);
-  return(-1);
- }
- str_line = OPT_SECTION_GENERAL;
- fprintf(fp, "[%s]\n", str_line);
- WpeWriteGeneral(cn, str_line, fp);
- str_line = malloc(strlen(OPT_SECTION_COLOR) + 10);
- strcpy(str_line, OPT_SECTION_COLOR);
- if (u_fb)
- {
-  strcat(str_line, "/Term");
-  fprintf(fp, "[%s]\n", str_line);
-  WpeWriteColor(cn, str_line, fp);
- }
- if (x_fb)
- {
-  strcpy(str_line + strlen(OPT_SECTION_COLOR), "/X11");
-  fprintf(fp, "[%s]\n", str_line);
-  WpeWriteColor(cn, str_line, fp);
- }
- free(str_line);
- str_line = OPT_SECTION_PROGRAMMING;
- fprintf(fp, "[%s]\n", str_line);
- WpeWriteProgramming(cn, str_line, fp);
- str_line = malloc(strlen(OPT_SECTION_LANGUAGE) + 2);
- strcpy(str_line, OPT_SECTION_LANGUAGE);
- strcat(str_line, "/");
- for (i = 0; i < e_prog.num; i++)
- {
-  str_line = realloc(str_line, strlen(OPT_SECTION_LANGUAGE) + strlen(e_prog.comp[i]->language) + 2);
-  strcpy(str_line + strlen(OPT_SECTION_LANGUAGE) + 1, e_prog.comp[i]->language);
-  fprintf(fp, "[%s]\n", str_line);
-  WpeWriteLanguage(cn, str_line, fp);
- }
- free(str_line);
- fclose(fp);
- return 0;
+  str_line = malloc ((strlen (cn->optfile) + 1) * sizeof (char));
+  strcpy (str_line, cn->optfile);
+  for (i = strlen (str_line); i > 0 && str_line[i] != DIRC; i--);
+  str_line[i] = '\0';
+  if (access (str_line, F_OK))
+    mkdir (str_line, 0700);
+  free (str_line);
+  fp = fopen (cn->optfile, "w");
+  if (fp == NULL)
+    {
+      e_error (e_msg[ERR_OPEN_OPF], 0, f->fb);
+      return (-1);
+    }
+  str_line = OPT_SECTION_GENERAL;
+  fprintf (fp, "[%s]\n", str_line);
+  WpeWriteGeneral (cn, str_line, fp);
+  str_line = malloc (strlen (OPT_SECTION_COLOR) + 10);
+  strcpy (str_line, OPT_SECTION_COLOR);
+  if (u_fb)
+    {
+      strcat (str_line, "/Term");
+      fprintf (fp, "[%s]\n", str_line);
+      WpeWriteColor (cn, str_line, fp);
+    }
+  if (x_fb)
+    {
+      strcpy (str_line + strlen (OPT_SECTION_COLOR), "/X11");
+      fprintf (fp, "[%s]\n", str_line);
+      WpeWriteColor (cn, str_line, fp);
+    }
+  free (str_line);
+  str_line = OPT_SECTION_PROGRAMMING;
+  fprintf (fp, "[%s]\n", str_line);
+  WpeWriteProgramming (cn, str_line, fp);
+  str_line = malloc (strlen (OPT_SECTION_LANGUAGE) + 2);
+  strcpy (str_line, OPT_SECTION_LANGUAGE);
+  strcat (str_line, "/");
+  for (i = 0; i < e_prog.num; i++)
+    {
+      str_line =
+	realloc (str_line,
+		 strlen (OPT_SECTION_LANGUAGE) +
+		 strlen (e_prog.comp[i]->language) + 2);
+      strcpy (str_line + strlen (OPT_SECTION_LANGUAGE) + 1,
+	      e_prog.comp[i]->language);
+      fprintf (fp, "[%s]\n", str_line);
+      WpeWriteLanguage (cn, str_line, fp);
+    }
+  free (str_line);
+  fclose (fp);
+  return 0;
 }
 
-int e_opt_read(ECNT *cn)
+int
+e_opt_read (ECNT * cn)
 {
- FILE *fp;
- char *str_line;
- char *section;
- char *option;
- char *value;
- char *str_tmp;
- int sz;
- int i;
+  FILE *fp;
+  char *str_line;
+  char *section;
+  char *option;
+  char *value;
+  char *str_tmp;
+  int sz;
+  int i;
 
- fp = fopen(cn->optfile, "r");
- if (fp == NULL)
- {
-  char *file = e_mkfilename(LIBRARY_DIR, OPTION_FILE);
-  fp = fopen(file, "r");
-  free(file);
- }
- if (fp == NULL) return(0);
- sz = 256;
- str_line = (char *)malloc(256 * sizeof(char));
- section = NULL;
- while (!feof(fp))
- {
-  if (sz != 256)
-  {
-   sz = 256;
-   str_line = (char *)realloc(str_line, sz * sizeof(char));
-  }
-  str_line[0] = 0;
-  char *read_result = fgets(str_line, sz, fp);
-  while ((read_result != NULL && !feof(fp)) &&
-    ((str_line[0] == 0) || (str_line[strlen(str_line) - 1] != '\n')))
-  {
-   sz += 255;
-   str_line = (char *)realloc(str_line, sz * sizeof(char));
-   read_result = fgets(str_line + sz - 256, 256, fp);
-  }
-  i = strlen(str_line);
-  if (i && (str_line[i - 1] == '\n'))
-   str_line[i - 1] = 0;
-  for (option = str_line; isspace(*option); option++)
-   ;
-  if ((*option) && (*option != '#'))
-  {
-   if (*option == '[')
-   {
-    if (section)
-     free(section);
-    for (value = option + 1; (*value) && (*value != ']'); value++)
-     ;
-    if (*value != ']')
+  fp = fopen (cn->optfile, "r");
+  if (fp == NULL)
     {
-     free(str_line);
-     return ERR_READ_OPF;
+      char *file = e_mkfilename (LIBRARY_DIR, OPTION_FILE);
+      fp = fopen (file, "r");
+      free (file);
     }
-    *value = 0;
-    section = WpeStrdup(option + 1);
-   }
-   else
-   {
-    value = strchr(option, ':');
-    if ((value == NULL) || (value == option))
+  if (fp == NULL)
+    return (0);
+  sz = 256;
+  str_line = (char *) malloc (256 * sizeof (char));
+  section = NULL;
+  while (!feof (fp))
     {
-     free(str_line);
-     return ERR_READ_OPF;
+      if (sz != 256)
+	{
+	  sz = 256;
+	  str_line = (char *) realloc (str_line, sz * sizeof (char));
+	}
+      str_line[0] = 0;
+      char *read_result = fgets (str_line, sz, fp);
+      while ((read_result != NULL && !feof (fp)) &&
+	     ((str_line[0] == 0)
+	      || (str_line[strlen (str_line) - 1] != '\n')))
+	{
+	  sz += 255;
+	  str_line = (char *) realloc (str_line, sz * sizeof (char));
+	  read_result = fgets (str_line + sz - 256, 256, fp);
+	}
+      i = strlen (str_line);
+      if (i && (str_line[i - 1] == '\n'))
+	str_line[i - 1] = 0;
+      for (option = str_line; isspace (*option); option++)
+	;
+      if ((*option) && (*option != '#'))
+	{
+	  if (*option == '[')
+	    {
+	      if (section)
+		free (section);
+	      for (value = option + 1; (*value) && (*value != ']'); value++)
+		;
+	      if (*value != ']')
+		{
+		  free (str_line);
+		  return ERR_READ_OPF;
+		}
+	      *value = 0;
+	      section = WpeStrdup (option + 1);
+	    }
+	  else
+	    {
+	      value = strchr (option, ':');
+	      if ((value == NULL) || (value == option))
+		{
+		  free (str_line);
+		  return ERR_READ_OPF;
+		}
+	      for (str_tmp = value - 1; isspace (*str_tmp); str_tmp--)
+		;
+	      for (value++; isspace (*value); value++)
+		;
+	      str_tmp++;
+	      *str_tmp = 0;
+	      for (i = 0;
+		   (i < OPTION_SECTIONS) &&
+		   (strncmp
+		    (WpeSectionRead[i].section, section,
+		     strlen (WpeSectionRead[i].section)) != 0); i++)
+		;
+	      if (i < OPTION_SECTIONS)
+		(*WpeSectionRead[i].function) (cn, section, option, value);
+	      else
+		return ERR_READ_OPF;
+	    }
+	}
     }
-    for (str_tmp = value - 1; isspace(*str_tmp); str_tmp--)
-     ;
-    for (value++; isspace(*value); value++)
-     ;
-    str_tmp++;
-    *str_tmp = 0;
-    for (i = 0;
-      (i < OPTION_SECTIONS) &&
-        (strncmp(WpeSectionRead[i].section, section, strlen(WpeSectionRead[i].section)) != 0);
-      i++)
-     ;
-    if (i < OPTION_SECTIONS)
-     (*WpeSectionRead[i].function)(cn, section, option, value);
-    else
-     return ERR_READ_OPF;
-   }
-  }
- }
- fclose(fp);
- return 0;
+  fclose (fp);
+  return 0;
 }
 
 /*  window for entering a text line */
-int e_add_arguments(char *str, char *head, FENSTER *f, int n, int sw,
-  struct dirfile **df)
+int
+e_add_arguments (char *str, char *head, FENSTER * f, int n, int sw,
+		 struct dirfile **df)
 {
- int ret;
- char *tmp = malloc((strlen(head)+2) * sizeof(char));
- W_OPTSTR *o = e_init_opt_kst(f);
+  int ret;
+  char *tmp = malloc ((strlen (head) + 2) * sizeof (char));
+  W_OPTSTR *o = e_init_opt_kst (f);
 
- if (!o || !tmp)
-  return(-1);
- o->xa = 20;  o->ya = 4;  o->xe = 57;  o->ye = 11;
- o->bgsw = 0;
- o->name = head;
- o->crsw = AltO;
- sprintf(tmp, "%s:", head);
- e_add_wrstr(4, 2, 4, 3, 30, 128, n, sw, tmp, str, df, o);
- e_add_bttstr(7, 5, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(24, 5, -1, WPE_ESC, "Cancel", NULL, o);
- free(tmp);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
-  strcpy(str, o->wstr[0]->txt);
- freeostr(o);
- return(ret == WPE_ESC ? 0 : 1);
+  if (!o || !tmp)
+    return (-1);
+  o->xa = 20;
+  o->ya = 4;
+  o->xe = 57;
+  o->ye = 11;
+  o->bgsw = 0;
+  o->name = head;
+  o->crsw = AltO;
+  sprintf (tmp, "%s:", head);
+  e_add_wrstr (4, 2, 4, 3, 30, 128, n, sw, tmp, str, df, o);
+  e_add_bttstr (7, 5, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (24, 5, -1, WPE_ESC, "Cancel", NULL, o);
+  free (tmp);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    strcpy (str, o->wstr[0]->txt);
+  freeostr (o);
+  return (ret == WPE_ESC ? 0 : 1);
 }
 
-W_O_TXTSTR **e_add_txtstr(int x, int y, char *txt, W_OPTSTR *o)
+W_O_TXTSTR **
+e_add_txtstr (int x, int y, char *txt, W_OPTSTR * o)
 {
- if (o->tn == 0)
-  o->tstr = malloc(1);
- (o->tn)++;
- if (!(o->tstr = realloc(o->tstr, o->tn * sizeof(W_O_TXTSTR *))))
-  return(NULL);
- if (!(o->tstr[o->tn-1] = malloc(sizeof(W_O_TXTSTR))))
-  return(NULL);
- if (!(o->tstr[o->tn-1]->txt = malloc((strlen(txt)+1) * sizeof(char))))
-  return(NULL);
- o->tstr[o->tn-1]->x = x;
- o->tstr[o->tn-1]->y = y;
- strcpy(o->tstr[o->tn-1]->txt, txt);
- return(o->tstr);
+  if (o->tn == 0)
+    o->tstr = malloc (1);
+  (o->tn)++;
+  if (!(o->tstr = realloc (o->tstr, o->tn * sizeof (W_O_TXTSTR *))))
+    return (NULL);
+  if (!(o->tstr[o->tn - 1] = malloc (sizeof (W_O_TXTSTR))))
+    return (NULL);
+  if (!
+      (o->tstr[o->tn - 1]->txt = malloc ((strlen (txt) + 1) * sizeof (char))))
+    return (NULL);
+  o->tstr[o->tn - 1]->x = x;
+  o->tstr[o->tn - 1]->y = y;
+  strcpy (o->tstr[o->tn - 1]->txt, txt);
+  return (o->tstr);
 }
 
-W_O_WRSTR **e_add_wrstr(int xt, int yt, int xw, int yw, int nw, int wmx,
-   int nc, int sw, char *header, char *txt, struct dirfile **df, W_OPTSTR *o)
+W_O_WRSTR **
+e_add_wrstr (int xt, int yt, int xw, int yw, int nw, int wmx,
+	     int nc, int sw, char *header, char *txt, struct dirfile ** df,
+	     W_OPTSTR * o)
 {
- if (o->wn == 0)
-  o->wstr = malloc(1);
- (o->wn)++;
- if (!(o->wstr = realloc(o->wstr, o->wn * sizeof(W_O_WRSTR *))))
-  return(NULL);
- if (!(o->wstr[o->wn-1] = malloc(sizeof(W_O_WRSTR))))
-  return(NULL);
- if (!(o->wstr[o->wn-1]->txt = malloc((wmx+1) * sizeof(char))))
-  return(NULL);
- if (!(o->wstr[o->wn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
-  return(NULL);
- o->wstr[o->wn-1]->xt = xt;
- o->wstr[o->wn-1]->yt = yt;
- o->wstr[o->wn-1]->xw = xw;
- o->wstr[o->wn-1]->yw = yw;
- o->wstr[o->wn-1]->nw = nw;
- o->wstr[o->wn-1]->wmx = wmx;
- o->wstr[o->wn-1]->nc = nc;
- o->wstr[o->wn-1]->sw = sw;
- o->wstr[o->wn-1]->df = df;
- strcpy(o->wstr[o->wn-1]->header, header);
- strcpy(o->wstr[o->wn-1]->txt, txt);
- return(o->wstr);
+  if (o->wn == 0)
+    o->wstr = malloc (1);
+  (o->wn)++;
+  if (!(o->wstr = realloc (o->wstr, o->wn * sizeof (W_O_WRSTR *))))
+    return (NULL);
+  if (!(o->wstr[o->wn - 1] = malloc (sizeof (W_O_WRSTR))))
+    return (NULL);
+  if (!(o->wstr[o->wn - 1]->txt = malloc ((wmx + 1) * sizeof (char))))
+    return (NULL);
+  if (!
+      (o->wstr[o->wn - 1]->header =
+       malloc ((strlen (header) + 1) * sizeof (char))))
+    return (NULL);
+  o->wstr[o->wn - 1]->xt = xt;
+  o->wstr[o->wn - 1]->yt = yt;
+  o->wstr[o->wn - 1]->xw = xw;
+  o->wstr[o->wn - 1]->yw = yw;
+  o->wstr[o->wn - 1]->nw = nw;
+  o->wstr[o->wn - 1]->wmx = wmx;
+  o->wstr[o->wn - 1]->nc = nc;
+  o->wstr[o->wn - 1]->sw = sw;
+  o->wstr[o->wn - 1]->df = df;
+  strcpy (o->wstr[o->wn - 1]->header, header);
+  strcpy (o->wstr[o->wn - 1]->txt, txt);
+  return (o->wstr);
 }
 
-W_O_NUMSTR **e_add_numstr(int xt, int yt, int xw, int yw, int nw, int wmx,
-   int nc, int sw, char *header, int num, W_OPTSTR *o)
+W_O_NUMSTR **
+e_add_numstr (int xt, int yt, int xw, int yw, int nw, int wmx,
+	      int nc, int sw, char *header, int num, W_OPTSTR * o)
 {
- if (o->nn == 0)
-  o->nstr = malloc(1);
- (o->nn)++;
- if (!(o->nstr = realloc(o->nstr, o->nn * sizeof(W_O_NUMSTR *))))
-  return(NULL);
- if (!(o->nstr[o->nn-1] = malloc(sizeof(W_O_NUMSTR))))
-  return(NULL);
- if (!(o->nstr[o->nn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
-  return(NULL);
- o->nstr[o->nn-1]->xt = xt;
- o->nstr[o->nn-1]->yt = yt;
- o->nstr[o->nn-1]->xw = xw;
- o->nstr[o->nn-1]->yw = yw;
- o->nstr[o->nn-1]->nw = nw;
- o->nstr[o->nn-1]->wmx = wmx;
- o->nstr[o->nn-1]->nc = nc;
- o->nstr[o->nn-1]->sw = sw;
- o->nstr[o->nn-1]->num = num;
- strcpy(o->nstr[o->nn-1]->header, header);
- return(o->nstr);
+  if (o->nn == 0)
+    o->nstr = malloc (1);
+  (o->nn)++;
+  if (!(o->nstr = realloc (o->nstr, o->nn * sizeof (W_O_NUMSTR *))))
+    return (NULL);
+  if (!(o->nstr[o->nn - 1] = malloc (sizeof (W_O_NUMSTR))))
+    return (NULL);
+  if (!
+      (o->nstr[o->nn - 1]->header =
+       malloc ((strlen (header) + 1) * sizeof (char))))
+    return (NULL);
+  o->nstr[o->nn - 1]->xt = xt;
+  o->nstr[o->nn - 1]->yt = yt;
+  o->nstr[o->nn - 1]->xw = xw;
+  o->nstr[o->nn - 1]->yw = yw;
+  o->nstr[o->nn - 1]->nw = nw;
+  o->nstr[o->nn - 1]->wmx = wmx;
+  o->nstr[o->nn - 1]->nc = nc;
+  o->nstr[o->nn - 1]->sw = sw;
+  o->nstr[o->nn - 1]->num = num;
+  strcpy (o->nstr[o->nn - 1]->header, header);
+  return (o->nstr);
 }
 
-W_O_SSWSTR **e_add_sswstr(int x, int y, int nc, int sw, int num,
-   char *header, W_OPTSTR *o)
+W_O_SSWSTR **
+e_add_sswstr (int x, int y, int nc, int sw, int num,
+	      char *header, W_OPTSTR * o)
 {
- if (o->sn == 0)
-  o->sstr = malloc(1);
- (o->sn)++;
- if (!(o->sstr = realloc(o->sstr, o->sn * sizeof(W_O_SSWSTR *))))
-  return(NULL);
- if (!(o->sstr[o->sn-1] = malloc(sizeof(W_O_SSWSTR))))
-  return(NULL);
- if (!(o->sstr[o->sn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
-  return(NULL);
- o->sstr[o->sn-1]->x = x;
- o->sstr[o->sn-1]->y = y;
- o->sstr[o->sn-1]->nc = nc;
- o->sstr[o->sn-1]->sw = sw;
- o->sstr[o->sn-1]->num = num;
- strcpy(o->sstr[o->sn-1]->header, header);
- return(o->sstr);
+  if (o->sn == 0)
+    o->sstr = malloc (1);
+  (o->sn)++;
+  if (!(o->sstr = realloc (o->sstr, o->sn * sizeof (W_O_SSWSTR *))))
+    return (NULL);
+  if (!(o->sstr[o->sn - 1] = malloc (sizeof (W_O_SSWSTR))))
+    return (NULL);
+  if (!
+      (o->sstr[o->sn - 1]->header =
+       malloc ((strlen (header) + 1) * sizeof (char))))
+    return (NULL);
+  o->sstr[o->sn - 1]->x = x;
+  o->sstr[o->sn - 1]->y = y;
+  o->sstr[o->sn - 1]->nc = nc;
+  o->sstr[o->sn - 1]->sw = sw;
+  o->sstr[o->sn - 1]->num = num;
+  strcpy (o->sstr[o->sn - 1]->header, header);
+  return (o->sstr);
 }
 
-W_O_SPSWSTR **e_add_spswstr(int n, int x, int y, int nc, int sw,
-   char *header, W_OPTSTR *o)
+W_O_SPSWSTR **
+e_add_spswstr (int n, int x, int y, int nc, int sw,
+	       char *header, W_OPTSTR * o)
 {
- if (n >= o->pn)
-  return(NULL);
- if (n < 0)
-  n = 0;
- if (o->pstr[n]->np == 0)
-  o->pstr[n]->ps = malloc(1);
- (o->pstr[n]->np)++;
- if (!(o->pstr[n]->ps = realloc(o->pstr[n]->ps, o->pstr[n]->np * sizeof(W_O_SPSWSTR *))))
-  return(NULL);
- if (!(o->pstr[n]->ps[o->pstr[n]->np-1] = malloc(sizeof(W_O_SPSWSTR))))
-  return(NULL);
- if (!(o->pstr[n]->ps[o->pstr[n]->np-1]->header = malloc((strlen(header)+1) * sizeof(char))))
-  return(NULL);
- o->pstr[n]->ps[o->pstr[n]->np-1]->x = x;
- o->pstr[n]->ps[o->pstr[n]->np-1]->y = y;
- o->pstr[n]->ps[o->pstr[n]->np-1]->nc = nc;
- o->pstr[n]->ps[o->pstr[n]->np-1]->sw = sw;
- strcpy(o->pstr[n]->ps[o->pstr[n]->np-1]->header, header);
- return(o->pstr[n]->ps);
+  if (n >= o->pn)
+    return (NULL);
+  if (n < 0)
+    n = 0;
+  if (o->pstr[n]->np == 0)
+    o->pstr[n]->ps = malloc (1);
+  (o->pstr[n]->np)++;
+  if (!
+      (o->pstr[n]->ps =
+       realloc (o->pstr[n]->ps, o->pstr[n]->np * sizeof (W_O_SPSWSTR *))))
+    return (NULL);
+  if (!(o->pstr[n]->ps[o->pstr[n]->np - 1] = malloc (sizeof (W_O_SPSWSTR))))
+    return (NULL);
+  if (!
+      (o->pstr[n]->ps[o->pstr[n]->np - 1]->header =
+       malloc ((strlen (header) + 1) * sizeof (char))))
+    return (NULL);
+  o->pstr[n]->ps[o->pstr[n]->np - 1]->x = x;
+  o->pstr[n]->ps[o->pstr[n]->np - 1]->y = y;
+  o->pstr[n]->ps[o->pstr[n]->np - 1]->nc = nc;
+  o->pstr[n]->ps[o->pstr[n]->np - 1]->sw = sw;
+  strcpy (o->pstr[n]->ps[o->pstr[n]->np - 1]->header, header);
+  return (o->pstr[n]->ps);
 }
 
-W_O_PSWSTR **e_add_pswstr(int n, int x, int y, int nc, int sw, int num,
-   char *header, W_OPTSTR *o)
+W_O_PSWSTR **
+e_add_pswstr (int n, int x, int y, int nc, int sw, int num,
+	      char *header, W_OPTSTR * o)
 {
- if (o->pn == 0)
-  o->pstr = malloc(1);
- if (n >= o->pn)
- {
-  n = o->pn;
-  (o->pn)++;
-  if (!(o->pstr = realloc(o->pstr, o->pn * sizeof(W_O_PSWSTR *))))
-   return(NULL);
-  if (!(o->pstr[o->pn-1] = malloc(sizeof(W_O_PSWSTR))))
-   return(NULL);
-  o->pstr[o->pn-1]->np = 0;
- }
- if (!e_add_spswstr(n, x, y, nc, sw, header, o))
-  return(NULL);
- o->pstr[o->pn-1]->num = num;
- return(o->pstr);
+  if (o->pn == 0)
+    o->pstr = malloc (1);
+  if (n >= o->pn)
+    {
+      n = o->pn;
+      (o->pn)++;
+      if (!(o->pstr = realloc (o->pstr, o->pn * sizeof (W_O_PSWSTR *))))
+	return (NULL);
+      if (!(o->pstr[o->pn - 1] = malloc (sizeof (W_O_PSWSTR))))
+	return (NULL);
+      o->pstr[o->pn - 1]->np = 0;
+    }
+  if (!e_add_spswstr (n, x, y, nc, sw, header, o))
+    return (NULL);
+  o->pstr[o->pn - 1]->num = num;
+  return (o->pstr);
 }
 
-W_O_BTTSTR **e_add_bttstr(int x, int y, int nc, int sw, char *header,
-   int (*fkt)(FENSTER *f), W_OPTSTR *o)
+W_O_BTTSTR **
+e_add_bttstr (int x, int y, int nc, int sw, char *header,
+	      int (*fkt) (FENSTER * f), W_OPTSTR * o)
 {
- if (o->bn == 0)
-  o->bstr = malloc(1);
- (o->bn)++;
- if (!(o->bstr = realloc(o->bstr, o->bn * sizeof(W_O_BTTSTR *))))
-  return(NULL);
- if (!(o->bstr[o->bn-1] = malloc(sizeof(W_O_BTTSTR))))
-  return(NULL);
- if (!(o->bstr[o->bn-1]->header = malloc((strlen(header)+1) * sizeof(char))))
-  return(NULL);
- o->bstr[o->bn-1]->x = x;
- o->bstr[o->bn-1]->y = y;
- o->bstr[o->bn-1]->nc = nc;
- o->bstr[o->bn-1]->sw = sw;
- o->bstr[o->bn-1]->fkt = fkt;
- strcpy(o->bstr[o->bn-1]->header, header);
- return(o->bstr);
+  if (o->bn == 0)
+    o->bstr = malloc (1);
+  (o->bn)++;
+  if (!(o->bstr = realloc (o->bstr, o->bn * sizeof (W_O_BTTSTR *))))
+    return (NULL);
+  if (!(o->bstr[o->bn - 1] = malloc (sizeof (W_O_BTTSTR))))
+    return (NULL);
+  if (!
+      (o->bstr[o->bn - 1]->header =
+       malloc ((strlen (header) + 1) * sizeof (char))))
+    return (NULL);
+  o->bstr[o->bn - 1]->x = x;
+  o->bstr[o->bn - 1]->y = y;
+  o->bstr[o->bn - 1]->nc = nc;
+  o->bstr[o->bn - 1]->sw = sw;
+  o->bstr[o->bn - 1]->fkt = fkt;
+  strcpy (o->bstr[o->bn - 1]->header, header);
+  return (o->bstr);
 }
 
-int freeostr(W_OPTSTR *o)
+int
+freeostr (W_OPTSTR * o)
 {
- int i, j;
+  int i, j;
 
- if (!o)
-  return(0);
- for (i = 0; i < o->tn; i++)
- {
-  free(o->tstr[i]->txt);
-  free(o->tstr[i]);
- }
- if (o->tn)
-  free(o->tstr);
- for (i = 0; i < o->wn; i++)
- {
-  free(o->wstr[i]->txt);
-  free(o->wstr[i]->header);
-  free(o->wstr[i]);
- }
- if (o->wn)
-  free(o->wstr);
- for (i = 0; i < o->nn; i++)
- {
-  free(o->nstr[i]->header);
-  free(o->nstr[i]);
- }
- if (o->nn)
-  free(o->nstr);
- for (i = 0; i < o->pn; i++)
- {
-  for (j = 0; j < o->pstr[i]->np; j++)
-  {
-   free(o->pstr[i]->ps[j]->header);
-   free(o->pstr[i]->ps[j]);
-  }
-  if (o->pstr[i]->np)
-   free(o->pstr[i]->ps);
-  free(o->pstr[i]);
- }
- if (o->pn)
-  free(o->pstr);
- for (i = 0; i < o->bn; i++)
- {
-  free(o->bstr[i]->header);
-  free(o->bstr[i]);
- }
- if (o->bn)
-  free(o->bstr);
- free(o);
- return(0);
+  if (!o)
+    return (0);
+  for (i = 0; i < o->tn; i++)
+    {
+      free (o->tstr[i]->txt);
+      free (o->tstr[i]);
+    }
+  if (o->tn)
+    free (o->tstr);
+  for (i = 0; i < o->wn; i++)
+    {
+      free (o->wstr[i]->txt);
+      free (o->wstr[i]->header);
+      free (o->wstr[i]);
+    }
+  if (o->wn)
+    free (o->wstr);
+  for (i = 0; i < o->nn; i++)
+    {
+      free (o->nstr[i]->header);
+      free (o->nstr[i]);
+    }
+  if (o->nn)
+    free (o->nstr);
+  for (i = 0; i < o->pn; i++)
+    {
+      for (j = 0; j < o->pstr[i]->np; j++)
+	{
+	  free (o->pstr[i]->ps[j]->header);
+	  free (o->pstr[i]->ps[j]);
+	}
+      if (o->pstr[i]->np)
+	free (o->pstr[i]->ps);
+      free (o->pstr[i]);
+    }
+  if (o->pn)
+    free (o->pstr);
+  for (i = 0; i < o->bn; i++)
+    {
+      free (o->bstr[i]->header);
+      free (o->bstr[i]);
+    }
+  if (o->bn)
+    free (o->bstr);
+  free (o);
+  return (0);
 }
 
-W_OPTSTR *e_init_opt_kst(FENSTER *f)
+W_OPTSTR *
+e_init_opt_kst (FENSTER * f)
 {
- W_OPTSTR *o = malloc(sizeof(W_OPTSTR));
- if (!o)
-  return(NULL);
- o->frt = f->fb->nr.fb;
- o->frs = f->fb->ne.fb;
- o->ftt = f->fb->nt.fb;
- o->fts = f->fb->nsnt.fb;
- o->fst = f->fb->fs.fb;
- o->fss = f->fb->nsft.fb;
- o->fsa = f->fb->fsm.fb;
- o->fwt = f->fb->fr.fb;
- o->fws = f->fb->fa.fb;
- o->fbt = f->fb->nz.fb;
- o->fbs = f->fb->ns.fb;
- o->fbz = f->fb->nm.fb;
- o->tn = o->sn = o->pn = o->bn = o->wn = o->nn = 0;
- o->f = f;
- o->pic = NULL;
- return(o);
+  W_OPTSTR *o = malloc (sizeof (W_OPTSTR));
+  if (!o)
+    return (NULL);
+  o->frt = f->fb->nr.fb;
+  o->frs = f->fb->ne.fb;
+  o->ftt = f->fb->nt.fb;
+  o->fts = f->fb->nsnt.fb;
+  o->fst = f->fb->fs.fb;
+  o->fss = f->fb->nsft.fb;
+  o->fsa = f->fb->fsm.fb;
+  o->fwt = f->fb->fr.fb;
+  o->fws = f->fb->fa.fb;
+  o->fbt = f->fb->nz.fb;
+  o->fbs = f->fb->ns.fb;
+  o->fbz = f->fb->nm.fb;
+  o->tn = o->sn = o->pn = o->bn = o->wn = o->nn = 0;
+  o->f = f;
+  o->pic = NULL;
+  return (o);
 }
 
-int e_opt_move(W_OPTSTR *o)
+int
+e_opt_move (W_OPTSTR * o)
 {
- int xa = o->xa, ya = o->ya, xe = o->xe, ye = o->ye;
- int c = 0;
- view *pic;
+  int xa = o->xa, ya = o->ya, xe = o->xe, ye = o->ye;
+  int c = 0;
+  view *pic;
 
- e_std_rahmen(o->xa, o->ya, o->xe, o->ye, o->name, 0, o->frt, o->frs);
+  e_std_rahmen (o->xa, o->ya, o->xe, o->ye, o->name, 0, o->frt, o->frs);
 #ifndef NEWSTYLE
- if (!WpeIsXwin())
-  pic = e_open_view(o->xa, o->ya, o->xe, o->ye, 0, 2);
- else 
- {
-  pic = e_open_view(o->xa, o->ya, o->xe-2, o->ye-1, 0, 2);
-  e_close_view(pic, 2);
- }
+  if (!WpeIsXwin ())
+    pic = e_open_view (o->xa, o->ya, o->xe, o->ye, 0, 2);
+  else
+    {
+      pic = e_open_view (o->xa, o->ya, o->xe - 2, o->ye - 1, 0, 2);
+      e_close_view (pic, 2);
+    }
 #else
- pic = e_open_view(o->xa, o->ya, o->xe, o->ye, 0, 2);
+  pic = e_open_view (o->xa, o->ya, o->xe, o->ye, 0, 2);
 #endif
- while ((c = e_getch()) != WPE_ESC && c != WPE_CR)
- {
-  switch(c)
-  {
-   case CLE:
-    if (xa > 0) {  xa--; xe--;  }
-    break;
-   case CRI:
-    if (xe < MAXSCOL-1) {  xa++; xe++;  }
-    break;
-   case CUP:
-    if (ya > 1) {  ya--; ye--;  }
-    break;
-   case CDO:
-    if (ye < MAXSLNS-2) {  ya++; ye++;  }
-    break;
-  }
-  if ( xa != o->xa || ya != o->ya || xe != o->xe || ye != o->ye)
-  {
-   o->xa = xa;
-   o->ya = ya;
-   o->xe = xe;
-   o->ye = ye;
-   o->pic = e_change_pic(o->xa, o->ya, o->xe, o->ye, o->pic, 1, o->frt);
-   if (o->pic == NULL)
-    e_error(e_msg[ERR_LOWMEM], 1, o->f->fb);
-   pic->a.x = o->xa;  pic->a.y = o->ya;
-   pic->e.x = o->xe;  pic->e.y = o->ye;
-   e_close_view(pic, 2);
-  }
- }
- pic->a.x = o->xa;  pic->a.y = o->ya;
- pic->e.x = o->xe;  pic->e.y = o->ye;
- e_close_view(pic, 1);
- e_std_rahmen(o->xa, o->ya, o->xe, o->ye, o->name, 1, o->frt, o->frs);
- return(c);
+  while ((c = e_getch ()) != WPE_ESC && c != WPE_CR)
+    {
+      switch (c)
+	{
+	case CLE:
+	  if (xa > 0)
+	    {
+	      xa--;
+	      xe--;
+	    }
+	  break;
+	case CRI:
+	  if (xe < MAXSCOL - 1)
+	    {
+	      xa++;
+	      xe++;
+	    }
+	  break;
+	case CUP:
+	  if (ya > 1)
+	    {
+	      ya--;
+	      ye--;
+	    }
+	  break;
+	case CDO:
+	  if (ye < MAXSLNS - 2)
+	    {
+	      ya++;
+	      ye++;
+	    }
+	  break;
+	}
+      if (xa != o->xa || ya != o->ya || xe != o->xe || ye != o->ye)
+	{
+	  o->xa = xa;
+	  o->ya = ya;
+	  o->xe = xe;
+	  o->ye = ye;
+	  o->pic =
+	    e_change_pic (o->xa, o->ya, o->xe, o->ye, o->pic, 1, o->frt);
+	  if (o->pic == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, o->f->fb);
+	  pic->a.x = o->xa;
+	  pic->a.y = o->ya;
+	  pic->e.x = o->xe;
+	  pic->e.y = o->ye;
+	  e_close_view (pic, 2);
+	}
+    }
+  pic->a.x = o->xa;
+  pic->a.y = o->ya;
+  pic->e.x = o->xe;
+  pic->e.y = o->ye;
+  e_close_view (pic, 1);
+  e_std_rahmen (o->xa, o->ya, o->xe, o->ye, o->name, 1, o->frt, o->frs);
+  return (c);
 }
 
-int e_get_sw_cmp(int xin, int yin, int x, int y, int xmin, int ymin, int c)
+int
+e_get_sw_cmp (int xin, int yin, int x, int y, int xmin, int ymin, int c)
 {
- return
-      (
-      ( c == 0 && yin == y && (xin-1 <= x && xin+xmin >= x))  ||
-      ((c == CDO || c == BDO || c == WPE_TAB) && yin > y && (yin < ymin ||
-      (yin == ymin && xin <= x && xin > xmin)) ) ||
-      ((c == CUP || c == BUP || c == WPE_BTAB) && yin < y && (yin > ymin ||
-      (yin == ymin && xin <=x && xin > xmin)) ) ||
-      ((c == CLE || c == CCLE) && yin == y && xin < x && xin > xmin) ||
-      ((c == CRI || c == CCRI) && yin == y && xin > x && xin < xmin) );
+  return
+    ((c == 0 && yin == y && (xin - 1 <= x && xin + xmin >= x)) ||
+     ((c == CDO || c == BDO || c == WPE_TAB) && yin > y && (yin < ymin ||
+							    (yin == ymin
+							     && xin <= x
+							     && xin > xmin)))
+     || ((c == CUP || c == BUP || c == WPE_BTAB) && yin < y
+	 && (yin > ymin || (yin == ymin && xin <= x && xin > xmin)))
+     || ((c == CLE || c == CCLE) && yin == y && xin < x && xin > xmin)
+     || ((c == CRI || c == CCRI) && yin == y && xin > x && xin < xmin));
 }
 
-int e_get_opt_sw(int c, int x, int y, W_OPTSTR *o)
+int
+e_get_opt_sw (int c, int x, int y, W_OPTSTR * o)
 {
-   int i, j, xmin, ymin, ret = 0;
-   if( c != 0 && c != CUP && c != CDO && c != CLE && c != CRI && c != BUP && 
-       c != BDO && c != CCLE && c != CCRI && c != WPE_TAB && c != WPE_BTAB )
-	return(c);
-   xmin = (c == CRI || c == CCRI) ? o->xe : o->xa;
-   ymin = (c == CUP || c == BUP || c == WPE_BTAB) ? o->ya : o->ye;
-   x -= o->xa;  xmin -= o->xa;
-   y -= o->ya;  ymin -= o->ya;
-   for(i = 0; i < o->wn; i++)
-   {  if(e_get_sw_cmp(o->wstr[i]->xw, o->wstr[i]->yw, x, y,
-         c ? xmin : o->wstr[i]->nw, ymin, c))
-      {  xmin = o->wstr[i]->xw;  ymin = o->wstr[i]->yw;
-         ret = o->wstr[i]->sw;
+  int i, j, xmin, ymin, ret = 0;
+  if (c != 0 && c != CUP && c != CDO && c != CLE && c != CRI && c != BUP &&
+      c != BDO && c != CCLE && c != CCRI && c != WPE_TAB && c != WPE_BTAB)
+    return (c);
+  xmin = (c == CRI || c == CCRI) ? o->xe : o->xa;
+  ymin = (c == CUP || c == BUP || c == WPE_BTAB) ? o->ya : o->ye;
+  x -= o->xa;
+  xmin -= o->xa;
+  y -= o->ya;
+  ymin -= o->ya;
+  for (i = 0; i < o->wn; i++)
+    {
+      if (e_get_sw_cmp (o->wstr[i]->xw, o->wstr[i]->yw, x, y,
+			c ? xmin : o->wstr[i]->nw, ymin, c))
+	{
+	  xmin = o->wstr[i]->xw;
+	  ymin = o->wstr[i]->yw;
+	  ret = o->wstr[i]->sw;
+	}
+    }
+  for (i = 0; i < o->nn; i++)
+    {
+      if (e_get_sw_cmp (o->nstr[i]->xw, o->nstr[i]->yw, x, y,
+			c ? xmin : o->nstr[i]->nw, ymin, c))
+	{
+	  xmin = o->nstr[i]->xw;
+	  ymin = o->nstr[i]->yw;
+	  ret = o->nstr[i]->sw;
+	}
+    }
+  for (i = 0; i < o->sn; i++)
+    {
+      if (e_get_sw_cmp (o->sstr[i]->x, o->sstr[i]->y, x, y,
+			c ? xmin : 2, ymin, c))
+	{
+	  xmin = o->sstr[i]->x;
+	  ymin = o->sstr[i]->y;
+	  ret = o->sstr[i]->sw;
+	}
+    }
+  for (i = 0; i < o->pn; i++)
+    for (j = 0; j < o->pstr[i]->np; j++)
+      {
+	if (e_get_sw_cmp (o->pstr[i]->ps[j]->x, o->pstr[i]->ps[j]->y, x, y,
+			  c ? xmin : 2, ymin, c))
+	  {
+	    xmin = o->pstr[i]->ps[j]->x;
+	    ymin = o->pstr[i]->ps[j]->y;
+	    ret = o->pstr[i]->ps[j]->sw;
+	  }
       }
-   }
-   for(i = 0; i < o->nn; i++)
-   {  if(e_get_sw_cmp(o->nstr[i]->xw, o->nstr[i]->yw, x, y,
-         c ? xmin : o->nstr[i]->nw, ymin, c))
-      {  xmin = o->nstr[i]->xw;  ymin = o->nstr[i]->yw;
-         ret = o->nstr[i]->sw;
-      }
-   }
-   for(i = 0; i < o->sn; i++)
-   {  if(e_get_sw_cmp(o->sstr[i]->x, o->sstr[i]->y, x, y,
-         c ? xmin : 2, ymin, c))
-      {  xmin = o->sstr[i]->x;  ymin = o->sstr[i]->y;
-         ret = o->sstr[i]->sw;
-      }
-   }
-   for(i = 0; i < o->pn; i++)
-      for(j = 0; j < o->pstr[i]->np; j++)
-      {  if(e_get_sw_cmp(o->pstr[i]->ps[j]->x, o->pstr[i]->ps[j]->y, x, y,
-            c ? xmin : 2, ymin, c))
-         {  xmin = o->pstr[i]->ps[j]->x;  ymin = o->pstr[i]->ps[j]->y;
-            ret = o->pstr[i]->ps[j]->sw;
-         }
-      }
-   for(i = 0; i < o->bn; i++)
-   {  if(e_get_sw_cmp(o->bstr[i]->x, o->bstr[i]->y, x, y,
-         c ? xmin : (int) strlen(o->bstr[i]->header), ymin, c))
-      {  xmin = o->bstr[i]->x;  ymin = o->bstr[i]->y;
-         ret = o->bstr[i]->sw;
-      }
-   }
-   return(!ret ? c : ret);
+  for (i = 0; i < o->bn; i++)
+    {
+      if (e_get_sw_cmp (o->bstr[i]->x, o->bstr[i]->y, x, y,
+			c ? xmin : (int) strlen (o->bstr[i]->header), ymin,
+			c))
+	{
+	  xmin = o->bstr[i]->x;
+	  ymin = o->bstr[i]->y;
+	  ret = o->bstr[i]->sw;
+	}
+    }
+  return (!ret ? c : ret);
 }
 
-int e_opt_kst(W_OPTSTR *o)
+int
+e_opt_kst (W_OPTSTR * o)
 {
-   int ret = 0, csv, sw = 1, i, j, num, cold, c = o->bgsw;
-   char *tmp;
-   fk_cursor(0);
-   o->pic = e_std_kst(o->xa, o->ya, o->xe, o->ye, o->name, 1, o->frt, o->ftt, o->frs);
-   if(o->pic == NULL) {  e_error(e_msg[ERR_LOWMEM], 0, o->f->fb); return(-1);  }
-   if(!c) c = e_get_opt_sw(CDO, 0, 0, o);
-   for(i = 0; i < o->tn; i++)
-      e_pr_str(o->xa+o->tstr[i]->x, o->ya+o->tstr[i]->y, o->tstr[i]->txt,
-      o->ftt, -1, 0, 0, 0);
-   for(i = 0; i < o->wn; i++)
-   {  e_pr_str(o->xa+o->wstr[i]->xt, o->ya+o->wstr[i]->yt, o->wstr[i]->header,
-         o->ftt, o->wstr[i]->nc, 1, o->fts, 0);
-      if(!o->wstr[i]->df)
-         e_schr_nchar(o->wstr[i]->txt, o->xa+o->wstr[i]->xw,
-         o->ya+o->wstr[i]->yw, 0, o->wstr[i]->nw, o->fwt);
+  int ret = 0, csv, sw = 1, i, j, num, cold, c = o->bgsw;
+  char *tmp;
+  fk_cursor (0);
+  o->pic =
+    e_std_kst (o->xa, o->ya, o->xe, o->ye, o->name, 1, o->frt, o->ftt,
+	       o->frs);
+  if (o->pic == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, o->f->fb);
+      return (-1);
+    }
+  if (!c)
+    c = e_get_opt_sw (CDO, 0, 0, o);
+  for (i = 0; i < o->tn; i++)
+    e_pr_str (o->xa + o->tstr[i]->x, o->ya + o->tstr[i]->y, o->tstr[i]->txt,
+	      o->ftt, -1, 0, 0, 0);
+  for (i = 0; i < o->wn; i++)
+    {
+      e_pr_str (o->xa + o->wstr[i]->xt, o->ya + o->wstr[i]->yt,
+		o->wstr[i]->header, o->ftt, o->wstr[i]->nc, 1, o->fts, 0);
+      if (!o->wstr[i]->df)
+	e_schr_nchar (o->wstr[i]->txt, o->xa + o->wstr[i]->xw,
+		      o->ya + o->wstr[i]->yw, 0, o->wstr[i]->nw, o->fwt);
       else
-         e_schr_nchar_wsv(o->wstr[i]->txt, o->xa+o->wstr[i]->xw,
-         o->ya+o->wstr[i]->yw, 0, o->wstr[i]->nw, o->fwt, o->fws);
-   }
-   for(i = 0; i < o->nn; i++)
-   {  e_pr_str(o->xa+o->nstr[i]->xt, o->ya+o->nstr[i]->yt, o->nstr[i]->header,
-         o->ftt, o->nstr[i]->nc, 1, o->fts, 0);
-      e_schr_nzif(o->nstr[i]->num, o->xa+o->nstr[i]->xw, o->ya+o->nstr[i]->yw,
-         o->nstr[i]->nw, o->fwt);
-   }
-   for(i = 0; i < o->sn; i++)
-   {  e_pr_str(o->xa+o->sstr[i]->x+4, o->ya+o->sstr[i]->y, o->sstr[i]->header,
-         o->fst, o->sstr[i]->nc, 1, o->fss, 0);
+	e_schr_nchar_wsv (o->wstr[i]->txt, o->xa + o->wstr[i]->xw,
+			  o->ya + o->wstr[i]->yw, 0, o->wstr[i]->nw, o->fwt,
+			  o->fws);
+    }
+  for (i = 0; i < o->nn; i++)
+    {
+      e_pr_str (o->xa + o->nstr[i]->xt, o->ya + o->nstr[i]->yt,
+		o->nstr[i]->header, o->ftt, o->nstr[i]->nc, 1, o->fts, 0);
+      e_schr_nzif (o->nstr[i]->num, o->xa + o->nstr[i]->xw,
+		   o->ya + o->nstr[i]->yw, o->nstr[i]->nw, o->fwt);
+    }
+  for (i = 0; i < o->sn; i++)
+    {
+      e_pr_str (o->xa + o->sstr[i]->x + 4, o->ya + o->sstr[i]->y,
+		o->sstr[i]->header, o->fst, o->sstr[i]->nc, 1, o->fss, 0);
 #ifdef NEWSTYLE
-      if (WpeIsXwin())
-         e_pr_str(o->xa+o->sstr[i]->x, o->ya+o->sstr[i]->y, "   ",
-         o->fst, -1, 1, 0, 0);
-      else
-#endif
-      e_pr_str(o->xa+o->sstr[i]->x, o->ya+o->sstr[i]->y, "[ ]", o->fst, -1, 1, 0, 0);
-   }
-   for(i = 0; i < o->pn; i++)
-   {  for(j = 0; j < o->pstr[i]->np; j++)
-      {  e_pr_str(o->xa+o->pstr[i]->ps[j]->x, o->ya+o->pstr[i]->ps[j]->y, "[ ] ",
-            o->fst, -1, 1, 0, 0);
-         e_pr_str(o->xa+o->pstr[i]->ps[j]->x+4, o->ya+o->pstr[i]->ps[j]->y,
-            o->pstr[i]->ps[j]->header, o->fst, o->pstr[i]->ps[j]->nc,
-            1, o->fss, 0);
-#ifdef NEWSTYLE
-         if (WpeIsXwin())
-            e_pr_str(o->xa+o->pstr[i]->ps[j]->x,
-            o->ya+o->pstr[i]->ps[j]->y, "   ", o->fst, -1, 1, 0, 0);
-         else
-#endif
-         e_pr_str(o->xa+o->pstr[i]->ps[j]->x, o->ya+o->pstr[i]->ps[j]->y, "[ ]", o->fst, -1, 1, 0, 0);
-      }
-   }
-   for(i = 0; i < o->bn; i++)
-   {  e_pr_str(o->xa+o->bstr[i]->x, o->ya+o->bstr[i]->y, o->bstr[i]->header,
-         o->fbt, o->bstr[i]->nc, -1, o->fbs, o->ftt);
-   }
-   cold = c;
-   while (c != WPE_ESC || sw)
-   {
-#ifdef NEWSTYLE
-      if (WpeIsXwin())
-      {  for(i = 0; i < o->sn; i++)
-         {  if(o->sstr[i]->num)
-               e_make_xrect_abs(o->xa+o->sstr[i]->x, o->ya+o->sstr[i]->y,
-               o->xa+o->sstr[i]->x + 2, o->ya+o->sstr[i]->y, 1);
-            else
-               e_make_xrect_abs(o->xa+o->sstr[i]->x, o->ya+o->sstr[i]->y,
-               o->xa+o->sstr[i]->x + 2, o->ya+o->sstr[i]->y, 0);
-         }
-         for(i = 0; i < o->pn; i++)
-            for(j = 0; j < o->pstr[i]->np; j++)
-            {  if(o->pstr[i]->num == j)
-                  e_make_xrect_abs(o->xa+o->pstr[i]->ps[j]->x, o->ya+o->pstr[i]->ps[j]->y,
-                  o->xa+o->pstr[i]->ps[j]->x + 2, o->ya+o->pstr[i]->ps[j]->y, 1);
-               else
-                  e_make_xrect_abs(o->xa+o->pstr[i]->ps[j]->x, o->ya+o->pstr[i]->ps[j]->y,
-                  o->xa+o->pstr[i]->ps[j]->x+2, o->ya+o->pstr[i]->ps[j]->y, 0);
-            }
-      }
+      if (WpeIsXwin ())
+	e_pr_str (o->xa + o->sstr[i]->x, o->ya + o->sstr[i]->y, "   ",
+		  o->fst, -1, 1, 0, 0);
       else
 #endif
-      {  for(i = 0; i < o->sn; i++)
-         {  if(o->sstr[i]->num)
-               e_pr_char(o->xa+o->sstr[i]->x+1, o->ya+o->sstr[i]->y, 'X', o->fst);
-            else
-               e_pr_char(o->xa+o->sstr[i]->x+1, o->ya+o->sstr[i]->y, ' ', o->fst);
-         }
-         for(i = 0; i < o->pn; i++)
-            for(j = 0; j < o->pstr[i]->np; j++)
-            {  if(o->pstr[i]->num == j)
-                  e_pr_char(o->xa+o->pstr[i]->ps[j]->x+1, o->ya+o->pstr[i]->ps[j]->y, SWSYM, o->fst);
-               else
-                  e_pr_char(o->xa+o->pstr[i]->ps[j]->x+1, o->ya+o->pstr[i]->ps[j]->y, ' ', o->fst);
-            }
-      }
-      if((c == AF2 && !(o->f->ed->edopt & ED_CUA_STYLE))
-         || (o->f->ed->edopt & ED_CUA_STYLE && c == CtrlL))
-      {  e_opt_move(o);  c = cold;  continue;  }
-      for(i = 0; i < o->wn; i++)
-         if(o->wstr[i]->sw == c || (o->wstr[i]->nc >= 0 &&
-         toupper(c) == o->wstr[i]->header[o->wstr[i]->nc]))
-      {  cold = c;
-         tmp = malloc((o->wstr[i]->wmx + 1) * sizeof(char));
-         strcpy(tmp, o->wstr[i]->txt);
-#if MOUSE
-         if(!o->wstr[i]->df && (c = e_schreib_leiste(tmp,
-            o->xa+o->wstr[i]->xw, o->ya+o->wstr[i]->yw,
-            o->wstr[i]->nw, o->wstr[i]->wmx, o->fwt, o->fws)) < 0)
-            c = e_opt_mouse(o);
-         else if(o->wstr[i]->df && (c = e_schr_lst_wsv(tmp,
-            o->xa+o->wstr[i]->xw, o->ya+o->wstr[i]->yw,
-            o->wstr[i]->nw, o->wstr[i]->wmx, o->fwt, o->fws,
-            o->wstr[i]->df, o->f)) < 0)
-            c = e_opt_mouse(o);
-#else
-         if(!o->wstr[i]->df)
-            c = e_schreib_leiste(tmp,
-            o->xa+o->wstr[i]->xw, o->ya+o->wstr[i]->yw,
-            o->wstr[i]->nw, o->wstr[i]->wmx, o->fwt, o->fws);
-         else if(o->wstr[i]->df)
-            c = e_schr_lst_wsv(tmp,
-            o->xa+o->wstr[i]->xw, o->ya+o->wstr[i]->yw,
-            o->wstr[i]->nw, o->wstr[i]->wmx, o->fwt, o->fws,
-            o->wstr[i]->df, o->f);
+	e_pr_str (o->xa + o->sstr[i]->x, o->ya + o->sstr[i]->y, "[ ]", o->fst,
+		  -1, 1, 0, 0);
+    }
+  for (i = 0; i < o->pn; i++)
+    {
+      for (j = 0; j < o->pstr[i]->np; j++)
+	{
+	  e_pr_str (o->xa + o->pstr[i]->ps[j]->x,
+		    o->ya + o->pstr[i]->ps[j]->y, "[ ] ", o->fst, -1, 1, 0,
+		    0);
+	  e_pr_str (o->xa + o->pstr[i]->ps[j]->x + 4,
+		    o->ya + o->pstr[i]->ps[j]->y, o->pstr[i]->ps[j]->header,
+		    o->fst, o->pstr[i]->ps[j]->nc, 1, o->fss, 0);
+#ifdef NEWSTYLE
+	  if (WpeIsXwin ())
+	    e_pr_str (o->xa + o->pstr[i]->ps[j]->x,
+		      o->ya + o->pstr[i]->ps[j]->y, "   ", o->fst, -1, 1, 0,
+		      0);
+	  else
 #endif
-         if(c != WPE_ESC) strcpy(o->wstr[i]->txt, tmp);
-         csv = c;
-         if(!o->wstr[i]->df)
-            e_schr_nchar(o->wstr[i]->txt, o->xa+o->wstr[i]->xw,
-            o->ya+o->wstr[i]->yw, 0, o->wstr[i]->nw, o->fwt);
-         else
-            e_schr_nchar_wsv(o->wstr[i]->txt, o->xa+o->wstr[i]->xw,
-            o->ya+o->wstr[i]->yw, 0, o->wstr[i]->nw, o->fwt, o->fws);
-         if((c = e_get_opt_sw(c, o->xa+o->wstr[i]->xw,
-            o->ya+o->wstr[i]->yw, o)) != csv)  sw = 1;
-         else sw = 0;
-         if(c == WPE_CR)  c = o->crsw;
-         else if(c == WPE_ESC) ret = WPE_ESC;
-         free(tmp);
-         fk_cursor(0);
-         break;
-      }
-      if(i < o->wn) continue;
-      for(i = 0; i < o->nn; i++)
-         if(o->nstr[i]->sw == c || (o->nstr[i]->nc >= 0 &&
-         toupper(c) == o->nstr[i]->header[o->nstr[i]->nc]))
-      {  cold = c;
-         num = o->nstr[i]->num;
-#if MOUSE
-         if((c = e_schreib_zif(&num, o->xa+o->nstr[i]->xw, o->ya+o->nstr[i]->yw,
-            o->nstr[i]->nw, o->fwt, o->fws)) < 0)
-            c = e_opt_mouse(o);
-#else
-         c = e_schreib_zif(&num, o->xa+o->nstr[i]->xw, o->ya+o->nstr[i]->yw,
-            o->nstr[i]->nw, o->fwt, o->fws);
+	    e_pr_str (o->xa + o->pstr[i]->ps[j]->x,
+		      o->ya + o->pstr[i]->ps[j]->y, "[ ]", o->fst, -1, 1, 0,
+		      0);
+	}
+    }
+  for (i = 0; i < o->bn; i++)
+    {
+      e_pr_str (o->xa + o->bstr[i]->x, o->ya + o->bstr[i]->y,
+		o->bstr[i]->header, o->fbt, o->bstr[i]->nc, -1, o->fbs,
+		o->ftt);
+    }
+  cold = c;
+  while (c != WPE_ESC || sw)
+    {
+#ifdef NEWSTYLE
+      if (WpeIsXwin ())
+	{
+	  for (i = 0; i < o->sn; i++)
+	    {
+	      if (o->sstr[i]->num)
+		e_make_xrect_abs (o->xa + o->sstr[i]->x,
+				  o->ya + o->sstr[i]->y,
+				  o->xa + o->sstr[i]->x + 2,
+				  o->ya + o->sstr[i]->y, 1);
+	      else
+		e_make_xrect_abs (o->xa + o->sstr[i]->x,
+				  o->ya + o->sstr[i]->y,
+				  o->xa + o->sstr[i]->x + 2,
+				  o->ya + o->sstr[i]->y, 0);
+	    }
+	  for (i = 0; i < o->pn; i++)
+	    for (j = 0; j < o->pstr[i]->np; j++)
+	      {
+		if (o->pstr[i]->num == j)
+		  e_make_xrect_abs (o->xa + o->pstr[i]->ps[j]->x,
+				    o->ya + o->pstr[i]->ps[j]->y,
+				    o->xa + o->pstr[i]->ps[j]->x + 2,
+				    o->ya + o->pstr[i]->ps[j]->y, 1);
+		else
+		  e_make_xrect_abs (o->xa + o->pstr[i]->ps[j]->x,
+				    o->ya + o->pstr[i]->ps[j]->y,
+				    o->xa + o->pstr[i]->ps[j]->x + 2,
+				    o->ya + o->pstr[i]->ps[j]->y, 0);
+	      }
+	}
+      else
 #endif
-         if(c != WPE_ESC) o->nstr[i]->num = num;
-         csv = c;
-         if((c = e_get_opt_sw(c, o->xa+o->nstr[i]->xw,
-            o->ya+o->nstr[i]->yw, o)) != csv)  sw = 1;
-         else sw = 0;
-         if(c != cold) e_schr_nzif(o->nstr[i]->num, o->xa+o->nstr[i]->xw,
-            o->ya+o->nstr[i]->yw, o->nstr[i]->nw, o->fwt);
-         if(c == WPE_CR)  c = o->crsw;
-         else if(c == WPE_ESC) ret = WPE_ESC;
-         fk_cursor(0);
-         break;
-      }
-      if(i < o->nn) continue;
-      for(i = 0; i < o->sn; i++)
-         if(o->sstr[i]->sw == c || (o->sstr[i]->nc >= 0 &&
-         toupper(c) == o->sstr[i]->header[o->sstr[i]->nc]))
-      {  if(!sw)
-         {  o->sstr[i]->num = !o->sstr[i]->num;
-            sw = 1;
-            c = cold;
-            break;
-         }
-         cold = c;
-         e_pr_str(o->xa+o->sstr[i]->x+4, o->ya+o->sstr[i]->y, o->sstr[i]->header,
-            o->fsa, o->sstr[i]->nc, 1, o->fsa, 0);
+	{
+	  for (i = 0; i < o->sn; i++)
+	    {
+	      if (o->sstr[i]->num)
+		e_pr_char (o->xa + o->sstr[i]->x + 1, o->ya + o->sstr[i]->y,
+			   'X', o->fst);
+	      else
+		e_pr_char (o->xa + o->sstr[i]->x + 1, o->ya + o->sstr[i]->y,
+			   ' ', o->fst);
+	    }
+	  for (i = 0; i < o->pn; i++)
+	    for (j = 0; j < o->pstr[i]->np; j++)
+	      {
+		if (o->pstr[i]->num == j)
+		  e_pr_char (o->xa + o->pstr[i]->ps[j]->x + 1,
+			     o->ya + o->pstr[i]->ps[j]->y, SWSYM, o->fst);
+		else
+		  e_pr_char (o->xa + o->pstr[i]->ps[j]->x + 1,
+			     o->ya + o->pstr[i]->ps[j]->y, ' ', o->fst);
+	      }
+	}
+      if ((c == AF2 && !(o->f->ed->edopt & ED_CUA_STYLE))
+	  || (o->f->ed->edopt & ED_CUA_STYLE && c == CtrlL))
+	{
+	  e_opt_move (o);
+	  c = cold;
+	  continue;
+	}
+      for (i = 0; i < o->wn; i++)
+	if (o->wstr[i]->sw == c || (o->wstr[i]->nc >= 0 &&
+				    toupper (c) ==
+				    o->wstr[i]->header[o->wstr[i]->nc]))
+	  {
+	    cold = c;
+	    tmp = malloc ((o->wstr[i]->wmx + 1) * sizeof (char));
+	    strcpy (tmp, o->wstr[i]->txt);
 #if MOUSE
-         if((c = e_getch()) < 0) c = e_opt_mouse(o);
+	    if (!o->wstr[i]->df && (c = e_schreib_leiste (tmp,
+							  o->xa +
+							  o->wstr[i]->xw,
+							  o->ya +
+							  o->wstr[i]->yw,
+							  o->wstr[i]->nw,
+							  o->wstr[i]->wmx,
+							  o->fwt,
+							  o->fws)) < 0)
+	      c = e_opt_mouse (o);
+	    else if (o->wstr[i]->df && (c = e_schr_lst_wsv (tmp,
+							    o->xa +
+							    o->wstr[i]->xw,
+							    o->ya +
+							    o->wstr[i]->yw,
+							    o->wstr[i]->nw,
+							    o->wstr[i]->wmx,
+							    o->fwt, o->fws,
+							    o->wstr[i]->df,
+							    o->f)) < 0)
+	      c = e_opt_mouse (o);
 #else
-         c = e_getch();
+	    if (!o->wstr[i]->df)
+	      c = e_schreib_leiste (tmp,
+				    o->xa + o->wstr[i]->xw,
+				    o->ya + o->wstr[i]->yw, o->wstr[i]->nw,
+				    o->wstr[i]->wmx, o->fwt, o->fws);
+	    else if (o->wstr[i]->df)
+	      c = e_schr_lst_wsv (tmp,
+				  o->xa + o->wstr[i]->xw,
+				  o->ya + o->wstr[i]->yw, o->wstr[i]->nw,
+				  o->wstr[i]->wmx, o->fwt, o->fws,
+				  o->wstr[i]->df, o->f);
 #endif
-         if(c == WPE_CR) {  sw = 0;  c = cold;  break;  }
-         else if(c == WPE_ESC)  sw = 1;
-         else
-         {  csv = c;
-            if((c = e_get_opt_sw(c, o->xa+o->sstr[i]->x,
-               o->ya+o->sstr[i]->y, o)) != csv)  sw = 1;
-            else sw = 0;
-         }
-         if(c != cold)
-            e_pr_str(o->xa+o->sstr[i]->x+4, o->ya+o->sstr[i]->y, o->sstr[i]->header,
-            o->fst, o->sstr[i]->nc, 1, o->fss, 0);
-         break;
-      }
-      if(i < o->sn) continue;
-      for(i = 0; i < o->pn; i++)
-      {  for(j = 0; j < o->pstr[i]->np; j++)
-            if(o->pstr[i]->ps[j]->sw == c || (o->pstr[i]->ps[j]->nc >= 0 &&
-            toupper(c) == o->pstr[i]->ps[j]->header[o->pstr[i]->ps[j]->nc]))
-         {  if(!sw)
-            {  o->pstr[i]->num = j;
-               sw = 1;
-               c = cold;
-               break;
-            }
-            cold = c;
-            e_pr_str(o->xa+o->pstr[i]->ps[j]->x+4, o->ya+o->pstr[i]->ps[j]->y, o->pstr[i]->ps[j]->header,
-               o->fsa, o->pstr[i]->ps[j]->nc, 1, o->fsa, 0);
+	    if (c != WPE_ESC)
+	      strcpy (o->wstr[i]->txt, tmp);
+	    csv = c;
+	    if (!o->wstr[i]->df)
+	      e_schr_nchar (o->wstr[i]->txt, o->xa + o->wstr[i]->xw,
+			    o->ya + o->wstr[i]->yw, 0, o->wstr[i]->nw,
+			    o->fwt);
+	    else
+	      e_schr_nchar_wsv (o->wstr[i]->txt, o->xa + o->wstr[i]->xw,
+				o->ya + o->wstr[i]->yw, 0, o->wstr[i]->nw,
+				o->fwt, o->fws);
+	    if ((c =
+		 e_get_opt_sw (c, o->xa + o->wstr[i]->xw,
+			       o->ya + o->wstr[i]->yw, o)) != csv)
+	      sw = 1;
+	    else
+	      sw = 0;
+	    if (c == WPE_CR)
+	      c = o->crsw;
+	    else if (c == WPE_ESC)
+	      ret = WPE_ESC;
+	    free (tmp);
+	    fk_cursor (0);
+	    break;
+	  }
+      if (i < o->wn)
+	continue;
+      for (i = 0; i < o->nn; i++)
+	if (o->nstr[i]->sw == c || (o->nstr[i]->nc >= 0 &&
+				    toupper (c) ==
+				    o->nstr[i]->header[o->nstr[i]->nc]))
+	  {
+	    cold = c;
+	    num = o->nstr[i]->num;
 #if MOUSE
-            if((c = e_getch()) < 0) c = e_opt_mouse(o);
+	    if ((c =
+		 e_schreib_zif (&num, o->xa + o->nstr[i]->xw,
+				o->ya + o->nstr[i]->yw, o->nstr[i]->nw,
+				o->fwt, o->fws)) < 0)
+	      c = e_opt_mouse (o);
 #else
-            c = e_getch();
+	    c =
+	      e_schreib_zif (&num, o->xa + o->nstr[i]->xw,
+			     o->ya + o->nstr[i]->yw, o->nstr[i]->nw, o->fwt,
+			     o->fws);
 #endif
-            if(c == WPE_CR)  {  sw = 0;  c = cold;  break;  }
-            else if(c == WPE_ESC)  sw = 1;
-            {  csv = c;
-               if((c = e_get_opt_sw(c, o->xa+o->pstr[i]->ps[j]->x,
-                  o->ya+o->pstr[i]->ps[j]->y, o)) != csv)  sw = 1;
-               else sw = 0;
-            }
-            if(c != cold)
-               e_pr_str(o->xa+o->pstr[i]->ps[j]->x+4, o->ya+o->pstr[i]->ps[j]->y, o->pstr[i]->ps[j]->header,
-               o->fst, o->pstr[i]->ps[j]->nc, 1, o->fss, 0);
-            break;
-         }
-         if(j < o->pstr[i]->np) break;
-      }
-      if(i < o->pn) continue;
-      for(i = 0; i < o->bn; i++)
-         if(o->bstr[i]->sw == c || (o->bstr[i]->nc >= 0 &&
-         toupper(c) == o->bstr[i]->header[o->bstr[i]->nc]))
-      {  e_pr_str(o->xa+o->bstr[i]->x, o->ya+o->bstr[i]->y, o->bstr[i]->header,
-            o->fbz, o->bstr[i]->nc, -1, o->fbz, o->ftt);
-         if(!sw)
-         {  if(o->bstr[i]->fkt != NULL)
-            {  if((ret = o->bstr[i]->fkt(o->f)) > 0) c = WPE_ESC;
-               else
-               {  c = cold;
-                  e_pr_str(o->xa+o->bstr[i]->x, o->ya+o->bstr[i]->y, o->bstr[i]->header,
-                     o->fbt, o->bstr[i]->nc, -1, o->fbs,  o->ftt);
-               }
-            }
-            else {  ret = o->bstr[i]->sw;  c = WPE_ESC;  }
-            break;
-         }
-         cold = c;
+	    if (c != WPE_ESC)
+	      o->nstr[i]->num = num;
+	    csv = c;
+	    if ((c = e_get_opt_sw (c, o->xa + o->nstr[i]->xw,
+				   o->ya + o->nstr[i]->yw, o)) != csv)
+	      sw = 1;
+	    else
+	      sw = 0;
+	    if (c != cold)
+	      e_schr_nzif (o->nstr[i]->num, o->xa + o->nstr[i]->xw,
+			   o->ya + o->nstr[i]->yw, o->nstr[i]->nw, o->fwt);
+	    if (c == WPE_CR)
+	      c = o->crsw;
+	    else if (c == WPE_ESC)
+	      ret = WPE_ESC;
+	    fk_cursor (0);
+	    break;
+	  }
+      if (i < o->nn)
+	continue;
+      for (i = 0; i < o->sn; i++)
+	if (o->sstr[i]->sw == c || (o->sstr[i]->nc >= 0 &&
+				    toupper (c) ==
+				    o->sstr[i]->header[o->sstr[i]->nc]))
+	  {
+	    if (!sw)
+	      {
+		o->sstr[i]->num = !o->sstr[i]->num;
+		sw = 1;
+		c = cold;
+		break;
+	      }
+	    cold = c;
+	    e_pr_str (o->xa + o->sstr[i]->x + 4, o->ya + o->sstr[i]->y,
+		      o->sstr[i]->header, o->fsa, o->sstr[i]->nc, 1, o->fsa,
+		      0);
 #if MOUSE
-         if((c = e_getch()) < 0) c = e_opt_mouse(o);
+	    if ((c = e_getch ()) < 0)
+	      c = e_opt_mouse (o);
 #else
-         c = e_getch();
+	    c = e_getch ();
 #endif
-         if(c == WPE_CR) {  ret = c = o->bstr[i]->sw;  sw = 0;  break;  }
-         else if(c == WPE_ESC) {  sw = 0;  ret = WPE_ESC;  break;  }
-         csv = c;
-         if((c = e_get_opt_sw(c, o->xa+o->bstr[i]->x,
-            o->ya+o->bstr[i]->y, o)) != csv)  sw = 1;
-         else sw = 0;
-         if(c != cold)
-            e_pr_str(o->xa+o->bstr[i]->x, o->ya+o->bstr[i]->y, o->bstr[i]->header,
-            o->fbt, o->bstr[i]->nc, -1, o->fbs,  o->ftt);
-         break;
-      }
-      if(i < o->bn) continue;
+	    if (c == WPE_CR)
+	      {
+		sw = 0;
+		c = cold;
+		break;
+	      }
+	    else if (c == WPE_ESC)
+	      sw = 1;
+	    else
+	      {
+		csv = c;
+		if ((c = e_get_opt_sw (c, o->xa + o->sstr[i]->x,
+				       o->ya + o->sstr[i]->y, o)) != csv)
+		  sw = 1;
+		else
+		  sw = 0;
+	      }
+	    if (c != cold)
+	      e_pr_str (o->xa + o->sstr[i]->x + 4, o->ya + o->sstr[i]->y,
+			o->sstr[i]->header, o->fst, o->sstr[i]->nc, 1, o->fss,
+			0);
+	    break;
+	  }
+      if (i < o->sn)
+	continue;
+      for (i = 0; i < o->pn; i++)
+	{
+	  for (j = 0; j < o->pstr[i]->np; j++)
+	    if (o->pstr[i]->ps[j]->sw == c || (o->pstr[i]->ps[j]->nc >= 0 &&
+					       toupper (c) ==
+					       o->pstr[i]->ps[j]->header[o->
+									 pstr
+									 [i]->
+									 ps
+									 [j]->
+									 nc]))
+	      {
+		if (!sw)
+		  {
+		    o->pstr[i]->num = j;
+		    sw = 1;
+		    c = cold;
+		    break;
+		  }
+		cold = c;
+		e_pr_str (o->xa + o->pstr[i]->ps[j]->x + 4,
+			  o->ya + o->pstr[i]->ps[j]->y,
+			  o->pstr[i]->ps[j]->header, o->fsa,
+			  o->pstr[i]->ps[j]->nc, 1, o->fsa, 0);
+#if MOUSE
+		if ((c = e_getch ()) < 0)
+		  c = e_opt_mouse (o);
+#else
+		c = e_getch ();
+#endif
+		if (c == WPE_CR)
+		  {
+		    sw = 0;
+		    c = cold;
+		    break;
+		  }
+		else if (c == WPE_ESC)
+		  sw = 1;
+		{
+		  csv = c;
+		  if ((c = e_get_opt_sw (c, o->xa + o->pstr[i]->ps[j]->x,
+					 o->ya + o->pstr[i]->ps[j]->y,
+					 o)) != csv)
+		    sw = 1;
+		  else
+		    sw = 0;
+		}
+		if (c != cold)
+		  e_pr_str (o->xa + o->pstr[i]->ps[j]->x + 4,
+			    o->ya + o->pstr[i]->ps[j]->y,
+			    o->pstr[i]->ps[j]->header, o->fst,
+			    o->pstr[i]->ps[j]->nc, 1, o->fss, 0);
+		break;
+	      }
+	  if (j < o->pstr[i]->np)
+	    break;
+	}
+      if (i < o->pn)
+	continue;
+      for (i = 0; i < o->bn; i++)
+	if (o->bstr[i]->sw == c || (o->bstr[i]->nc >= 0 &&
+				    toupper (c) ==
+				    o->bstr[i]->header[o->bstr[i]->nc]))
+	  {
+	    e_pr_str (o->xa + o->bstr[i]->x, o->ya + o->bstr[i]->y,
+		      o->bstr[i]->header, o->fbz, o->bstr[i]->nc, -1, o->fbz,
+		      o->ftt);
+	    if (!sw)
+	      {
+		if (o->bstr[i]->fkt != NULL)
+		  {
+		    if ((ret = o->bstr[i]->fkt (o->f)) > 0)
+		      c = WPE_ESC;
+		    else
+		      {
+			c = cold;
+			e_pr_str (o->xa + o->bstr[i]->x,
+				  o->ya + o->bstr[i]->y, o->bstr[i]->header,
+				  o->fbt, o->bstr[i]->nc, -1, o->fbs, o->ftt);
+		      }
+		  }
+		else
+		  {
+		    ret = o->bstr[i]->sw;
+		    c = WPE_ESC;
+		  }
+		break;
+	      }
+	    cold = c;
+#if MOUSE
+	    if ((c = e_getch ()) < 0)
+	      c = e_opt_mouse (o);
+#else
+	    c = e_getch ();
+#endif
+	    if (c == WPE_CR)
+	      {
+		ret = c = o->bstr[i]->sw;
+		sw = 0;
+		break;
+	      }
+	    else if (c == WPE_ESC)
+	      {
+		sw = 0;
+		ret = WPE_ESC;
+		break;
+	      }
+	    csv = c;
+	    if ((c = e_get_opt_sw (c, o->xa + o->bstr[i]->x,
+				   o->ya + o->bstr[i]->y, o)) != csv)
+	      sw = 1;
+	    else
+	      sw = 0;
+	    if (c != cold)
+	      e_pr_str (o->xa + o->bstr[i]->x, o->ya + o->bstr[i]->y,
+			o->bstr[i]->header, o->fbt, o->bstr[i]->nc, -1,
+			o->fbs, o->ftt);
+	    break;
+	  }
+      if (i < o->bn)
+	continue;
 
       c = cold;
       sw = 1;
-   }
-   e_close_view(o->pic, 1);
-   return(ret);
+    }
+  e_close_view (o->pic, 1);
+  return (ret);
 }
 
-int e_edt_options(FENSTER *f)
+int
+e_edt_options (FENSTER * f)
 {
- int i, ret, edopt = f->ed->edopt;
- W_OPTSTR *o = e_init_opt_kst(f);
+  int i, ret, edopt = f->ed->edopt;
+  W_OPTSTR *o = e_init_opt_kst (f);
 
- if (!o) return(-1);
- o->xa = 15;  o->ya = 3;  o->xe = 64;  o->ye = 22;
- o->bgsw = AltO;
- o->name = "Editor-Options";
- o->crsw = AltO;
- e_add_txtstr(3, 2, "Display:", o);
- e_add_txtstr(25, 2, "Autosave:", o);
- e_add_txtstr(25, 6, "Keys:", o);
- e_add_txtstr(25, 10, "Auto-Indent:", o);
- e_add_txtstr(3, 5, "Tile:", o);
- e_add_numstr(3, 8, 19, 8, 3, 100, 0, AltM, "Max. Columns:", f->ed->maxcol, o);
- e_add_numstr(3, 9, 20, 9, 2, 100, 0, AltT, "Tabstops:", f->ed->tabn, o);
- e_add_numstr(3, 10, 19, 10, 3, 1000, 2, AltX, "MaX. Changes:", f->ed->maxchg, o);
- e_add_numstr(3, 11, 20, 11, 2, 100, 0, AltN, "Num. Undo:", f->ed->numundo, o);
- e_add_numstr(3, 12, 20, 12, 2, 100, 5, AltI, "Auto Ind. Col.:", f->ed->autoindent, o);
- e_add_sswstr(4, 3, 0, AltS, f->ed->edopt & ED_SHOW_ENDMARKS ? 1 : 0, "Show Endmark ", o);
- e_add_sswstr(26, 3, 1, AltP, f->ed->autosv & 1, "OPtions         ", o);
- e_add_sswstr(26, 4, 1, AltH, f->ed->autosv & 2 ? 1 : 0, "CHanges         ", o);
- e_add_sswstr(4, 6, 2, AltD, f->ed->edopt & ED_OLD_TILE_METHOD ? 1 : 0, "OlD Style    ", o);
- e_add_pswstr(0, 26, 7, 1, AltL, 0, "OLd-Style       ", o);
- e_add_pswstr(0, 26, 8, 0, AltC, f->ed->edopt & ED_CUA_STYLE, "CUA-Style       ", o);
- e_add_pswstr(1, 26, 11, 3, AltY, 0, "OnlY Source-Text", o);
- e_add_pswstr(1, 26, 12, 2, AltW, 0, "AlWays          ", o);
- e_add_pswstr(1, 26, 13, 2, AltV,
-   (f->ed->edopt & ED_ALWAYS_AUTO_INDENT ? 1 : f->ed->edopt & ED_SOURCE_AUTO_INDENT ? 0 : 2),
-   "NeVer           ", o);
- e_add_wrstr(3, 14, 3, 15, 44, 128, 1, AltR, "PRint Command:",
-   f->ed->print_cmd, NULL, o);
- e_add_bttstr(12, 17, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(31, 17, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
-  f->ed->autosv = o->sstr[1]->num + (o->sstr[2]->num << 1);
-  f->ed->maxcol = o->nstr[0]->num;
-  f->ed->tabn = o->nstr[1]->num;
-  f->ed->maxchg = o->nstr[2]->num;
-  f->ed->numundo = o->nstr[3]->num;
-  f->ed->autoindent = o->nstr[4]->num;
-  f->ed->edopt = ((f->ed->edopt & ~ED_EDITOR_OPTIONS) + o->pstr[0]->num) +
-    (o->pstr[1]->num == 0 ? ED_SOURCE_AUTO_INDENT : 0) +
-    (o->pstr[1]->num == 1 ? ED_ALWAYS_AUTO_INDENT : 0) +
-    (o->sstr[3]->num ? ED_OLD_TILE_METHOD : 0) +
-    (o->sstr[0]->num ? ED_SHOW_ENDMARKS : 0);
-  if (f->ed->print_cmd)
-   free(f->ed->print_cmd);
-  f->ed->print_cmd = WpeStrdup(o->wstr[0]->txt);
-  if (edopt != f->ed->edopt)
-  {
-   e_switch_blst(f->ed);
-   for (i = 0; i <= f->ed->mxedt; i++)
-    if ((f->ed->edopt & ED_ALWAYS_AUTO_INDENT) ||
-      ((f->ed->edopt & ED_SOURCE_AUTO_INDENT) && f->ed->f[i]->c_st))
-     f->ed->f[i]->flg = 1;
-    else
-     f->ed->f[i]->flg = 0;
-   e_repaint_desk(f);
-  }
- }
- freeostr(o);
- return(0);
+  if (!o)
+    return (-1);
+  o->xa = 15;
+  o->ya = 3;
+  o->xe = 64;
+  o->ye = 22;
+  o->bgsw = AltO;
+  o->name = "Editor-Options";
+  o->crsw = AltO;
+  e_add_txtstr (3, 2, "Display:", o);
+  e_add_txtstr (25, 2, "Autosave:", o);
+  e_add_txtstr (25, 6, "Keys:", o);
+  e_add_txtstr (25, 10, "Auto-Indent:", o);
+  e_add_txtstr (3, 5, "Tile:", o);
+  e_add_numstr (3, 8, 19, 8, 3, 100, 0, AltM, "Max. Columns:", f->ed->maxcol,
+		o);
+  e_add_numstr (3, 9, 20, 9, 2, 100, 0, AltT, "Tabstops:", f->ed->tabn, o);
+  e_add_numstr (3, 10, 19, 10, 3, 1000, 2, AltX, "MaX. Changes:",
+		f->ed->maxchg, o);
+  e_add_numstr (3, 11, 20, 11, 2, 100, 0, AltN, "Num. Undo:", f->ed->numundo,
+		o);
+  e_add_numstr (3, 12, 20, 12, 2, 100, 5, AltI, "Auto Ind. Col.:",
+		f->ed->autoindent, o);
+  e_add_sswstr (4, 3, 0, AltS, f->ed->edopt & ED_SHOW_ENDMARKS ? 1 : 0,
+		"Show Endmark ", o);
+  e_add_sswstr (26, 3, 1, AltP, f->ed->autosv & 1, "OPtions         ", o);
+  e_add_sswstr (26, 4, 1, AltH, f->ed->autosv & 2 ? 1 : 0, "CHanges         ",
+		o);
+  e_add_sswstr (4, 6, 2, AltD, f->ed->edopt & ED_OLD_TILE_METHOD ? 1 : 0,
+		"OlD Style    ", o);
+  e_add_pswstr (0, 26, 7, 1, AltL, 0, "OLd-Style       ", o);
+  e_add_pswstr (0, 26, 8, 0, AltC, f->ed->edopt & ED_CUA_STYLE,
+		"CUA-Style       ", o);
+  e_add_pswstr (1, 26, 11, 3, AltY, 0, "OnlY Source-Text", o);
+  e_add_pswstr (1, 26, 12, 2, AltW, 0, "AlWays          ", o);
+  e_add_pswstr (1, 26, 13, 2, AltV,
+		(f->ed->edopt & ED_ALWAYS_AUTO_INDENT ? 1 : f->ed->
+		 edopt & ED_SOURCE_AUTO_INDENT ? 0 : 2), "NeVer           ",
+		o);
+  e_add_wrstr (3, 14, 3, 15, 44, 128, 1, AltR, "PRint Command:",
+	       f->ed->print_cmd, NULL, o);
+  e_add_bttstr (12, 17, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (31, 17, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      f->ed->autosv = o->sstr[1]->num + (o->sstr[2]->num << 1);
+      f->ed->maxcol = o->nstr[0]->num;
+      f->ed->tabn = o->nstr[1]->num;
+      f->ed->maxchg = o->nstr[2]->num;
+      f->ed->numundo = o->nstr[3]->num;
+      f->ed->autoindent = o->nstr[4]->num;
+      f->ed->edopt = ((f->ed->edopt & ~ED_EDITOR_OPTIONS) + o->pstr[0]->num) +
+	(o->pstr[1]->num == 0 ? ED_SOURCE_AUTO_INDENT : 0) +
+	(o->pstr[1]->num == 1 ? ED_ALWAYS_AUTO_INDENT : 0) +
+	(o->sstr[3]->num ? ED_OLD_TILE_METHOD : 0) +
+	(o->sstr[0]->num ? ED_SHOW_ENDMARKS : 0);
+      if (f->ed->print_cmd)
+	free (f->ed->print_cmd);
+      f->ed->print_cmd = WpeStrdup (o->wstr[0]->txt);
+      if (edopt != f->ed->edopt)
+	{
+	  e_switch_blst (f->ed);
+	  for (i = 0; i <= f->ed->mxedt; i++)
+	    if ((f->ed->edopt & ED_ALWAYS_AUTO_INDENT) ||
+		((f->ed->edopt & ED_SOURCE_AUTO_INDENT) && f->ed->f[i]->c_st))
+	      f->ed->f[i]->flg = 1;
+	    else
+	      f->ed->f[i]->flg = 0;
+	  e_repaint_desk (f);
+	}
+    }
+  freeostr (o);
+  return (0);
 }
 
-int e_read_help_str()
+int
+e_read_help_str ()
 {
- FILE *fp;
- char str[128];
- int i, len;
+  FILE *fp;
+  char str[128];
+  int i, len;
 
- sprintf(str, "%s/help.key", LIBRARY_DIR);
- for (i = 0; i < E_HLP_NUM; i++)
- {
-  e_hlp_str[i] = malloc(sizeof(char));
-  *e_hlp_str[i] = '\0';
- }
- if (!(fp = fopen(str, "rb")))
-  return(-1);
- for (i = 0; i < E_HLP_NUM && fgets(str, 128, fp); i++)
- {
-  len = strlen(str);
-  if (str[len-1] == '\n')
-   str[--len] = '\0';
-  e_hlp_str[i] = realloc(e_hlp_str[i], (len+1)*sizeof(char));
-  strcpy(e_hlp_str[i], str);
- }
- fclose(fp);
- return(i == E_HLP_NUM ? 0 : -2);
+  sprintf (str, "%s/help.key", LIBRARY_DIR);
+  for (i = 0; i < E_HLP_NUM; i++)
+    {
+      e_hlp_str[i] = malloc (sizeof (char));
+      *e_hlp_str[i] = '\0';
+    }
+  if (!(fp = fopen (str, "rb")))
+    return (-1);
+  for (i = 0; i < E_HLP_NUM && fgets (str, 128, fp); i++)
+    {
+      len = strlen (str);
+      if (str[len - 1] == '\n')
+	str[--len] = '\0';
+      e_hlp_str[i] = realloc (e_hlp_str[i], (len + 1) * sizeof (char));
+      strcpy (e_hlp_str[i], str);
+    }
+  fclose (fp);
+  return (i == E_HLP_NUM ? 0 : -2);
 }
-

--- a/src/we_opt.h
+++ b/src/we_opt.h
@@ -7,45 +7,47 @@
 #include "we_xterm.h"
 
 /*   we_opt.c   */
-char *WpeStringToValue(const char *str);
-char *WpeValueToString(const char *value);
-int e_about_WE(FENSTER *f);
-int e_clear_desk(FENSTER *f);
-int e_repaint_desk(FENSTER *f);
-int e_sys_info(FENSTER *f);
-int e_ad_colors(FENSTER *f);
-int e_dif_colors(int sw, int xa, int ya, FENSTER *f, int md);
-void e_pr_dif_colors(int sw, int xa, int ya, FENSTER *f, int sw2, int md);
-void e_pr_x_col_kasten(int xa, int ya, int x, int y, FENSTER *f, int sw);
-void e_pr_ed_beispiel(int xa, int ya, FENSTER *f, int sw, int md);
-int e_opt_save(FENSTER *f);
-int e_save_opt(FENSTER *f);
-int e_opt_read(ECNT *cn);
-int e_add_arguments(char *str, char *head, FENSTER *f, int n, int sw,
-  struct dirfile **df);
-W_O_TXTSTR **e_add_txtstr(int x, int y, char *txt, W_OPTSTR *o);
-W_O_WRSTR **e_add_wrstr(int xt, int yt, int xw, int yw, int nw, int wmx,
-  int nc, int sw, char *header, char *txt, struct dirfile **df, W_OPTSTR *o);
-W_O_NUMSTR **e_add_numstr(int xt, int yt, int xw, int yw, int nw, int wmx,
-  int nc, int sw, char *header, int num, W_OPTSTR *o);
-W_O_SSWSTR **e_add_sswstr(int x, int y, int nc, int sw, int num,
-  char *header, W_OPTSTR *o);
-W_O_SPSWSTR **e_add_spswstr(int n, int x, int y, int nc, int sw,
-  char *header, W_OPTSTR *o);
-W_O_PSWSTR **e_add_pswstr(int n, int x, int y, int nc, int sw, int num,
-  char *header, W_OPTSTR *o);
-W_O_BTTSTR **e_add_bttstr(int x, int y, int nc, int sw, char *header,
-  int (*fkt)(FENSTER *f), W_OPTSTR *o);
-int freeostr(W_OPTSTR *o);
-W_OPTSTR *e_init_opt_kst(FENSTER *f);
-int e_opt_move(W_OPTSTR *o);
-int e_get_sw_cmp(int xin, int yin, int x, int y, int xmin, int ymin, int c);
-int e_get_opt_sw(int c, int x, int y, W_OPTSTR *o);
-int e_opt_kst(W_OPTSTR *o);
-int e_edt_options(FENSTER *f);
-int e_read_colors(FENSTER *f);
-int e_ad_colors_md(FENSTER *f, int md);
-int e_frb_x_menue(int sw, int xa, int ya, FENSTER *f, int md);
-void e_pr_x_col_kasten(int xa, int ya, int x, int y, FENSTER *f, int sw);
+char *WpeStringToValue (const char *str);
+char *WpeValueToString (const char *value);
+int e_about_WE (FENSTER * f);
+int e_clear_desk (FENSTER * f);
+int e_repaint_desk (FENSTER * f);
+int e_sys_info (FENSTER * f);
+int e_ad_colors (FENSTER * f);
+int e_dif_colors (int sw, int xa, int ya, FENSTER * f, int md);
+void e_pr_dif_colors (int sw, int xa, int ya, FENSTER * f, int sw2, int md);
+void e_pr_x_col_kasten (int xa, int ya, int x, int y, FENSTER * f, int sw);
+void e_pr_ed_beispiel (int xa, int ya, FENSTER * f, int sw, int md);
+int e_opt_save (FENSTER * f);
+int e_save_opt (FENSTER * f);
+int e_opt_read (ECNT * cn);
+int e_add_arguments (char *str, char *head, FENSTER * f, int n, int sw,
+		     struct dirfile **df);
+W_O_TXTSTR **e_add_txtstr (int x, int y, char *txt, W_OPTSTR * o);
+W_O_WRSTR **e_add_wrstr (int xt, int yt, int xw, int yw, int nw, int wmx,
+			 int nc, int sw, char *header, char *txt,
+			 struct dirfile **df, W_OPTSTR * o);
+W_O_NUMSTR **e_add_numstr (int xt, int yt, int xw, int yw, int nw, int wmx,
+			   int nc, int sw, char *header, int num,
+			   W_OPTSTR * o);
+W_O_SSWSTR **e_add_sswstr (int x, int y, int nc, int sw, int num,
+			   char *header, W_OPTSTR * o);
+W_O_SPSWSTR **e_add_spswstr (int n, int x, int y, int nc, int sw,
+			     char *header, W_OPTSTR * o);
+W_O_PSWSTR **e_add_pswstr (int n, int x, int y, int nc, int sw, int num,
+			   char *header, W_OPTSTR * o);
+W_O_BTTSTR **e_add_bttstr (int x, int y, int nc, int sw, char *header,
+			   int (*fkt) (FENSTER * f), W_OPTSTR * o);
+int freeostr (W_OPTSTR * o);
+W_OPTSTR *e_init_opt_kst (FENSTER * f);
+int e_opt_move (W_OPTSTR * o);
+int e_get_sw_cmp (int xin, int yin, int x, int y, int xmin, int ymin, int c);
+int e_get_opt_sw (int c, int x, int y, W_OPTSTR * o);
+int e_opt_kst (W_OPTSTR * o);
+int e_edt_options (FENSTER * f);
+int e_read_colors (FENSTER * f);
+int e_ad_colors_md (FENSTER * f, int md);
+int e_frb_x_menue (int sw, int xa, int ya, FENSTER * f, int md);
+void e_pr_x_col_kasten (int xa, int ya, int x, int y, FENSTER * f, int sw);
 
 #endif

--- a/src/we_prog.c
+++ b/src/we_prog.c
@@ -11,7 +11,7 @@
 #include "messages.h"
 #include "options.h"
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
-#  include "curses.h"
+#include "curses.h"
 #endif
 #include "edit.h"
 #include "we_prog.h"
@@ -29,20 +29,25 @@
 #include <sys/wait.h>
 #include <signal.h>
 
-#define CHECKHEADER	// moved from model.h, only in use in we_prog.c
+#define CHECKHEADER		// moved from model.h, only in use in we_prog.c
 
-int e_run_sh(FENSTER *f);
-int e_make_library(char *library, char *ofile, FENSTER *f);
-int e_p_exec(int file, FENSTER *f, view *pic);
+int e_run_sh (FENSTER * f);
+int e_make_library (char *library, char *ofile, FENSTER * f);
+int e_p_exec (int file, FENSTER * f, view * pic);
 
 int wfildes[2], efildes[2];
 char *wfile = NULL, *efile = NULL;
 
-struct e_s_prog e_s_prog = {  NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0};
+struct e_s_prog e_s_prog =
+  { NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0 };
 
-struct e_prog e_prog = {  0, NULL, NULL, NULL, NULL, NULL  };
+struct e_prog e_prog = { 0, NULL, NULL, NULL, NULL, NULL };
 
-struct ERR_LI  {  char *file, *text, *srch;  int x, y, line;  } *err_li = NULL;
+struct ERR_LI
+{
+  char *file, *text, *srch;
+  int x, y, line;
+} *err_li = NULL;
 int err_no, err_num;
 
 int e__project = 0, e_argc, e_p_l_comp;
@@ -59,582 +64,599 @@ extern char *e_tmp_dir;
 extern int e_d_swtch;
 #endif
 
-/********************************************************/   
+/********************************************************/
 /**** defs for breakpoints and watches manipulations ****/
 /*** breakpoints ***/
 extern int e_d_nbrpts;
-extern char ** e_d_sbrpts;
-extern int * e_d_ybrpts;
+extern char **e_d_sbrpts;
+extern int *e_d_ybrpts;
 
 /*** watches ***/
 extern int e_d_nwtchs;
-extern char ** e_d_swtchs;
-extern int * e_d_nrwtchs;
+extern char **e_d_swtchs;
+extern int *e_d_nrwtchs;
 
-/********************************************************/   
+/********************************************************/
 
-char *gnu_intstr = "${?*:warning:}${FILE}:${LINE}:* before `${COLUMN=BEFORE}\'*";
-char *cc_intstr = "${?*:warning:}\"${FILE}\", line ${LINE}:* at or near * \"${COLUMN=AFTER}\"";
-char *pc_intstr = "${?0:e}${?0:w}${?0:s}*:*:* * ${FILE}:\n\n* ${LINE}  ${CMPTEXT}\n*-------\
+char *gnu_intstr =
+  "${?*:warning:}${FILE}:${LINE}:* before `${COLUMN=BEFORE}\'*";
+char *cc_intstr =
+  "${?*:warning:}\"${FILE}\", line ${LINE}:* at or near * \"${COLUMN=AFTER}\"";
+char *pc_intstr =
+  "${?0:e}${?0:w}${?0:s}*:*:* * ${FILE}:\n\n* ${LINE}  ${CMPTEXT}\n*-------\
 ${COLUMN=PREVIOUS?^+14}\n[EWew] * line*";
 
 
 char *e_p_msg[] = {
- "Not a C - File",
- "Can\'t open Pipe",
- "Error in Process",
- "Error in Pipe\n Pipe Nr.: %d\n",
- "Error at Command: ",
- "Return-Code: %d",      /*   Number 5   */
- "%s is not a C - File",
- "No Compiler specified",
- "No Files to compile",
- "No Project-Window",
+  "Not a C - File",
+  "Can\'t open Pipe",
+  "Error in Process",
+  "Error in Pipe\n Pipe Nr.: %d\n",
+  "Error at Command: ",
+  "Return-Code: %d",		/*   Number 5   */
+  "%s is not a C - File",
+  "No Compiler specified",
+  "No Files to compile",
+  "No Project-Window",
 };
 
 
-int e_prog_switch(FENSTER *f, int c)
+int
+e_prog_switch (FENSTER * f, int c)
 {
- switch(c)
- {
-  case AltU:
-  case CF9:
-   e_run(f);
-   break;
-  case AltM:   /*  Alt M  Make */
-  case F9:
-   e_p_make(f);
-   break;
-  case AltC:   /*  Alt C  Compile */
-  case AF9:
-   e_compile(f);
-   break;
-  case AltL:   /*  Alt L  InstaLl */
-   e_install(f);
-   break;
-  case AltA:   /*  Alt A  Execute MAke */
-   e_exec_make(f);
-   break;
-  case AltT:   /*  Alt T  NexT Error */
-  case AF8:
-   e_next_error(f);
-   break;
-  case AltV:   /*  Alt V  PreVious Error  */
-  case AF7:
-   e_previous_error(f);
-   break;
+  switch (c)
+    {
+    case AltU:
+    case CF9:
+      e_run (f);
+      break;
+    case AltM:			/*  Alt M  Make */
+    case F9:
+      e_p_make (f);
+      break;
+    case AltC:			/*  Alt C  Compile */
+    case AF9:
+      e_compile (f);
+      break;
+    case AltL:			/*  Alt L  InstaLl */
+      e_install (f);
+      break;
+    case AltA:			/*  Alt A  Execute MAke */
+      e_exec_make (f);
+      break;
+    case AltT:			/*  Alt T  NexT Error */
+    case AF8:
+      e_next_error (f);
+      break;
+    case AltV:			/*  Alt V  PreVious Error  */
+    case AF7:
+      e_previous_error (f);
+      break;
 #ifdef DEBUGGER
-  case CtrlG:   /*  Ctrl G DebuG - Modus */
-   e_deb_inp(f);
-   break;
-  default:
-   return(e_debug_switch(f, c));
+    case CtrlG:		/*  Ctrl G DebuG - Modus */
+      e_deb_inp (f);
+      break;
+    default:
+      return (e_debug_switch (f, c));
 #else
-  default:
-   return(c);
+    default:
+      return (c);
 #endif
- }
- return(0);
+    }
+  return (0);
 }
 
-int e_compile(FENSTER *f)
+int
+e_compile (FENSTER * f)
 {
- int ret;
+  int ret;
 
- WpeMouseChangeShape(WpeWorkingShape);
- efildes[0] = efildes[1] = -1;
- wfildes[0] = wfildes[1] = -1;
- ret = e_comp(f);
- WpeMouseRestoreShape();
- return(ret);
+  WpeMouseChangeShape (WpeWorkingShape);
+  efildes[0] = efildes[1] = -1;
+  wfildes[0] = wfildes[1] = -1;
+  ret = e_comp (f);
+  WpeMouseRestoreShape ();
+  return (ret);
 }
 
-int e_p_make(FENSTER *f)
+int
+e_p_make (FENSTER * f)
 {
- ECNT *cn = f->ed;
- char ostr[128], estr[128], mstr[80];
- int len, i, file = -1;
- struct stat cbuf[1], obuf[1];
- view *pic = NULL;
- int linkRequest = 1; /* assume linking has to be done */
+  ECNT *cn = f->ed;
+  char ostr[128], estr[128], mstr[80];
+  int len, i, file = -1;
+  struct stat cbuf[1], obuf[1];
+  view *pic = NULL;
+  int linkRequest = 1;		/* assume linking has to be done */
 
- WpeMouseChangeShape(WpeWorkingShape);
- efildes[0] = efildes[1] = -1;
- wfildes[0] = wfildes[1] = -1;
- if (e_comp(f))
- {
-  WpeMouseRestoreShape();
-  return(-1);
- }
- f = cn->f[cn->mxedt-1];
- if (!e__project)
- {
-  e_arg = malloc(6 * sizeof(char *));
-  e_argc = e_make_arg(&e_arg, e_s_prog.libraries);
-  e_arg[1] = malloc(3);
-  strcpy(e_arg[1], "-o");
-  strcpy(mstr, f->datnam);
-  WpeStringCutChar(mstr, '.');
-  len = strlen(e_prog.exedir) - 1;
-  if (e_s_prog.exe_name && e_s_prog.exe_name[0])
-  {
-   if (e_prog.exedir[len] == DIRC)
-    sprintf(estr, "%s%s", e_prog.exedir, e_s_prog.exe_name);
-   else
-    sprintf(estr, "%s%c%s", e_prog.exedir, DIRC, e_s_prog.exe_name);
-  }
+  WpeMouseChangeShape (WpeWorkingShape);
+  efildes[0] = efildes[1] = -1;
+  wfildes[0] = wfildes[1] = -1;
+  if (e_comp (f))
+    {
+      WpeMouseRestoreShape ();
+      return (-1);
+    }
+  f = cn->f[cn->mxedt - 1];
+  if (!e__project)
+    {
+      e_arg = malloc (6 * sizeof (char *));
+      e_argc = e_make_arg (&e_arg, e_s_prog.libraries);
+      e_arg[1] = malloc (3);
+      strcpy (e_arg[1], "-o");
+      strcpy (mstr, f->datnam);
+      WpeStringCutChar (mstr, '.');
+      len = strlen (e_prog.exedir) - 1;
+      if (e_s_prog.exe_name && e_s_prog.exe_name[0])
+	{
+	  if (e_prog.exedir[len] == DIRC)
+	    sprintf (estr, "%s%s", e_prog.exedir, e_s_prog.exe_name);
+	  else
+	    sprintf (estr, "%s%c%s", e_prog.exedir, DIRC, e_s_prog.exe_name);
+	}
+      else
+	{
+	  if (e_prog.exedir[len] == DIRC)
+	    sprintf (estr, "%s%s.e", e_prog.exedir, mstr);
+	  else
+	    sprintf (estr, "%s%c%s.e", e_prog.exedir, DIRC, mstr);
+	}
+      if (e_prog.exedir[len] == DIRC)
+	sprintf (ostr, "%s%s.o", e_prog.exedir, mstr);
+      else
+	sprintf (ostr, "%s%c%s.o", e_prog.exedir, DIRC, mstr);
+      e_argc = e_add_arg (&e_arg, estr, 2, e_argc);
+      e_argc = e_add_arg (&e_arg, ostr, 3, e_argc);
+      stat (ostr, cbuf);
+      if (!stat (estr, obuf) && obuf->st_mtime >= cbuf->st_mtime)
+	linkRequest = 0;
+    }
   else
-  {
-   if (e_prog.exedir[len] == DIRC)
-    sprintf(estr, "%s%s.e", e_prog.exedir, mstr);
-   else
-    sprintf(estr, "%s%c%s.e", e_prog.exedir, DIRC, mstr);
-  }
-  if (e_prog.exedir[len] == DIRC)
-   sprintf(ostr, "%s%s.o", e_prog.exedir, mstr);
+    {
+      if (!stat (e_s_prog.exe_name, obuf) && !e_p_l_comp &&
+	  obuf->st_mtime >= last_time)
+	linkRequest = 0;
+    }
+  if (linkRequest)
+    {
+#ifdef DEBUGGER
+      if (e_d_swtch > 0)
+	e_d_quit (f);
+#endif
+      if (!e_p_mess_win ("Linking", e_argc, e_arg, &pic, f))
+	{
+	  (*e_u_sys_ini) ();
+	  file = e_exec_inf (f, e_arg, e_argc);
+	  (*e_u_sys_end) ();
+	}
+      else
+	file = 0;
+    }
+  if (!e__project)
+    {
+      e_free_arg (e_arg, e_argc);
+    }
+  if (file != 0)
+    i = e_p_exec (file, f, pic);
   else
-   sprintf(ostr, "%s%c%s.o", e_prog.exedir, DIRC, mstr);
-  e_argc = e_add_arg(&e_arg, estr, 2, e_argc);
-  e_argc = e_add_arg(&e_arg, ostr, 3, e_argc);
-  stat(ostr, cbuf);
-  if (!stat(estr, obuf) && obuf->st_mtime >= cbuf->st_mtime)
-   linkRequest = 0;
- }
- else
- {
-  if (!stat(e_s_prog.exe_name, obuf) && !e_p_l_comp &&
-    obuf->st_mtime >= last_time)
-   linkRequest = 0;
- }
- if (linkRequest)
- {
+    {
+      i = WPE_ESC;
+      if (pic)
+	e_close_view (pic, 1);
+    }
+  WpeMouseRestoreShape ();
+  return (i);
+}
+
+int
+e_run (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  BUFFER *b;
+  char estr[256];
+  int len, ret;
+
+  efildes[0] = efildes[1] = -1;
+  wfildes[0] = wfildes[1] = -1;
+  if (!e_run_sh (f))
+    return (0);
+  if (e_p_make (f))
+    return (-1);
+  WpeMouseChangeShape (WpeWorkingShape);
+  f = cn->f[cn->mxedt - 1];
 #ifdef DEBUGGER
   if (e_d_swtch > 0)
-   e_d_quit(f);
+    e_d_quit (f);
 #endif
-  if (!e_p_mess_win("Linking", e_argc, e_arg, &pic, f))
-  {
-   (*e_u_sys_ini)();
-   file = e_exec_inf(f, e_arg, e_argc);
-   (*e_u_sys_end)();
-  }
-  else
-   file = 0;
- }
- if (!e__project)
- {
-  e_free_arg(e_arg, e_argc);
- }
- if (file != 0)
-  i = e_p_exec(file, f, pic);
- else
- {
-  i = WPE_ESC;
-  if (pic)
-   e_close_view(pic, 1);
- }
- WpeMouseRestoreShape();
- return(i);
-}
-
-int e_run(FENSTER *f)
-{
- ECNT *cn = f->ed;
- BUFFER *b;
- char estr[256];
- int len, ret;
-
- efildes[0] = efildes[1] = -1;
- wfildes[0] = wfildes[1] = -1;
- if (!e_run_sh(f))
-  return(0);
- if (e_p_make(f))
-  return(-1);
- WpeMouseChangeShape(WpeWorkingShape);
- f = cn->f[cn->mxedt-1];
-#ifdef DEBUGGER
- if (e_d_swtch > 0)
-  e_d_quit(f);
-#endif
- estr[0] = '\0';
- if ((!e_s_prog.exe_name) || (e_s_prog.exe_name[0]!=DIRC))
- {
-  strcat(estr, e_prog.exedir);
-  len = strlen(estr) - 1;
-  if (estr[len] != DIRC)
-  {
-   estr[++len] = DIRC;
-   estr[++len] = '\0';
-  }
- }
- if (e_s_prog.exe_name && e_s_prog.exe_name[0])
- {
-  strcat(estr, e_s_prog.exe_name);
- }
- else if (!e__project)
- {
-  /* Default executable name of the source file - extension + ".e" */
-  strcat(estr, f->datnam);
-  WpeStringCutChar(estr, '.');
-  strcat(estr, ".e");
- }
- else /* Default project executable name of "a.out" */
-  strcat(estr, "a.out");
- strcat(estr, " ");
- if (e_prog.arguments)
-  strcat(estr, e_prog.arguments);
+  estr[0] = '\0';
+  if ((!e_s_prog.exe_name) || (e_s_prog.exe_name[0] != DIRC))
+    {
+      strcat (estr, e_prog.exedir);
+      len = strlen (estr) - 1;
+      if (estr[len] != DIRC)
+	{
+	  estr[++len] = DIRC;
+	  estr[++len] = '\0';
+	}
+    }
+  if (e_s_prog.exe_name && e_s_prog.exe_name[0])
+    {
+      strcat (estr, e_s_prog.exe_name);
+    }
+  else if (!e__project)
+    {
+      /* Default executable name of the source file - extension + ".e" */
+      strcat (estr, f->datnam);
+      WpeStringCutChar (estr, '.');
+      strcat (estr, ".e");
+    }
+  else				/* Default project executable name of "a.out" */
+    strcat (estr, "a.out");
+  strcat (estr, " ");
+  if (e_prog.arguments)
+    strcat (estr, e_prog.arguments);
 #ifndef NO_XWINDOWS
- if (WpeIsXwin())
-  ret = (*e_u_system)(estr);
- else
-#endif
-  ret = e_system(estr, cn);
- f = cn->f[cn->mxedt];
- b = cn->f[cn->mxedt]->b;
-
- sprintf(estr, e_p_msg[ERR_RETCODE], ret);
- print_to_end_of_buffer(b, estr, b->mx.x);
-
- b->b.y = b->mxlines-1;
- e_cursor(f, 1);
- e_schirm(f, 1);
- e_refresh();
- WpeMouseRestoreShape();
- return(0);
-}
-
-int e_comp(FENSTER *f)
-{
- ECNT *cn = f->ed;
- view *pic = NULL;
- char **arg = NULL, fstr[128], ostr[128];
- int i, file = -1, len, argc;
-#ifdef CHECKHEADER
- struct stat obuf[1];
-#else
- struct stat cbuf[1], obuf[1];
-#endif
-
-#ifdef DEBUGGER
- if (e_d_swtch > 0)
- {
-  i = e_message(1, "The Debugger is Running\nDo You want to Quit Debugging ?",f);
-  if (i == 'Y')
-   e_d_quit(f);
+  if (WpeIsXwin ())
+    ret = (*e_u_system) (estr);
   else
-   return(-1);
-  WpeMouseChangeShape(WpeWorkingShape);
- }
 #endif
- if (e_prog.project[0] && !access(e_prog.project, 0))
-  e__project = 1;
- else
-  e__project = 0;
- if (e__project)
-  return(e_c_project(f));
- for (i = cn->mxedt; i > 0; i--)
- {
-  if (e_check_c_file(cn->f[i]->datnam))
-   break;
- }
- if (i == 0)
- {
-  sprintf(ostr, e_p_msg[ERR_S_NO_CFILE], f->datnam);
-  e_error(ostr, 0, f->fb);
-  return(WPE_ESC);
- }
- else if (cn->f[i]->save)
-  e_save(cn->f[i]);
- f = cn->f[i];
- e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
- if (e_new_message(f))
-  return(WPE_ESC);
- argc = e_make_arg(&arg, e_s_prog.comp_str);
- arg[1] = malloc(3);
- strcpy(arg[1], "-c");
- len = strlen(f->dirct) - 1;
- if (!strcmp(f->ed->dirct, f->dirct))
-  strcpy(fstr, f->datnam);
- if (f->dirct[len] == DIRC)
-  sprintf(fstr, "%s%s", f->dirct, f->datnam);
- else
-  sprintf(fstr, "%s%c%s", f->dirct, DIRC, f->datnam);
- argc = e_add_arg(&arg, fstr, argc, argc);
- if (e_prog.exedir[strlen(e_prog.exedir)-1] == DIRC)
-  sprintf(ostr, "%s%s", e_prog.exedir, f->datnam);
- else
-  sprintf(ostr, "%s%c%s", e_prog.exedir, DIRC, f->datnam);
- WpeStringCutChar(ostr, '.');
- strcat(ostr, ".o");
-#ifndef NO_MINUS_C_MINUS_O
- argc = e_add_arg(&arg, "-o", argc, argc);
- argc = e_add_arg(&arg, ostr, argc, argc);
-#endif
- (*e_u_sys_ini)();
+    ret = e_system (estr, cn);
+  f = cn->f[cn->mxedt];
+  b = cn->f[cn->mxedt]->b;
+
+  sprintf (estr, e_p_msg[ERR_RETCODE], ret);
+  print_to_end_of_buffer (b, estr, b->mx.x);
+
+  b->b.y = b->mxlines - 1;
+  e_cursor (f, 1);
+  e_schirm (f, 1);
+  e_refresh ();
+  WpeMouseRestoreShape ();
+  return (0);
+}
+
+int
+e_comp (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  view *pic = NULL;
+  char **arg = NULL, fstr[128], ostr[128];
+  int i, file = -1, len, argc;
 #ifdef CHECKHEADER
- if ((stat(ostr, obuf) || e_check_header(fstr, obuf->st_mtime, cn, 0)))
+  struct stat obuf[1];
 #else
- stat(f->datnam, cbuf);
- if ((stat(ostr, obuf) || obuf->st_mtime < cbuf->st_mtime))
+  struct stat cbuf[1], obuf[1];
 #endif
- {
-  remove(ostr);
-  if (!e_p_mess_win("Compiling", argc, arg, &pic, f) &&
-    (file = e_exec_inf(f, arg, argc)) == 0)
-  {
-   (*e_u_sys_end)();
-   e_free_arg(arg, argc);
-   if (pic)
-    e_close_view(pic, 1);
-   return(WPE_ESC);
-  }
- }
- (*e_u_sys_end)();
- e_free_arg(arg, argc);
- i = e_p_exec(file, f, pic);
- return(i);
-}
 
-int e_exec_inf(FENSTER *f, char **argv, int n)
-{
- int pid;
- char tstr[128];
 #ifdef DEBUGGER
- if (e_d_swtch > 0)
-  e_d_quit(f);
+  if (e_d_swtch > 0)
+    {
+      i =
+	e_message (1,
+		   "The Debugger is Running\nDo You want to Quit Debugging ?",
+		   f);
+      if (i == 'Y')
+	e_d_quit (f);
+      else
+	return (-1);
+      WpeMouseChangeShape (WpeWorkingShape);
+    }
 #endif
- fflush(stdout);
- sprintf(tstr, "%s/we_111", e_tmp_dir);
- if((efildes[1] = creat(tstr, 0777)) < 0)
- {
-  e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-  return(0);
- }
- if((efildes[0] = open(tstr, O_RDONLY)) < 0 )
- {
-  e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-  return(0);
- }
- efile = malloc((strlen(tstr)+1)*sizeof(char));
- strcpy(efile, tstr);
- sprintf(tstr, "%s/we_112", e_tmp_dir);
- if((wfildes[1] = creat(tstr, 0777)) < 0)
- {
-  e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-  return(0);
- }
- if((wfildes[0] = open(tstr, O_RDONLY)) < 0 )
- {
-  e_error(e_p_msg[ERR_PIPEOPEN], 0, f->fb);
-  return(0);
- }
- wfile = malloc((strlen(tstr)+1)*sizeof(char));
- strcpy(wfile, tstr);
-
- if((e_save_pid = pid = fork()) > 0)
-  return(efildes[1]);
- else if(pid < 0)
- {
-  e_error(e_p_msg[ERR_PROCESS], 0, f->fb);
-  return(0);
- }
-
- close(2);   /*  new process   */
- if(fcntl(efildes[1], F_DUPFD, 2) != 2)
- {
-  fprintf(stderr, e_p_msg[ERR_PIPEEXEC], efildes[1]);
-  exit(1);
- }
- close(1);
- if(fcntl(wfildes[1], F_DUPFD, 1) != 1)
- {
-  fprintf(stderr, e_p_msg[ERR_PIPEEXEC], wfildes[1]);
-  exit(1);
- }
- e_print_arg(stderr, "", argv, n);
- execvp(argv[0], argv);
- e_print_arg(stderr, e_p_msg[ERR_IN_COMMAND], argv, n);
- exit(1);
- /* Can never get here */
- return 0;
+  if (e_prog.project[0] && !access (e_prog.project, 0))
+    e__project = 1;
+  else
+    e__project = 0;
+  if (e__project)
+    return (e_c_project (f));
+  for (i = cn->mxedt; i > 0; i--)
+    {
+      if (e_check_c_file (cn->f[i]->datnam))
+	break;
+    }
+  if (i == 0)
+    {
+      sprintf (ostr, e_p_msg[ERR_S_NO_CFILE], f->datnam);
+      e_error (ostr, 0, f->fb);
+      return (WPE_ESC);
+    }
+  else if (cn->f[i]->save)
+    e_save (cn->f[i]);
+  f = cn->f[i];
+  e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+  if (e_new_message (f))
+    return (WPE_ESC);
+  argc = e_make_arg (&arg, e_s_prog.comp_str);
+  arg[1] = malloc (3);
+  strcpy (arg[1], "-c");
+  len = strlen (f->dirct) - 1;
+  if (!strcmp (f->ed->dirct, f->dirct))
+    strcpy (fstr, f->datnam);
+  if (f->dirct[len] == DIRC)
+    sprintf (fstr, "%s%s", f->dirct, f->datnam);
+  else
+    sprintf (fstr, "%s%c%s", f->dirct, DIRC, f->datnam);
+  argc = e_add_arg (&arg, fstr, argc, argc);
+  if (e_prog.exedir[strlen (e_prog.exedir) - 1] == DIRC)
+    sprintf (ostr, "%s%s", e_prog.exedir, f->datnam);
+  else
+    sprintf (ostr, "%s%c%s", e_prog.exedir, DIRC, f->datnam);
+  WpeStringCutChar (ostr, '.');
+  strcat (ostr, ".o");
+#ifndef NO_MINUS_C_MINUS_O
+  argc = e_add_arg (&arg, "-o", argc, argc);
+  argc = e_add_arg (&arg, ostr, argc, argc);
+#endif
+  (*e_u_sys_ini) ();
+#ifdef CHECKHEADER
+  if ((stat (ostr, obuf) || e_check_header (fstr, obuf->st_mtime, cn, 0)))
+#else
+  stat (f->datnam, cbuf);
+  if ((stat (ostr, obuf) || obuf->st_mtime < cbuf->st_mtime))
+#endif
+    {
+      remove (ostr);
+      if (!e_p_mess_win ("Compiling", argc, arg, &pic, f) &&
+	  (file = e_exec_inf (f, arg, argc)) == 0)
+	{
+	  (*e_u_sys_end) ();
+	  e_free_arg (arg, argc);
+	  if (pic)
+	    e_close_view (pic, 1);
+	  return (WPE_ESC);
+	}
+    }
+  (*e_u_sys_end) ();
+  e_free_arg (arg, argc);
+  i = e_p_exec (file, f, pic);
+  return (i);
 }
 
-int e_print_arg(FILE *fp, char *s, char **argv, int n)
+int
+e_exec_inf (FENSTER * f, char **argv, int n)
 {
- int i;
+  int pid;
+  char tstr[128];
+#ifdef DEBUGGER
+  if (e_d_swtch > 0)
+    e_d_quit (f);
+#endif
+  fflush (stdout);
+  sprintf (tstr, "%s/we_111", e_tmp_dir);
+  if ((efildes[1] = creat (tstr, 0777)) < 0)
+    {
+      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+      return (0);
+    }
+  if ((efildes[0] = open (tstr, O_RDONLY)) < 0)
+    {
+      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+      return (0);
+    }
+  efile = malloc ((strlen (tstr) + 1) * sizeof (char));
+  strcpy (efile, tstr);
+  sprintf (tstr, "%s/we_112", e_tmp_dir);
+  if ((wfildes[1] = creat (tstr, 0777)) < 0)
+    {
+      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+      return (0);
+    }
+  if ((wfildes[0] = open (tstr, O_RDONLY)) < 0)
+    {
+      e_error (e_p_msg[ERR_PIPEOPEN], 0, f->fb);
+      return (0);
+    }
+  wfile = malloc ((strlen (tstr) + 1) * sizeof (char));
+  strcpy (wfile, tstr);
 
- if ((s) && (s[0]))
-  fprintf(fp,"%s ", s);
- for (i = 0; i < n && argv[i] != NULL; i++)
-  fprintf(fp,"%s ", argv[i]);
- fprintf(fp,"\n");
- return(n);
+  if ((e_save_pid = pid = fork ()) > 0)
+    return (efildes[1]);
+  else if (pid < 0)
+    {
+      e_error (e_p_msg[ERR_PROCESS], 0, f->fb);
+      return (0);
+    }
+
+  close (2);			/*  new process   */
+  if (fcntl (efildes[1], F_DUPFD, 2) != 2)
+    {
+      fprintf (stderr, e_p_msg[ERR_PIPEEXEC], efildes[1]);
+      exit (1);
+    }
+  close (1);
+  if (fcntl (wfildes[1], F_DUPFD, 1) != 1)
+    {
+      fprintf (stderr, e_p_msg[ERR_PIPEEXEC], wfildes[1]);
+      exit (1);
+    }
+  e_print_arg (stderr, "", argv, n);
+  execvp (argv[0], argv);
+  e_print_arg (stderr, e_p_msg[ERR_IN_COMMAND], argv, n);
+  exit (1);
+  /* Can never get here */
+  return 0;
 }
 
-int e_p_exec(int file, FENSTER *f, view *pic)
+int
+e_print_arg (FILE * fp, char *s, char **argv, int n)
 {
- UNUSED(file);
- ECNT *cn = f->ed;
- BUFFER *b = cn->f[cn->mxedt]->b;
- int ret = 0, i = 0, is, fd, stat_loc;
- char str[128];
- char *buff;
+  int i;
 
- f = cn->f[cn->mxedt];
- while ((ret = wait(&stat_loc)) >= 0 && ret != e_save_pid)
-  ;
- ret = 0;
- for (is = b->mxlines-1, fd = efildes[0]; fd > 0; fd = wfildes[0])
- {
-  buff=malloc(1);
-  buff[0]='\0';
-  while( e_line_read(fd, str, 128) == 0 )
-  {
-   buff=realloc(buff, strlen(buff) + strlen(str) + 1);
-   strcat(buff, str);
+  if ((s) && (s[0]))
+    fprintf (fp, "%s ", s);
+  for (i = 0; i < n && argv[i] != NULL; i++)
+    fprintf (fp, "%s ", argv[i]);
+  fprintf (fp, "\n");
+  return (n);
+}
 
-   fflush(stdout);
-  }
-  print_to_end_of_buffer(b, buff, b->mx.x);
-  free(buff);
+int
+e_p_exec (int file, FENSTER * f, view * pic)
+{
+  UNUSED (file);
+  ECNT *cn = f->ed;
+  BUFFER *b = cn->f[cn->mxedt]->b;
+  int ret = 0, i = 0, is, fd, stat_loc;
+  char str[128];
+  char *buff;
 
-  if( fd == wfildes[0] )
-    break;
- }
- b->b.y = b->mxlines-1;
- if (efildes[0] >= 0)
-  close(efildes[0]);
- if (wfildes[0] >= 0)
-  close(wfildes[0]);
- if (efildes[1] >= 0)
-  close(efildes[0]);
- if (wfildes[1] >= 0)
-  close(wfildes[0]);
- if (wfile)
- {
-  remove(wfile);
-  free(wfile);
-  wfile = NULL;
- }
- if (efile)
- {
-  remove(efile);
-  free(efile);
-  efile = NULL;
- }
- efildes[0] = efildes[1] = -1;
- wfildes[0] = wfildes[1] = -1;
- if (pic)
-  e_close_view(pic, 1);
- if (ret || (b->mxlines - is > 2 && (i = e_make_error_list(f))))
- {
-  if (i != -2 && !ret)
-   e_show_error(err_no = 0, f);
-  return(-1);
- }
+  f = cn->f[cn->mxedt];
+  while ((ret = wait (&stat_loc)) >= 0 && ret != e_save_pid)
+    ;
+  ret = 0;
+  for (is = b->mxlines - 1, fd = efildes[0]; fd > 0; fd = wfildes[0])
+    {
+      buff = malloc (1);
+      buff[0] = '\0';
+      while (e_line_read (fd, str, 128) == 0)
+	{
+	  buff = realloc (buff, strlen (buff) + strlen (str) + 1);
+	  strcat (buff, str);
 
- print_to_end_of_buffer(b, "Success", b->mx.x);
+	  fflush (stdout);
+	}
+      print_to_end_of_buffer (b, buff, b->mx.x);
+      free (buff);
 
- e_cursor(f, 1);
- e_schirm(f, 1);
- e_refresh();
- return(0);
+      if (fd == wfildes[0])
+	break;
+    }
+  b->b.y = b->mxlines - 1;
+  if (efildes[0] >= 0)
+    close (efildes[0]);
+  if (wfildes[0] >= 0)
+    close (wfildes[0]);
+  if (efildes[1] >= 0)
+    close (efildes[0]);
+  if (wfildes[1] >= 0)
+    close (wfildes[0]);
+  if (wfile)
+    {
+      remove (wfile);
+      free (wfile);
+      wfile = NULL;
+    }
+  if (efile)
+    {
+      remove (efile);
+      free (efile);
+      efile = NULL;
+    }
+  efildes[0] = efildes[1] = -1;
+  wfildes[0] = wfildes[1] = -1;
+  if (pic)
+    e_close_view (pic, 1);
+  if (ret || (b->mxlines - is > 2 && (i = e_make_error_list (f))))
+    {
+      if (i != -2 && !ret)
+	e_show_error (err_no = 0, f);
+      return (-1);
+    }
+
+  print_to_end_of_buffer (b, "Success", b->mx.x);
+
+  e_cursor (f, 1);
+  e_schirm (f, 1);
+  e_refresh ();
+  return (0);
 }
 
 /* show source-position of error number "n" from actual errorlist */
-int e_show_error(int n, FENSTER *f)
+int
+e_show_error (int n, FENSTER * f)
 {
- ECNT *cn = f->ed;
- BUFFER *b = cn->f[cn->mxedt]->b;
- int i, j, bg = 0;
- char *filename;
- unsigned char *cp;
+  ECNT *cn = f->ed;
+  BUFFER *b = cn->f[cn->mxedt]->b;
+  int i, j, bg = 0;
+  char *filename;
+  unsigned char *cp;
 
- if (!err_li || n >= err_num || n < 0)
-  return(1);
- f = cn->f[cn->mxedt];
- if (err_li[n].file[0] == '.' && err_li[n].file[1] == DIRC)
-  bg = 2;
- if (err_li[n].file[0] == DIRC)
- {
-  filename = e_mkfilename(f->dirct, f->datnam);
- }
- else
-  filename = f->datnam;
- if (strcmp(err_li[n].file+bg, filename))
- {
-  for (i = cn->mxedt - 1; i > 0; i--)
-  {
-   if (filename != cn->f[i+1]->datnam)
-   {
-    free(filename);
-    filename = e_mkfilename(cn->f[i]->dirct, cn->f[i]->datnam);
-   }
-   else
-    filename = cn->f[i]->datnam;
-   if (!strcmp(err_li[n].file+bg, filename))
-   {
-    if (filename != cn->f[i]->datnam)
-     free(filename);
-    e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-    break;  
-   }
-  }
-  if (i <= 0)
-  {
-   if (filename != cn->f[i+1]->datnam)
-    free(filename); 
-   if (e_edit(cn, err_li[n].file))
-    return(WPE_ESC);
-  }
- }
- else if (filename != f->datnam)
-  free(filename);
- e_pr_str_wsd(1, MAXSLNS - 1, err_li[n].text, f->fb->mt.fb, -1, 0,
-   f->fb->mt.fb, 1, MAXSCOL-2);
+  if (!err_li || n >= err_num || n < 0)
+    return (1);
+  f = cn->f[cn->mxedt];
+  if (err_li[n].file[0] == '.' && err_li[n].file[1] == DIRC)
+    bg = 2;
+  if (err_li[n].file[0] == DIRC)
+    {
+      filename = e_mkfilename (f->dirct, f->datnam);
+    }
+  else
+    filename = f->datnam;
+  if (strcmp (err_li[n].file + bg, filename))
+    {
+      for (i = cn->mxedt - 1; i > 0; i--)
+	{
+	  if (filename != cn->f[i + 1]->datnam)
+	    {
+	      free (filename);
+	      filename = e_mkfilename (cn->f[i]->dirct, cn->f[i]->datnam);
+	    }
+	  else
+	    filename = cn->f[i]->datnam;
+	  if (!strcmp (err_li[n].file + bg, filename))
+	    {
+	      if (filename != cn->f[i]->datnam)
+		free (filename);
+	      e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	      break;
+	    }
+	}
+      if (i <= 0)
+	{
+	  if (filename != cn->f[i + 1]->datnam)
+	    free (filename);
+	  if (e_edit (cn, err_li[n].file))
+	    return (WPE_ESC);
+	}
+    }
+  else if (filename != f->datnam)
+    free (filename);
+  e_pr_str_wsd (1, MAXSLNS - 1, err_li[n].text, f->fb->mt.fb, -1, 0,
+		f->fb->mt.fb, 1, MAXSCOL - 2);
 /*   e_pr_nstr(2, MAXSLNS - 1, MAXSCOL-2, err_li[n].text,
                                                 f->fb->mt.fb, f->fb->mt.fb); */
- b = cn->f[cn->mxedt]->b;
- b->b.y = err_li[n].line > b->mxlines ? b->mxlines - 1 : err_li[n].line - 1;
- if (!err_li[n].srch)
- {
-  for(i = j = 0; i + j < err_li[n].x && i < b->bf[b->b.y].len; i++)
-  {
-   if (*(b->bf[b->b.y].s + i) == WPE_TAB)
-    j += (f->ed->tabn - ((j + i) % f->ed->tabn) - 1);
+  b = cn->f[cn->mxedt]->b;
+  b->b.y = err_li[n].line > b->mxlines ? b->mxlines - 1 : err_li[n].line - 1;
+  if (!err_li[n].srch)
+    {
+      for (i = j = 0; i + j < err_li[n].x && i < b->bf[b->b.y].len; i++)
+	{
+	  if (*(b->bf[b->b.y].s + i) == WPE_TAB)
+	    j += (f->ed->tabn - ((j + i) % f->ed->tabn) - 1);
 #ifdef UNIX
-   else if (((unsigned char) *(b->bf[b->b.y].s + i)) > 126)
-   {
-    j++;
-    if (((unsigned char) *(b->bf[b->b.y].s + i)) < 128 + ' ')
-     j++;
-   }
-   else if (*(b->bf[b->b.y].s + i) < ' ')
-    j++;
+	  else if (((unsigned char) *(b->bf[b->b.y].s + i)) > 126)
+	    {
+	      j++;
+	      if (((unsigned char) *(b->bf[b->b.y].s + i)) < 128 + ' ')
+		j++;
+	    }
+	  else if (*(b->bf[b->b.y].s + i) < ' ')
+	    j++;
 #endif
-  }
-  b->b.x = i;
- }
- else
- {
-  cp = (unsigned char *)strstr((const char *)b->bf[b->b.y].s, err_li[n].srch+1);
-  for (i = 0; b->bf[b->b.y].s + i < cp; i++);
-  if (err_li[n].srch[0] == 'B')
-  {
-   for (i--; i >= 0 && isspace(b->bf[b->b.y].s[i]); i--);
-   if (i < 0 && b->b.y > 0)
-   {
-    (b->b.y)--;
-    i = b->bf[b->b.y].len+1;
-   }
-   else
-    i++;
-  }
+	}
+      b->b.x = i;
+    }
+  else
+    {
+      cp =
+	(unsigned char *) strstr ((const char *) b->bf[b->b.y].s,
+				  err_li[n].srch + 1);
+      for (i = 0; b->bf[b->b.y].s + i < cp; i++);
+      if (err_li[n].srch[0] == 'B')
+	{
+	  for (i--; i >= 0 && isspace (b->bf[b->b.y].s[i]); i--);
+	  if (i < 0 && b->b.y > 0)
+	    {
+	      (b->b.y)--;
+	      i = b->bf[b->b.y].len + 1;
+	    }
+	  else
+	    i++;
+	}
 /*      else if(err_li[n].x < -1) i++;    */
-  b->b.x = i +  err_li[n].x;
- }
- e_cursor(cn->f[cn->mxedt],1);
- return(0);
+      b->b.x = i + err_li[n].x;
+    }
+  e_cursor (cn->f[cn->mxedt], 1);
+  return (0);
 }
 
 /**
@@ -647,821 +669,922 @@ int e_show_error(int n, FENSTER *f)
  * using ch = ':'.
  *
  */
-int e_pure_bin(char *str, int ch)
+int
+e_pure_bin (char *str, int ch)
 {
- int i;
+  int i;
 
- for (i = 0; isspace(str[i]); i++)
-  ;
- for (; str[i] && str[i] != ch; i++)
-  ;
- for(; i >= 0 && str[i] != DIRC; i--)
-  ;
- return(i+1);
+  for (i = 0; isspace (str[i]); i++)
+    ;
+  for (; str[i] && str[i] != ch; i++)
+    ;
+  for (; i >= 0 && str[i] != DIRC; i--)
+    ;
+  return (i + 1);
 }
 
-int e_make_error_list(FENSTER *f)
+int
+e_make_error_list (FENSTER * f)
 {
- char file[256];
- ECNT *cn = f->ed;
- BUFFER *b = cn->f[cn->mxedt]->b;
- int i, j, k = 0, ret = 0;
- char *spt;
+  char file[256];
+  ECNT *cn = f->ed;
+  BUFFER *b = cn->f[cn->mxedt]->b;
+  int i, j, k = 0, ret = 0;
+  char *spt;
 
- if (err_li)
- {
-  for (i = 0; i < err_num; i++)
-  {
-   if(err_li[i].file) free(err_li[i].file);
-   if(err_li[i].text) free(err_li[i].text);
-   if(err_li[i].srch) free(err_li[i].srch);
-  }
-  free(err_li);
- }
- err_li = malloc(sizeof(struct ERR_LI) * b->mxlines);
- err_num = 0;
- for (i = 0; i < b->mxlines; i++)
- {
-  if (!strncmp((char *)b->bf[i].s, "Error at Command:", 17)) 
-   return(!ret ? -2 : ret);
-  if ((!strncmp((char *)b->bf[i].s, "ld", 2) &&
-    (b->bf[i].s[2] == ' '  || b->bf[i].s[2] == ':')) ||
-    !strncmp((char *)b->bf[i].s, "collect:", 8))
-   ret = -2;
-  else if (!strncmp((char *)b->bf[i].s, "makefile:", 9) ||
-    !strncmp((char *)b->bf[i].s, "Makefile:", 9))
-  {
-   err_li[k].file = malloc(9);
-   for (j = 0; j < 8; j++)
-    err_li[k].file[j] = b->bf[i].s[j];
-   err_li[k].file[8] = '\0';
-   err_li[k].line = atoi((char *)b->bf[i].s+9);
-   err_li[k].y = i;
-   err_li[k].x = 0;
-   err_li[k].srch = NULL;
-   err_li[k].text = malloc(strlen((char *)b->bf[i].s) + 1);
-   strcpy(err_li[k].text, (char *)b->bf[i].s);
-   err_li[k].text[b->bf[i].len] = '\0';
-   k++;
-   err_num++;
-   ret = -1;
-   continue;
-  }
-  else if (!strncmp((char *)b->bf[i].s, "make:", 5) &&
-    ((spt = strstr((char *)b->bf[i].s, "makefile")) ||
-    (spt = strstr((char *)b->bf[i].s, "Makefile")) ) &&
-    (err_li[k].line = atoi(spt+14)) > 0 )
-  {
-   err_li[k].file = malloc(9);
-   for (j = 0; j < 8; j++)
-    err_li[k].file[j] = spt[j];
-   err_li[k].file[8] = '\0';
-   err_li[k].y = i;
-   err_li[k].x = 0;
-   err_li[k].srch = NULL;
-   err_li[k].text = malloc(strlen((char *)b->bf[i].s) + 1);
-   strcpy(err_li[k].text, (char *)b->bf[i].s);
-   err_li[k].text[b->bf[i].len] = '\0';
-   k++;
-   err_num++;
-   continue;
-  }
-  else
-  {
-   char *tststr = e_s_prog.comp_sw ? e_s_prog.intstr : gnu_intstr;
-   if (!(ret = e_p_cmp_mess(tststr, b, &i, &k, ret)))
-   {
-    int ip, in;
-    ip = e_pure_bin((char *)e_s_prog.compiler, ' ');
-    in = e_pure_bin((char *)b->bf[i].s, ':');
-    sprintf(file, "%s:", e_s_prog.compiler+ip);
-    if (!strncmp(file, (const char *)b->bf[i].s+in, strlen(file)))
-     ret = -2;
-    else if (!strncmp("ld:", (const char *)b->bf[i].s+in, 3))
-     ret = -2;
-    else if (!strncmp("as:", (const char *)b->bf[i].s+in, 3))
-     ret = -2;
-   }
-  }
- }
- if (!(f->ed->edopt & (ED_ERRORS_STOP_AT | ED_MESSAGES_STOP_AT)) &&
-   ret == -1)
-  ret = 0;
- return(ret);
-}
-
-int e_previous_error(FENSTER *f)
-{
- if (err_no > 0)
-  return(e_show_error(--err_no, f));
- e_pr_uul(f->fb);
- return(0);
-}
-
-int e_next_error(FENSTER *f)
-{
- if (err_no < err_num - 1)
-  return(e_show_error(++err_no, f));
- e_pr_uul(f->fb);
- return(0);
-}
-
-int e_cur_error(int y, FENSTER *f)
-{
- int i;
-
- if(err_num)
- {
-  for(i = 1; i < err_num && err_li[i].y <= y; i++);
-  return(e_show_error(err_no = i - 1, f));
- }
- e_pr_uul(f->fb);
- return(0);
-}
-
-int e_d_car_ret(FENSTER *f)
-{
- if (!strcmp(f->datnam, "Messages"))
-  return(e_cur_error(f->ed->f[f->ed->mxedt]->b->b.y, f));
-#ifdef DEBUGGER
- if (!strcmp(f->datnam, "Watches"))
-  return(e_edit_watches(f));
- if(!strcmp(f->datnam, "Stack"))
-  return(e_make_stack(f));
-#endif
- return(0);
-}
-
-int e_line_read(int n, char *s, int max)
-{
- int i, ret = 0;
-
- for (i = 0; i < max - 1; i++)
-  if ((ret = read(n, s + i, 1)) != 1 || s[i] == '\n'|| s[i] == '\0')
-   break;
- if (ret != 1 && i == 0)
-  return(-1);
- if (i == max - 1)
-  i--;
- s[i+1] = '\0';
- return(0);
-}
-
-int e_arguments(FENSTER *f)
-{
- char str[80];
-
- if (!e_prog.arguments)
- {
-  e_prog.arguments = malloc(1);
-  e_prog.arguments[0] = '\0';
- }
- strcpy(str, e_prog.arguments);
- if (e_add_arguments(str, "Arguments", f, 0 , AltA, NULL))
- {
-  e_prog.arguments = realloc(e_prog.arguments, strlen(str) + 1);
-  strcpy(e_prog.arguments, str);
- }
- return(0);
-}
-
-int e_check_c_file(char *name)
-{
- int i, j;
- char *postfix;
-
- postfix = strrchr(name, '.');
- if (postfix)
- {
-  for (i = 0; i < e_prog.num; i++)
-   for (j = WpeExpArrayGetSize(e_prog.comp[i]->filepostfix); j; j--)
-    if(!strcmp(e_prog.comp[i]->filepostfix[j - 1], postfix))
+  if (err_li)
     {
-     e_copy_prog(&e_s_prog, e_prog.comp[i]);
-     return(i+1);
+      for (i = 0; i < err_num; i++)
+	{
+	  if (err_li[i].file)
+	    free (err_li[i].file);
+	  if (err_li[i].text)
+	    free (err_li[i].text);
+	  if (err_li[i].srch)
+	    free (err_li[i].srch);
+	}
+      free (err_li);
     }
- }
- return(0);
+  err_li = malloc (sizeof (struct ERR_LI) * b->mxlines);
+  err_num = 0;
+  for (i = 0; i < b->mxlines; i++)
+    {
+      if (!strncmp ((char *) b->bf[i].s, "Error at Command:", 17))
+	return (!ret ? -2 : ret);
+      if ((!strncmp ((char *) b->bf[i].s, "ld", 2) &&
+	   (b->bf[i].s[2] == ' ' || b->bf[i].s[2] == ':')) ||
+	  !strncmp ((char *) b->bf[i].s, "collect:", 8))
+	ret = -2;
+      else if (!strncmp ((char *) b->bf[i].s, "makefile:", 9) ||
+	       !strncmp ((char *) b->bf[i].s, "Makefile:", 9))
+	{
+	  err_li[k].file = malloc (9);
+	  for (j = 0; j < 8; j++)
+	    err_li[k].file[j] = b->bf[i].s[j];
+	  err_li[k].file[8] = '\0';
+	  err_li[k].line = atoi ((char *) b->bf[i].s + 9);
+	  err_li[k].y = i;
+	  err_li[k].x = 0;
+	  err_li[k].srch = NULL;
+	  err_li[k].text = malloc (strlen ((char *) b->bf[i].s) + 1);
+	  strcpy (err_li[k].text, (char *) b->bf[i].s);
+	  err_li[k].text[b->bf[i].len] = '\0';
+	  k++;
+	  err_num++;
+	  ret = -1;
+	  continue;
+	}
+      else if (!strncmp ((char *) b->bf[i].s, "make:", 5) &&
+	       ((spt = strstr ((char *) b->bf[i].s, "makefile")) ||
+		(spt = strstr ((char *) b->bf[i].s, "Makefile"))) &&
+	       (err_li[k].line = atoi (spt + 14)) > 0)
+	{
+	  err_li[k].file = malloc (9);
+	  for (j = 0; j < 8; j++)
+	    err_li[k].file[j] = spt[j];
+	  err_li[k].file[8] = '\0';
+	  err_li[k].y = i;
+	  err_li[k].x = 0;
+	  err_li[k].srch = NULL;
+	  err_li[k].text = malloc (strlen ((char *) b->bf[i].s) + 1);
+	  strcpy (err_li[k].text, (char *) b->bf[i].s);
+	  err_li[k].text[b->bf[i].len] = '\0';
+	  k++;
+	  err_num++;
+	  continue;
+	}
+      else
+	{
+	  char *tststr = e_s_prog.comp_sw ? e_s_prog.intstr : gnu_intstr;
+	  if (!(ret = e_p_cmp_mess (tststr, b, &i, &k, ret)))
+	    {
+	      int ip, in;
+	      ip = e_pure_bin ((char *) e_s_prog.compiler, ' ');
+	      in = e_pure_bin ((char *) b->bf[i].s, ':');
+	      sprintf (file, "%s:", e_s_prog.compiler + ip);
+	      if (!strncmp
+		  (file, (const char *) b->bf[i].s + in, strlen (file)))
+		ret = -2;
+	      else if (!strncmp ("ld:", (const char *) b->bf[i].s + in, 3))
+		ret = -2;
+	      else if (!strncmp ("as:", (const char *) b->bf[i].s + in, 3))
+		ret = -2;
+	    }
+	}
+    }
+  if (!(f->ed->edopt & (ED_ERRORS_STOP_AT | ED_MESSAGES_STOP_AT)) &&
+      ret == -1)
+    ret = 0;
+  return (ret);
+}
+
+int
+e_previous_error (FENSTER * f)
+{
+  if (err_no > 0)
+    return (e_show_error (--err_no, f));
+  e_pr_uul (f->fb);
+  return (0);
+}
+
+int
+e_next_error (FENSTER * f)
+{
+  if (err_no < err_num - 1)
+    return (e_show_error (++err_no, f));
+  e_pr_uul (f->fb);
+  return (0);
+}
+
+int
+e_cur_error (int y, FENSTER * f)
+{
+  int i;
+
+  if (err_num)
+    {
+      for (i = 1; i < err_num && err_li[i].y <= y; i++);
+      return (e_show_error (err_no = i - 1, f));
+    }
+  e_pr_uul (f->fb);
+  return (0);
+}
+
+int
+e_d_car_ret (FENSTER * f)
+{
+  if (!strcmp (f->datnam, "Messages"))
+    return (e_cur_error (f->ed->f[f->ed->mxedt]->b->b.y, f));
+#ifdef DEBUGGER
+  if (!strcmp (f->datnam, "Watches"))
+    return (e_edit_watches (f));
+  if (!strcmp (f->datnam, "Stack"))
+    return (e_make_stack (f));
+#endif
+  return (0);
+}
+
+int
+e_line_read (int n, char *s, int max)
+{
+  int i, ret = 0;
+
+  for (i = 0; i < max - 1; i++)
+    if ((ret = read (n, s + i, 1)) != 1 || s[i] == '\n' || s[i] == '\0')
+      break;
+  if (ret != 1 && i == 0)
+    return (-1);
+  if (i == max - 1)
+    i--;
+  s[i + 1] = '\0';
+  return (0);
+}
+
+int
+e_arguments (FENSTER * f)
+{
+  char str[80];
+
+  if (!e_prog.arguments)
+    {
+      e_prog.arguments = malloc (1);
+      e_prog.arguments[0] = '\0';
+    }
+  strcpy (str, e_prog.arguments);
+  if (e_add_arguments (str, "Arguments", f, 0, AltA, NULL))
+    {
+      e_prog.arguments = realloc (e_prog.arguments, strlen (str) + 1);
+      strcpy (e_prog.arguments, str);
+    }
+  return (0);
+}
+
+int
+e_check_c_file (char *name)
+{
+  int i, j;
+  char *postfix;
+
+  postfix = strrchr (name, '.');
+  if (postfix)
+    {
+      for (i = 0; i < e_prog.num; i++)
+	for (j = WpeExpArrayGetSize (e_prog.comp[i]->filepostfix); j; j--)
+	  if (!strcmp (e_prog.comp[i]->filepostfix[j - 1], postfix))
+	    {
+	      e_copy_prog (&e_s_prog, e_prog.comp[i]);
+	      return (i + 1);
+	    }
+    }
+  return (0);
 }
 
 #ifdef CHECKHEADER
 
-int e_check_header(char *file, M_TIME otime, ECNT *cn, int sw)
+int
+e_check_header (char *file, M_TIME otime, ECNT * cn, int sw)
 {
- struct stat cbuf[1];
- FILE *fp;
- char *p, str[120], str2[120];
- int i;
+  struct stat cbuf[1];
+  FILE *fp;
+  char *p, str[120], str2[120];
+  int i;
 
- for (i = cn->mxedt; i > 0; i--)
- {
-  if (file[0] == DIRC)
-   p = e_mkfilename(cn->f[i]->dirct, cn->f[i]->datnam);
-  else
-   p = cn->f[i]->datnam;
-  if (!strcmp(p, file) && cn->f[i]->save)
-  {  e_save(cn->f[i]);  if(p != cn->f[i]->datnam) free(p);  break;  }
-  if (p != cn->f[i]->datnam)
-   free(p);
- }
- if ((fp = fopen(file, "r")) == NULL)
-  return(sw);
- stat(file, cbuf);
- if (otime < cbuf->st_mtime)
-  sw++;
- while (fgets(str, 120, fp))
- {
-  for (p = str; isspace(*p); p++);
-  if (*p == '/' && *(p+1) == '*')
-  {
-   p++;
-   do
-   {
-    for (p++; *p && *p != '*'; p++)
-     ;
-    if (!*p && !fgets((p = str), 120, fp))
-     break;
-   } while (p != NULL && (*p != '*' || *(p+1) != '/'));
-   if (!p) break;
-   for (p += 2; isspace(*p); p++)
-    ;
-  }
-  if (*p == '#')
-  {
-   for (p++; isspace(*p); p++)
-    ;
-   if (!strncmp(p, "include", 7))
-   {
-    for (p += 8; isspace(*p); p++)
-     ;
-    if (*p == '\"')
+  for (i = cn->mxedt; i > 0; i--)
     {
-     for (p++, i = 0; p[i] != '\"' && p[i] != '\0' && p[i] != '\n'; i++)
-      str2[i] = p[i];
-     str2[i] = '\0';
-     sw = e_check_header(str2, otime, cn, sw);
+      if (file[0] == DIRC)
+	p = e_mkfilename (cn->f[i]->dirct, cn->f[i]->datnam);
+      else
+	p = cn->f[i]->datnam;
+      if (!strcmp (p, file) && cn->f[i]->save)
+	{
+	  e_save (cn->f[i]);
+	  if (p != cn->f[i]->datnam)
+	    free (p);
+	  break;
+	}
+      if (p != cn->f[i]->datnam)
+	free (p);
     }
-   }
-  }
- }
- fclose(fp);
- return(sw);
+  if ((fp = fopen (file, "r")) == NULL)
+    return (sw);
+  stat (file, cbuf);
+  if (otime < cbuf->st_mtime)
+    sw++;
+  while (fgets (str, 120, fp))
+    {
+      for (p = str; isspace (*p); p++);
+      if (*p == '/' && *(p + 1) == '*')
+	{
+	  p++;
+	  do
+	    {
+	      for (p++; *p && *p != '*'; p++)
+		;
+	      if (!*p && !fgets ((p = str), 120, fp))
+		break;
+	    }
+	  while (p != NULL && (*p != '*' || *(p + 1) != '/'));
+	  if (!p)
+	    break;
+	  for (p += 2; isspace (*p); p++)
+	    ;
+	}
+      if (*p == '#')
+	{
+	  for (p++; isspace (*p); p++)
+	    ;
+	  if (!strncmp (p, "include", 7))
+	    {
+	      for (p += 8; isspace (*p); p++)
+		;
+	      if (*p == '\"')
+		{
+		  for (p++, i = 0;
+		       p[i] != '\"' && p[i] != '\0' && p[i] != '\n'; i++)
+		    str2[i] = p[i];
+		  str2[i] = '\0';
+		  sw = e_check_header (str2, otime, cn, sw);
+		}
+	    }
+	}
+    }
+  fclose (fp);
+  return (sw);
 }
 #endif
 
-char *e_cat_string(char *p, char *str)
+char *
+e_cat_string (char *p, char *str)
 {
- if(str == NULL) return(p = NULL);
- if(p == NULL)
- {
-  if((p = malloc(strlen(str)+2)) == NULL) return(NULL);
-  p[0] = '\0';
- }
- else if ((p = realloc(p, strlen(p) + strlen(str)+2)) == NULL)
-  return(NULL);
- strcat(p, " ");
- strcat(p, str);
- return(p);
+  if (str == NULL)
+    return (p = NULL);
+  if (p == NULL)
+    {
+      if ((p = malloc (strlen (str) + 2)) == NULL)
+	return (NULL);
+      p[0] = '\0';
+    }
+  else if ((p = realloc (p, strlen (p) + strlen (str) + 2)) == NULL)
+    return (NULL);
+  strcat (p, " ");
+  strcat (p, str);
+  return (p);
 }
 
-int e_make_arg(char ***arg, char *str)
+int
+e_make_arg (char ***arg, char *str)
 {
- int i, j;
- char tmp[128], *p = tmp;
+  int i, j;
+  char tmp[128], *p = tmp;
 
- if (!(*arg))
-  *arg = (char **) malloc(4*sizeof(char *));
- else
-  *arg = (char **) realloc(*arg, 4*sizeof(char *));
- (*arg)[0] = malloc(strlen(e_s_prog.compiler) + 1);
- strcpy((*arg)[0], e_s_prog.compiler);
- if (!str)
- {
-  (*arg)[1] = NULL;
-  (*arg)[2] = NULL;
-  return(2);
- }
- strcpy(tmp, str);
- for (j = 2, i = 0; p[i] != '\0'; j++)
- {
-  for (; p[i] != '\0' && p[i] != ' '; i++)
-   ;
-  (*arg)[j] = malloc(i + 1);
-  strncpy((*arg)[j], p, i);
-  (*arg)[j][i] = '\0';
-  *arg = (char **) realloc(*arg, (j + 3)*sizeof(char *));
-  if (p[i] != '\0')
-  {
-   p += (i + 1);
-   i = 0;
-  }
- }
- (*arg)[j] = NULL;
- return(j);
-}
-
-int e_add_arg(char ***arg, char *str, int n, int argc)
-{
- int i;
-
- argc++;
- *arg = (char **) realloc(*arg, (argc+1)*sizeof(char *));
- for(i = argc; i > n; i--)
-  (*arg)[i] = (*arg)[i-1];
- (*arg)[n] = malloc(strlen(str) + 1);
- strcpy((*arg)[n], str);
- return(argc);
-}
-
-int e_ini_prog(ECNT *cn)
-{
- UNUSED(cn);
- int i;
-
- e_prog.num = 4;
- if (e_prog.arguments) free(e_prog.arguments);
- e_prog.arguments = WpeStrdup("");
- if (e_prog.project) free(e_prog.project);
- e_prog.project = WpeStrdup("project.prj");
- if (e_prog.exedir) free(e_prog.exedir);
- e_prog.exedir = WpeStrdup(".");
- if (e_prog.sys_include) free(e_prog.sys_include);
- e_prog.sys_include =
-   WpeStrdup("/usr/include:/usr/local/include:/usr/include/X11");
- if (e_prog.comp == NULL)
-  e_prog.comp = malloc(e_prog.num * sizeof(struct e_s_prog *));
- else
-  e_prog.comp = realloc(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
- for (i = 0; i < e_prog.num; i++)
-  e_prog.comp[i] = malloc(sizeof(struct e_s_prog));
- e_prog.comp[0]->compiler = WpeStrdup("gcc");
- e_prog.comp[0]->language = WpeStrdup("C");
- e_prog.comp[0]->filepostfix = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
- e_prog.comp[0]->filepostfix[0] = WpeStrdup(".c");
- e_prog.comp[0]->key = 'C';
- e_prog.comp[0]->x = 0;
- e_prog.comp[0]->intstr = WpeStrdup(cc_intstr);
- e_prog.comp[2]->compiler = WpeStrdup("f77");
- e_prog.comp[1]->compiler = WpeStrdup("g++");
- e_prog.comp[1]->language = WpeStrdup("C++");
- e_prog.comp[1]->filepostfix = (char **)WpeExpArrayCreate(4, sizeof(char *), 1);
- e_prog.comp[1]->filepostfix[0] = WpeStrdup(".C");
- e_prog.comp[1]->filepostfix[1] = WpeStrdup(".cc");
- e_prog.comp[1]->filepostfix[2] = WpeStrdup(".cpp");
- e_prog.comp[1]->filepostfix[3] = WpeStrdup(".cxx");
- e_prog.comp[1]->key = '+';
- e_prog.comp[1]->x = 1;
- e_prog.comp[1]->intstr = WpeStrdup(cc_intstr);
- e_prog.comp[2]->language = WpeStrdup("Fortran");
- e_prog.comp[2]->filepostfix = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
- e_prog.comp[2]->filepostfix[0] = WpeStrdup(".f");
- e_prog.comp[2]->key = 'F';
- e_prog.comp[2]->x = 0;
- e_prog.comp[2]->intstr = WpeStrdup(cc_intstr);
- e_prog.comp[3]->compiler = WpeStrdup("pc");
- e_prog.comp[3]->language = WpeStrdup("Pascal");
- e_prog.comp[3]->filepostfix = (char **)WpeExpArrayCreate(1, sizeof(char *), 1);
- e_prog.comp[3]->filepostfix[0] = WpeStrdup(".p");
- e_prog.comp[3]->key = 'P';
- e_prog.comp[3]->x = 0;
- e_prog.comp[3]->intstr = WpeStrdup(pc_intstr);
- for (i = 0; i < e_prog.num; i++)
- {
-  e_prog.comp[i]->comp_str = WpeStrdup("-g");
-  e_prog.comp[i]->libraries = WpeStrdup("");
-  e_prog.comp[i]->exe_name = WpeStrdup("");
-  e_prog.comp[i]->comp_sw = i < 2 ? 0 : 1;
- }
- e_copy_prog(&e_s_prog, e_prog.comp[0]);
- return(0);
-}
-
-int e_copy_prog(struct e_s_prog *out, struct e_s_prog *in)
-{
- int i;
-
- if (out->language) free(out->language);
- out->language = WpeStrdup(in->language);
- if (out->filepostfix)
- {
-  for (i = WpeExpArrayGetSize(out->filepostfix); i; i--)
-   free(out->filepostfix[i - 1]);
-  WpeExpArrayDestroy(out->filepostfix);
- }
- out->filepostfix = (char **)WpeExpArrayCreate(WpeExpArrayGetSize(in->filepostfix), sizeof(char *), 1);
- for (i = WpeExpArrayGetSize(out->filepostfix); i; i--)
-  out->filepostfix[i - 1] = WpeStrdup(in->filepostfix[i - 1]);
- if (out->compiler) free(out->compiler);
- out->compiler = WpeStrdup(in->compiler);
- if (out->comp_str) free(out->comp_str);
- out->comp_str = WpeStrdup(in->comp_str);
- if (out->libraries) free(out->libraries);
- out->libraries = WpeStrdup(in->libraries);
- if (out->exe_name) free(out->exe_name);
- out->exe_name = WpeStrdup(in->exe_name);
- if (out->intstr) free(out->intstr);
- out->intstr = WpeStrdup(in->intstr);
- out->key = in->key;
- out->comp_sw = in->comp_sw;
- return(0);
-}
-
-int e_prj_ob_btt(FENSTER *f, int sw)
-{
- FLWND *fw;
-
- e_data_first(sw+4, f->ed, f->ed->dirct);
- if (sw > 0)
- {
-  if (!(f->ed->edopt & ED_CUA_STYLE))
-   while (e_data_eingabe(f->ed) != AF3)
-    ;
+  if (!(*arg))
+    *arg = (char **) malloc (4 * sizeof (char *));
   else
-   while (e_data_eingabe(f->ed) != CF4)
-    ;
-  fw = (FLWND *)f->ed->f[f->ed->mxedt]->b;
-  fw->df = NULL;
-  e_close_window(f->ed->f[f->ed->mxedt]);
- }
- return(0);
+    *arg = (char **) realloc (*arg, 4 * sizeof (char *));
+  (*arg)[0] = malloc (strlen (e_s_prog.compiler) + 1);
+  strcpy ((*arg)[0], e_s_prog.compiler);
+  if (!str)
+    {
+      (*arg)[1] = NULL;
+      (*arg)[2] = NULL;
+      return (2);
+    }
+  strcpy (tmp, str);
+  for (j = 2, i = 0; p[i] != '\0'; j++)
+    {
+      for (; p[i] != '\0' && p[i] != ' '; i++)
+	;
+      (*arg)[j] = malloc (i + 1);
+      strncpy ((*arg)[j], p, i);
+      (*arg)[j][i] = '\0';
+      *arg = (char **) realloc (*arg, (j + 3) * sizeof (char *));
+      if (p[i] != '\0')
+	{
+	  p += (i + 1);
+	  i = 0;
+	}
+    }
+  (*arg)[j] = NULL;
+  return (j);
 }
 
-int e_prj_ob_file(FENSTER *f)
+int
+e_add_arg (char ***arg, char *str, int n, int argc)
 {
- return(e_prj_ob_btt(f, 0));
+  int i;
+
+  argc++;
+  *arg = (char **) realloc (*arg, (argc + 1) * sizeof (char *));
+  for (i = argc; i > n; i--)
+    (*arg)[i] = (*arg)[i - 1];
+  (*arg)[n] = malloc (strlen (str) + 1);
+  strcpy ((*arg)[n], str);
+  return (argc);
 }
 
-int e_prj_ob_varb(FENSTER *f)
+int
+e_ini_prog (ECNT * cn)
 {
- return(e_prj_ob_btt(f, 1));
+  UNUSED (cn);
+  int i;
+
+  e_prog.num = 4;
+  if (e_prog.arguments)
+    free (e_prog.arguments);
+  e_prog.arguments = WpeStrdup ("");
+  if (e_prog.project)
+    free (e_prog.project);
+  e_prog.project = WpeStrdup ("project.prj");
+  if (e_prog.exedir)
+    free (e_prog.exedir);
+  e_prog.exedir = WpeStrdup (".");
+  if (e_prog.sys_include)
+    free (e_prog.sys_include);
+  e_prog.sys_include =
+    WpeStrdup ("/usr/include:/usr/local/include:/usr/include/X11");
+  if (e_prog.comp == NULL)
+    e_prog.comp = malloc (e_prog.num * sizeof (struct e_s_prog *));
+  else
+    e_prog.comp =
+      realloc (e_prog.comp, e_prog.num * sizeof (struct e_s_prog *));
+  for (i = 0; i < e_prog.num; i++)
+    e_prog.comp[i] = malloc (sizeof (struct e_s_prog));
+  e_prog.comp[0]->compiler = WpeStrdup ("gcc");
+  e_prog.comp[0]->language = WpeStrdup ("C");
+  e_prog.comp[0]->filepostfix =
+    (char **) WpeExpArrayCreate (1, sizeof (char *), 1);
+  e_prog.comp[0]->filepostfix[0] = WpeStrdup (".c");
+  e_prog.comp[0]->key = 'C';
+  e_prog.comp[0]->x = 0;
+  e_prog.comp[0]->intstr = WpeStrdup (cc_intstr);
+  e_prog.comp[2]->compiler = WpeStrdup ("f77");
+  e_prog.comp[1]->compiler = WpeStrdup ("g++");
+  e_prog.comp[1]->language = WpeStrdup ("C++");
+  e_prog.comp[1]->filepostfix =
+    (char **) WpeExpArrayCreate (4, sizeof (char *), 1);
+  e_prog.comp[1]->filepostfix[0] = WpeStrdup (".C");
+  e_prog.comp[1]->filepostfix[1] = WpeStrdup (".cc");
+  e_prog.comp[1]->filepostfix[2] = WpeStrdup (".cpp");
+  e_prog.comp[1]->filepostfix[3] = WpeStrdup (".cxx");
+  e_prog.comp[1]->key = '+';
+  e_prog.comp[1]->x = 1;
+  e_prog.comp[1]->intstr = WpeStrdup (cc_intstr);
+  e_prog.comp[2]->language = WpeStrdup ("Fortran");
+  e_prog.comp[2]->filepostfix =
+    (char **) WpeExpArrayCreate (1, sizeof (char *), 1);
+  e_prog.comp[2]->filepostfix[0] = WpeStrdup (".f");
+  e_prog.comp[2]->key = 'F';
+  e_prog.comp[2]->x = 0;
+  e_prog.comp[2]->intstr = WpeStrdup (cc_intstr);
+  e_prog.comp[3]->compiler = WpeStrdup ("pc");
+  e_prog.comp[3]->language = WpeStrdup ("Pascal");
+  e_prog.comp[3]->filepostfix =
+    (char **) WpeExpArrayCreate (1, sizeof (char *), 1);
+  e_prog.comp[3]->filepostfix[0] = WpeStrdup (".p");
+  e_prog.comp[3]->key = 'P';
+  e_prog.comp[3]->x = 0;
+  e_prog.comp[3]->intstr = WpeStrdup (pc_intstr);
+  for (i = 0; i < e_prog.num; i++)
+    {
+      e_prog.comp[i]->comp_str = WpeStrdup ("-g");
+      e_prog.comp[i]->libraries = WpeStrdup ("");
+      e_prog.comp[i]->exe_name = WpeStrdup ("");
+      e_prog.comp[i]->comp_sw = i < 2 ? 0 : 1;
+    }
+  e_copy_prog (&e_s_prog, e_prog.comp[0]);
+  return (0);
 }
 
-int e_prj_ob_inst(FENSTER *f)
+int
+e_copy_prog (struct e_s_prog *out, struct e_s_prog *in)
 {
- return(e_prj_ob_btt(f, 2));
+  int i;
+
+  if (out->language)
+    free (out->language);
+  out->language = WpeStrdup (in->language);
+  if (out->filepostfix)
+    {
+      for (i = WpeExpArrayGetSize (out->filepostfix); i; i--)
+	free (out->filepostfix[i - 1]);
+      WpeExpArrayDestroy (out->filepostfix);
+    }
+  out->filepostfix =
+    (char **) WpeExpArrayCreate (WpeExpArrayGetSize (in->filepostfix),
+				 sizeof (char *), 1);
+  for (i = WpeExpArrayGetSize (out->filepostfix); i; i--)
+    out->filepostfix[i - 1] = WpeStrdup (in->filepostfix[i - 1]);
+  if (out->compiler)
+    free (out->compiler);
+  out->compiler = WpeStrdup (in->compiler);
+  if (out->comp_str)
+    free (out->comp_str);
+  out->comp_str = WpeStrdup (in->comp_str);
+  if (out->libraries)
+    free (out->libraries);
+  out->libraries = WpeStrdup (in->libraries);
+  if (out->exe_name)
+    free (out->exe_name);
+  out->exe_name = WpeStrdup (in->exe_name);
+  if (out->intstr)
+    free (out->intstr);
+  out->intstr = WpeStrdup (in->intstr);
+  out->key = in->key;
+  out->comp_sw = in->comp_sw;
+  return (0);
 }
 
-int e_prj_ob_svas(FENSTER *f)
+int
+e_prj_ob_btt (FENSTER * f, int sw)
 {
- return(e_project_name(f) ? 0 : AltS);
-}
-
-int e_project_options(FENSTER *f)
-{
- int ret;
- W_OPTSTR *o = e_init_opt_kst(f);
- char *messagestring;
-
- if (!o)
-  return(-1);
- if (!(e_make_prj_opt(f)))
- {
-  freeostr(o);
-  return(-1);
- }
- o->xa = 8;  o->ya = 2;  o->xe = 68;  o->ye = 22;
- o->bgsw = 0;
- o->name = "Project-Options";
- o->crsw = AltS;
- e_add_txtstr(4, 12, "Compiler-Style:", o);
- e_add_wrstr(4, 2, 22, 2, 36, 128, 0, AltC, "Compiler:", e_s_prog.compiler, NULL, o);
- e_add_wrstr(4, 4, 22, 4, 36, 256, 3, AltP, "ComPiler-Options:", e_s_prog.comp_str, NULL, o);
- e_add_wrstr(4, 6, 22, 6, 36, 256, 0, AltL, "Loader-Options:", e_s_prog.libraries, NULL, o);
- e_add_wrstr(4, 8, 22, 8, 36, 128, 0, AltE, "Executable:", e_s_prog.exe_name, NULL, o);
- e_add_wrstr(4, 10, 22, 10, 36, 128, 2, AltB, "LiBrary:", library, NULL, o);
- messagestring = WpeStringToValue(e_s_prog.intstr);
- e_add_wrstr(22, 12, 22, 13, 36, 256, 0, AltM, "Message-String:", messagestring, NULL, o);
- free(messagestring);
- e_add_pswstr(0, 5, 13, 0, AltG, 0, "GNU       ", o);
- e_add_pswstr(0, 5, 14, 1, AltT, e_s_prog.comp_sw, "OTher     ", o);
- e_add_bttstr(9, 18, 0, AltS, "Save", NULL, o);
- e_add_bttstr(44, 18, -1, WPE_ESC, "Cancel", NULL, o);
- e_add_bttstr(26, 18, 5, AltA, "Save As", e_prj_ob_svas, o);
-/* e_add_bttstr(7, 16, 0, AltF, "Files ...", e_prj_ob_file, o);  */
- e_add_bttstr(12, 16, 0, AltV, "Variables ...", e_prj_ob_varb, o);
- e_add_bttstr(35, 16, 0, AltI, "Install ...", e_prj_ob_inst, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
-  if (e_s_prog.compiler) free(e_s_prog.compiler);
-  e_s_prog.compiler = WpeStrdup(o->wstr[0]->txt);
-  if (e_s_prog.comp_str) free(e_s_prog.comp_str);
-  e_s_prog.comp_str = WpeStrdup(o->wstr[1]->txt);
-  if (e_s_prog.libraries) free(e_s_prog.libraries);
-  e_s_prog.libraries = WpeStrdup(o->wstr[2]->txt);
-  if (e_s_prog.exe_name) free(e_s_prog.exe_name);
-  e_s_prog.exe_name = WpeStrdup(o->wstr[3]->txt);
-  if (e_s_prog.intstr) free(e_s_prog.intstr);
-  e_s_prog.intstr = WpeValueToString(o->wstr[5]->txt);
-  strcpy(library, o->wstr[4]->txt);
-  e_s_prog.comp_sw = o->pstr[0]->num;
-  e_wrt_prj_fl(f);
- }
- freeostr(o);
- if (f->ed->mxedt > 0)
-  e_ed_rahmen(f, 1);
- return(0);
-}
-
-int e_run_c_options(FENSTER *f)
-{
- int i, j, ret;
- W_OPTSTR *o = e_init_opt_kst(f);
- char filepostfix[128];
- char *newpostfix;
- char *messagestring;
-
- if (!o)
-  return(-1);
- o->xa = 8;  o->ya = 2;  o->xe = 68;  o->ye = 22;
- o->bgsw = 0;
- o->name = "Compiler-Options";
- o->crsw = AltO;
- e_add_txtstr(4, 14, "Compiler-Style:", o);
- e_add_wrstr(4, 2, 22, 2, 36, 128, 1, AltA, "LAnguage:", e_s_prog.language, NULL, o);
- e_add_wrstr(4, 4, 22, 4, 36, 128, 0, AltC, "Compiler:", e_s_prog.compiler, NULL, o);
- e_add_wrstr(4, 6, 22, 6, 36, 128, 3, AltP, "ComPiler-Options:", e_s_prog.comp_str, NULL, o);
- e_add_wrstr(4, 8, 22, 8, 36, 128, 0, AltL, "Loader-Options:", e_s_prog.libraries, NULL, o);
- e_add_wrstr(4, 10, 22, 10, 36, 128, 0, AltE, "Executable:", e_s_prog.exe_name, NULL, o);
- filepostfix[0] = 0;
- if ((j = WpeExpArrayGetSize(e_s_prog.filepostfix)))
- {
-  strcpy(filepostfix, e_s_prog.filepostfix[0]);
-  for (i = 1; i < j; i++)
-  {
-   strcat(filepostfix, " ");
-   strcat(filepostfix, e_s_prog.filepostfix[i]);
-  }
- }
- e_add_wrstr(4, 12, 22, 12, 36, 128, 0, AltF, "File-Postfix:", filepostfix, NULL, o);
- messagestring = WpeStringToValue(e_s_prog.intstr);
- e_add_wrstr(22, 14, 22, 15, 36, 128, 0, AltM, "Message-String:", messagestring, NULL, o);
- free(messagestring);
- e_add_pswstr(0, 5, 15, 0, AltG, 0, "GNU      ", o);
- e_add_pswstr(0, 5, 16, 1, AltT, e_s_prog.comp_sw, "OTher    ", o);
- e_add_bttstr(16, 18, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(37, 18, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
-  if (e_s_prog.language) free(e_s_prog.language);
-  e_s_prog.language = WpeStrdup(o->wstr[0]->txt);
-  if (e_s_prog.compiler) free(e_s_prog.compiler);
-  e_s_prog.compiler = WpeStrdup(o->wstr[1]->txt);
-  if (e_s_prog.comp_str) free(e_s_prog.comp_str);
-  e_s_prog.comp_str = WpeStrdup(o->wstr[2]->txt);
-  if (e_s_prog.libraries) free(e_s_prog.libraries);
-  e_s_prog.libraries = WpeStrdup(o->wstr[3]->txt);
-  if (e_s_prog.exe_name) free(e_s_prog.exe_name);
-  e_s_prog.exe_name = WpeStrdup(o->wstr[4]->txt);
-  for (i = 0; i < j; i++)
-   free(e_s_prog.filepostfix[i]);
-  WpeExpArrayDestroy(e_s_prog.filepostfix);
-  e_s_prog.filepostfix = (char **)WpeExpArrayCreate(0, sizeof(char *), 1);
-  for (i = 0; o->wstr[5]->txt[i]; i++)
-  {
-   if (isspace(o->wstr[5]->txt[i]))
-    continue;
-   for (j = i; (o->wstr[5]->txt[j]) && (!isspace(o->wstr[5]->txt[j])); j++)
-    ;
-   newpostfix = (char *)malloc(sizeof(char) * j - i + 1);
-   strncpy(newpostfix, o->wstr[5]->txt + i, j - i);
-   newpostfix[j - i] = 0;
-   WpeExpArrayAdd((void **)&e_s_prog.filepostfix, &newpostfix);
-   i = j - 1;
-  }
-  if (e_s_prog.intstr) free(e_s_prog.intstr);
-  e_s_prog.intstr = WpeValueToString(o->wstr[6]->txt);
-  e_s_prog.comp_sw = o->pstr[0]->num;
- }
- freeostr(o);
- return(0);
-}
-
-int e_run_options(FENSTER *f)
-{
- int i, n, xa = 48, ya = 2, num = 2 + e_prog.num;
- OPTK *opt = malloc(num * sizeof(OPTK));
- char tmp[80];
-
- tmp[0] = '\0';
- opt[0].t = "Add Compiler   ";     opt[0].x = 0;  opt[0].o = 'A';
- opt[1].t = "Remove Compiler";     opt[1].x = 0;  opt[1].o = 'R';
-
- for (i = 0; i < e_prog.num; i++)
- {
-  opt[i+2].t = e_prog.comp[i]->language;  opt[i+2].x = e_prog.comp[i]->x;
-  opt[i+2].o = e_prog.comp[i]->key;
- }
- n = e_opt_sec_box(xa, ya, num, opt, f, 1);
-
- if (n == 0)
- {
-  if (!e_run_c_options(f))
-  {
-   e_prog.num++;
-   e_prog.comp = realloc(e_prog.comp, e_prog.num * sizeof(struct e_s_prog *));
-   e_prog.comp[e_prog.num - 1] = malloc(sizeof(struct e_s_prog));
-   e_prog.comp[e_prog.num - 1]->language = (char *)malloc(1);
-   e_prog.comp[e_prog.num - 1]->language[0] = 0;
-   e_prog.comp[e_prog.num - 1]->compiler = (char *)malloc(1);
-   e_prog.comp[e_prog.num - 1]->compiler[0] = 0;
-   e_prog.comp[e_prog.num - 1]->comp_str = (char *)malloc(1);
-   e_prog.comp[e_prog.num - 1]->comp_str[0] = 0;
-   e_prog.comp[e_prog.num - 1]->libraries = (char *)malloc(1);
-   e_prog.comp[e_prog.num - 1]->libraries[0] = 0;
-   e_prog.comp[e_prog.num - 1]->exe_name = (char *)malloc(1);
-   e_prog.comp[e_prog.num - 1]->exe_name[0] = 0;
-   e_prog.comp[e_prog.num - 1]->intstr = (char *)malloc(1);
-   e_prog.comp[e_prog.num - 1]->intstr[0] = 0;
-   e_prog.comp[e_prog.num - 1]->filepostfix =
-     (char **)WpeExpArrayCreate(0, sizeof(char *), 1);
-   e_copy_prog(e_prog.comp[e_prog.num-1], &e_s_prog);
-   for (n = 0; e_prog.comp[e_prog.num-1]->language[n]; n++)
-   {
-    for (i = 0; i <= e_prog.num &&
-      toupper(e_prog.comp[e_prog.num-1]->language[n]) != opt[i].o; i++)
-     ;
-    if (i > e_prog.num)
-     break;
-   }
-   e_prog.comp[e_prog.num-1]->key =
-    toupper(e_prog.comp[e_prog.num-1]->language[n]);
-   e_prog.comp[e_prog.num-1]->x = n;
-  }
- }
- else if (n == 1)
- {
-  if(e_add_arguments(tmp, "Remove Compiler", f, 0, AltR, NULL))
-  {
-   for (i = 0; i < e_prog.num && strcmp(e_prog.comp[i]->language, tmp); i++)
-    ;
-   if (i >= e_prog.num)
-   {
-    e_error(e_p_msg[ERR_NO_COMPILER], 0, f->fb);
-    free(opt);
-    return(0);
-   }
-   free(e_prog.comp[i]);
-   for(; i < e_prog.num-1; i++) e_prog.comp[i] = e_prog.comp[i+1];
-    e_prog.num--;
-  }
- }
- else if (n > 1)
- {
-  e_copy_prog(&e_s_prog, e_prog.comp[n-2]);
-  e_run_c_options(f);
-  e_copy_prog(e_prog.comp[n-2], &e_s_prog);
- }
- free(opt);
- return(n < 0 ? WPE_ESC : 0);
-}
-
-int e_project_name(FENSTER *f)
-{
- char str[80];
-
- if (!e_prog.project)
- {
-  e_prog.project = malloc(1);
-  e_prog.project[0] = '\0';
- }
- strcpy(str, e_prog.project);
- if (e_add_arguments(str, "Project", f, 0, AltP, NULL))
- {
-  e_prog.project = realloc(e_prog.project, strlen(str) + 1);
-  strcpy(e_prog.project, str);
-  return(0);
- }
- return(WPE_ESC);
-}
-
-int e_project(FENSTER *f)
-{
- ECNT *cn = f->ed;
- int i;
- if (!e_project_name(f))
- {
-  for (i = cn->mxedt; i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4);
-    i--)
-   ;
-  if (i > 0)
-  {
-   e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-   e_close_window(cn->f[cn->mxedt]);
-  }
-  f = cn->f[cn->mxedt];
-  e_make_prj_opt(f);
-  e_rel_brkwtch(f);
-  e_prj_ob_file(f);
-  return(0);
- }
- return(WPE_ESC);
-}
-
-int e_show_project(FENSTER *f)
-{
- ECNT *cn = f->ed;
- int i;
-
- for (i = cn->mxedt; i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4);
-   i--)
-  ;
- if (i > 0)
-  e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
- else
- {
-  e_make_prj_opt(f);
-  e_prj_ob_file(f);
- }
- return(0);
-}
-
-int e_cl_project(FENSTER *f)
-{
- ECNT *cn = f->ed;
- int i;
-
- if (!e_prog.project)
-  e_prog.project = malloc(sizeof(char));
- else
-  e_prog.project = realloc(e_prog.project, sizeof(char));
- e_prog.project[0] = '\0';
- for (i = cn->mxedt; i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4);
-   i--)
-  ;
- if (i > 0)
- {
-  e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-  e_close_window(cn->f[cn->mxedt]);
- }
- return(0);
-}
-
-int e_p_add_item(FENSTER *f)
-{
- ECNT *cn = f->ed;
- int i;
-
- for (i = cn->mxedt; i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4);
-   i--)
-  ;
- if (i > 0)
-  e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
- else
- {
   FLWND *fw;
 
-  e_make_prj_opt(f);
-  e_prj_ob_file(f);
-  fw = (FLWND *) cn->f[cn->mxedt]->b;
-  fw->nf = fw->df->anz - 1;
- }
- cn->f[cn->mxedt]->save = 1;
- WpeCreateFileManager(5, cn, NULL);
- WpeHandleFileManager(cn);
- return(0);
+  e_data_first (sw + 4, f->ed, f->ed->dirct);
+  if (sw > 0)
+    {
+      if (!(f->ed->edopt & ED_CUA_STYLE))
+	while (e_data_eingabe (f->ed) != AF3)
+	  ;
+      else
+	while (e_data_eingabe (f->ed) != CF4)
+	  ;
+      fw = (FLWND *) f->ed->f[f->ed->mxedt]->b;
+      fw->df = NULL;
+      e_close_window (f->ed->f[f->ed->mxedt]);
+    }
+  return (0);
 }
 
-int e_p_del_item(FENSTER *f)
+int
+e_prj_ob_file (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int i;
-
- for (i = cn->mxedt;
-   i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
-  ;
- if (i > 0)
-  e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
- else
-  return(e_error(e_p_msg[ERR_NOPROJECT], 0, f->fb));
- f = cn->f[cn->mxedt];
- f->save = 1;
- e_p_del_df((FLWND *) f->b, f->ins);
- return 0;
+  return (e_prj_ob_btt (f, 0));
 }
 
-int e_make_library(char *library, char *ofile, FENSTER *f)
+int
+e_prj_ob_varb (FENSTER * f)
 {
- char *ar_arg[5] = {  NULL, NULL, NULL, NULL, NULL  };
- int ret = 0, file = -1;
- view *pic = NULL;
+  return (e_prj_ob_btt (f, 1));
+}
 
- ar_arg[0] = "ar";
- if (access(library, F_OK))
-  ar_arg[1] = "-cr";
- else
-  ar_arg[1] = "-r";
- ar_arg[2] = library;
- ar_arg[3] = ofile;
- if ((ret = e_p_mess_win("Insert into Archive", 4, ar_arg, &pic, f)) == 0)
- {
-  (*e_u_sys_ini)();
-  file = e_exec_inf(f, ar_arg, 4);
-  (*e_u_sys_end)();
-  if ((file) && ((ret = e_p_exec(file, f, pic)) == 0))
-  {
-   pic = NULL;
+int
+e_prj_ob_inst (FENSTER * f)
+{
+  return (e_prj_ob_btt (f, 2));
+}
+
+int
+e_prj_ob_svas (FENSTER * f)
+{
+  return (e_project_name (f) ? 0 : AltS);
+}
+
+int
+e_project_options (FENSTER * f)
+{
+  int ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
+  char *messagestring;
+
+  if (!o)
+    return (-1);
+  if (!(e_make_prj_opt (f)))
+    {
+      freeostr (o);
+      return (-1);
+    }
+  o->xa = 8;
+  o->ya = 2;
+  o->xe = 68;
+  o->ye = 22;
+  o->bgsw = 0;
+  o->name = "Project-Options";
+  o->crsw = AltS;
+  e_add_txtstr (4, 12, "Compiler-Style:", o);
+  e_add_wrstr (4, 2, 22, 2, 36, 128, 0, AltC, "Compiler:", e_s_prog.compiler,
+	       NULL, o);
+  e_add_wrstr (4, 4, 22, 4, 36, 256, 3, AltP, "ComPiler-Options:",
+	       e_s_prog.comp_str, NULL, o);
+  e_add_wrstr (4, 6, 22, 6, 36, 256, 0, AltL, "Loader-Options:",
+	       e_s_prog.libraries, NULL, o);
+  e_add_wrstr (4, 8, 22, 8, 36, 128, 0, AltE, "Executable:",
+	       e_s_prog.exe_name, NULL, o);
+  e_add_wrstr (4, 10, 22, 10, 36, 128, 2, AltB, "LiBrary:", library, NULL, o);
+  messagestring = WpeStringToValue (e_s_prog.intstr);
+  e_add_wrstr (22, 12, 22, 13, 36, 256, 0, AltM, "Message-String:",
+	       messagestring, NULL, o);
+  free (messagestring);
+  e_add_pswstr (0, 5, 13, 0, AltG, 0, "GNU       ", o);
+  e_add_pswstr (0, 5, 14, 1, AltT, e_s_prog.comp_sw, "OTher     ", o);
+  e_add_bttstr (9, 18, 0, AltS, "Save", NULL, o);
+  e_add_bttstr (44, 18, -1, WPE_ESC, "Cancel", NULL, o);
+  e_add_bttstr (26, 18, 5, AltA, "Save As", e_prj_ob_svas, o);
+/* e_add_bttstr(7, 16, 0, AltF, "Files ...", e_prj_ob_file, o);  */
+  e_add_bttstr (12, 16, 0, AltV, "Variables ...", e_prj_ob_varb, o);
+  e_add_bttstr (35, 16, 0, AltI, "Install ...", e_prj_ob_inst, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      if (e_s_prog.compiler)
+	free (e_s_prog.compiler);
+      e_s_prog.compiler = WpeStrdup (o->wstr[0]->txt);
+      if (e_s_prog.comp_str)
+	free (e_s_prog.comp_str);
+      e_s_prog.comp_str = WpeStrdup (o->wstr[1]->txt);
+      if (e_s_prog.libraries)
+	free (e_s_prog.libraries);
+      e_s_prog.libraries = WpeStrdup (o->wstr[2]->txt);
+      if (e_s_prog.exe_name)
+	free (e_s_prog.exe_name);
+      e_s_prog.exe_name = WpeStrdup (o->wstr[3]->txt);
+      if (e_s_prog.intstr)
+	free (e_s_prog.intstr);
+      e_s_prog.intstr = WpeValueToString (o->wstr[5]->txt);
+      strcpy (library, o->wstr[4]->txt);
+      e_s_prog.comp_sw = o->pstr[0]->num;
+      e_wrt_prj_fl (f);
+    }
+  freeostr (o);
+  if (f->ed->mxedt > 0)
+    e_ed_rahmen (f, 1);
+  return (0);
+}
+
+int
+e_run_c_options (FENSTER * f)
+{
+  int i, j, ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
+  char filepostfix[128];
+  char *newpostfix;
+  char *messagestring;
+
+  if (!o)
+    return (-1);
+  o->xa = 8;
+  o->ya = 2;
+  o->xe = 68;
+  o->ye = 22;
+  o->bgsw = 0;
+  o->name = "Compiler-Options";
+  o->crsw = AltO;
+  e_add_txtstr (4, 14, "Compiler-Style:", o);
+  e_add_wrstr (4, 2, 22, 2, 36, 128, 1, AltA, "LAnguage:", e_s_prog.language,
+	       NULL, o);
+  e_add_wrstr (4, 4, 22, 4, 36, 128, 0, AltC, "Compiler:", e_s_prog.compiler,
+	       NULL, o);
+  e_add_wrstr (4, 6, 22, 6, 36, 128, 3, AltP, "ComPiler-Options:",
+	       e_s_prog.comp_str, NULL, o);
+  e_add_wrstr (4, 8, 22, 8, 36, 128, 0, AltL, "Loader-Options:",
+	       e_s_prog.libraries, NULL, o);
+  e_add_wrstr (4, 10, 22, 10, 36, 128, 0, AltE, "Executable:",
+	       e_s_prog.exe_name, NULL, o);
+  filepostfix[0] = 0;
+  if ((j = WpeExpArrayGetSize (e_s_prog.filepostfix)))
+    {
+      strcpy (filepostfix, e_s_prog.filepostfix[0]);
+      for (i = 1; i < j; i++)
+	{
+	  strcat (filepostfix, " ");
+	  strcat (filepostfix, e_s_prog.filepostfix[i]);
+	}
+    }
+  e_add_wrstr (4, 12, 22, 12, 36, 128, 0, AltF, "File-Postfix:", filepostfix,
+	       NULL, o);
+  messagestring = WpeStringToValue (e_s_prog.intstr);
+  e_add_wrstr (22, 14, 22, 15, 36, 128, 0, AltM, "Message-String:",
+	       messagestring, NULL, o);
+  free (messagestring);
+  e_add_pswstr (0, 5, 15, 0, AltG, 0, "GNU      ", o);
+  e_add_pswstr (0, 5, 16, 1, AltT, e_s_prog.comp_sw, "OTher    ", o);
+  e_add_bttstr (16, 18, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (37, 18, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      if (e_s_prog.language)
+	free (e_s_prog.language);
+      e_s_prog.language = WpeStrdup (o->wstr[0]->txt);
+      if (e_s_prog.compiler)
+	free (e_s_prog.compiler);
+      e_s_prog.compiler = WpeStrdup (o->wstr[1]->txt);
+      if (e_s_prog.comp_str)
+	free (e_s_prog.comp_str);
+      e_s_prog.comp_str = WpeStrdup (o->wstr[2]->txt);
+      if (e_s_prog.libraries)
+	free (e_s_prog.libraries);
+      e_s_prog.libraries = WpeStrdup (o->wstr[3]->txt);
+      if (e_s_prog.exe_name)
+	free (e_s_prog.exe_name);
+      e_s_prog.exe_name = WpeStrdup (o->wstr[4]->txt);
+      for (i = 0; i < j; i++)
+	free (e_s_prog.filepostfix[i]);
+      WpeExpArrayDestroy (e_s_prog.filepostfix);
+      e_s_prog.filepostfix =
+	(char **) WpeExpArrayCreate (0, sizeof (char *), 1);
+      for (i = 0; o->wstr[5]->txt[i]; i++)
+	{
+	  if (isspace (o->wstr[5]->txt[i]))
+	    continue;
+	  for (j = i; (o->wstr[5]->txt[j]) && (!isspace (o->wstr[5]->txt[j]));
+	       j++)
+	    ;
+	  newpostfix = (char *) malloc (sizeof (char) * j - i + 1);
+	  strncpy (newpostfix, o->wstr[5]->txt + i, j - i);
+	  newpostfix[j - i] = 0;
+	  WpeExpArrayAdd ((void **) &e_s_prog.filepostfix, &newpostfix);
+	  i = j - 1;
+	}
+      if (e_s_prog.intstr)
+	free (e_s_prog.intstr);
+      e_s_prog.intstr = WpeValueToString (o->wstr[6]->txt);
+      e_s_prog.comp_sw = o->pstr[0]->num;
+    }
+  freeostr (o);
+  return (0);
+}
+
+int
+e_run_options (FENSTER * f)
+{
+  int i, n, xa = 48, ya = 2, num = 2 + e_prog.num;
+  OPTK *opt = malloc (num * sizeof (OPTK));
+  char tmp[80];
+
+  tmp[0] = '\0';
+  opt[0].t = "Add Compiler   ";
+  opt[0].x = 0;
+  opt[0].o = 'A';
+  opt[1].t = "Remove Compiler";
+  opt[1].x = 0;
+  opt[1].o = 'R';
+
+  for (i = 0; i < e_prog.num; i++)
+    {
+      opt[i + 2].t = e_prog.comp[i]->language;
+      opt[i + 2].x = e_prog.comp[i]->x;
+      opt[i + 2].o = e_prog.comp[i]->key;
+    }
+  n = e_opt_sec_box (xa, ya, num, opt, f, 1);
+
+  if (n == 0)
+    {
+      if (!e_run_c_options (f))
+	{
+	  e_prog.num++;
+	  e_prog.comp =
+	    realloc (e_prog.comp, e_prog.num * sizeof (struct e_s_prog *));
+	  e_prog.comp[e_prog.num - 1] = malloc (sizeof (struct e_s_prog));
+	  e_prog.comp[e_prog.num - 1]->language = (char *) malloc (1);
+	  e_prog.comp[e_prog.num - 1]->language[0] = 0;
+	  e_prog.comp[e_prog.num - 1]->compiler = (char *) malloc (1);
+	  e_prog.comp[e_prog.num - 1]->compiler[0] = 0;
+	  e_prog.comp[e_prog.num - 1]->comp_str = (char *) malloc (1);
+	  e_prog.comp[e_prog.num - 1]->comp_str[0] = 0;
+	  e_prog.comp[e_prog.num - 1]->libraries = (char *) malloc (1);
+	  e_prog.comp[e_prog.num - 1]->libraries[0] = 0;
+	  e_prog.comp[e_prog.num - 1]->exe_name = (char *) malloc (1);
+	  e_prog.comp[e_prog.num - 1]->exe_name[0] = 0;
+	  e_prog.comp[e_prog.num - 1]->intstr = (char *) malloc (1);
+	  e_prog.comp[e_prog.num - 1]->intstr[0] = 0;
+	  e_prog.comp[e_prog.num - 1]->filepostfix =
+	    (char **) WpeExpArrayCreate (0, sizeof (char *), 1);
+	  e_copy_prog (e_prog.comp[e_prog.num - 1], &e_s_prog);
+	  for (n = 0; e_prog.comp[e_prog.num - 1]->language[n]; n++)
+	    {
+	      for (i = 0; i <= e_prog.num &&
+		   toupper (e_prog.comp[e_prog.num - 1]->language[n]) !=
+		   opt[i].o; i++)
+		;
+	      if (i > e_prog.num)
+		break;
+	    }
+	  e_prog.comp[e_prog.num - 1]->key =
+	    toupper (e_prog.comp[e_prog.num - 1]->language[n]);
+	  e_prog.comp[e_prog.num - 1]->x = n;
+	}
+    }
+  else if (n == 1)
+    {
+      if (e_add_arguments (tmp, "Remove Compiler", f, 0, AltR, NULL))
+	{
+	  for (i = 0;
+	       i < e_prog.num && strcmp (e_prog.comp[i]->language, tmp); i++)
+	    ;
+	  if (i >= e_prog.num)
+	    {
+	      e_error (e_p_msg[ERR_NO_COMPILER], 0, f->fb);
+	      free (opt);
+	      return (0);
+	    }
+	  free (e_prog.comp[i]);
+	  for (; i < e_prog.num - 1; i++)
+	    e_prog.comp[i] = e_prog.comp[i + 1];
+	  e_prog.num--;
+	}
+    }
+  else if (n > 1)
+    {
+      e_copy_prog (&e_s_prog, e_prog.comp[n - 2]);
+      e_run_c_options (f);
+      e_copy_prog (e_prog.comp[n - 2], &e_s_prog);
+    }
+  free (opt);
+  return (n < 0 ? WPE_ESC : 0);
+}
+
+int
+e_project_name (FENSTER * f)
+{
+  char str[80];
+
+  if (!e_prog.project)
+    {
+      e_prog.project = malloc (1);
+      e_prog.project[0] = '\0';
+    }
+  strcpy (str, e_prog.project);
+  if (e_add_arguments (str, "Project", f, 0, AltP, NULL))
+    {
+      e_prog.project = realloc (e_prog.project, strlen (str) + 1);
+      strcpy (e_prog.project, str);
+      return (0);
+    }
+  return (WPE_ESC);
+}
+
+int
+e_project (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  int i;
+  if (!e_project_name (f))
+    {
+      for (i = cn->mxedt;
+	   i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
+	;
+      if (i > 0)
+	{
+	  e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	  e_close_window (cn->f[cn->mxedt]);
+	}
+      f = cn->f[cn->mxedt];
+      e_make_prj_opt (f);
+      e_rel_brkwtch (f);
+      e_prj_ob_file (f);
+      return (0);
+    }
+  return (WPE_ESC);
+}
+
+int
+e_show_project (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  int i;
+
+  for (i = cn->mxedt;
+       i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
+    ;
+  if (i > 0)
+    e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+  else
+    {
+      e_make_prj_opt (f);
+      e_prj_ob_file (f);
+    }
+  return (0);
+}
+
+int
+e_cl_project (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  int i;
+
+  if (!e_prog.project)
+    e_prog.project = malloc (sizeof (char));
+  else
+    e_prog.project = realloc (e_prog.project, sizeof (char));
+  e_prog.project[0] = '\0';
+  for (i = cn->mxedt;
+       i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
+    ;
+  if (i > 0)
+    {
+      e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+      e_close_window (cn->f[cn->mxedt]);
+    }
+  return (0);
+}
+
+int
+e_p_add_item (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  int i;
+
+  for (i = cn->mxedt;
+       i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
+    ;
+  if (i > 0)
+    e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+  else
+    {
+      FLWND *fw;
+
+      e_make_prj_opt (f);
+      e_prj_ob_file (f);
+      fw = (FLWND *) cn->f[cn->mxedt]->b;
+      fw->nf = fw->df->anz - 1;
+    }
+  cn->f[cn->mxedt]->save = 1;
+  WpeCreateFileManager (5, cn, NULL);
+  WpeHandleFileManager (cn);
+  return (0);
+}
+
+int
+e_p_del_item (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  int i;
+
+  for (i = cn->mxedt;
+       i > 0 && (cn->f[i]->dtmd != DTMD_DATA || cn->f[i]->ins != 4); i--)
+    ;
+  if (i > 0)
+    e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+  else
+    return (e_error (e_p_msg[ERR_NOPROJECT], 0, f->fb));
+  f = cn->f[cn->mxedt];
+  f->save = 1;
+  e_p_del_df ((FLWND *) f->b, f->ins);
+  return 0;
+}
+
+int
+e_make_library (char *library, char *ofile, FENSTER * f)
+{
+  char *ar_arg[5] = { NULL, NULL, NULL, NULL, NULL };
+  int ret = 0, file = -1;
+  view *pic = NULL;
+
+  ar_arg[0] = "ar";
+  if (access (library, F_OK))
+    ar_arg[1] = "-cr";
+  else
+    ar_arg[1] = "-r";
+  ar_arg[2] = library;
+  ar_arg[3] = ofile;
+  if ((ret = e_p_mess_win ("Insert into Archive", 4, ar_arg, &pic, f)) == 0)
+    {
+      (*e_u_sys_ini) ();
+      file = e_exec_inf (f, ar_arg, 4);
+      (*e_u_sys_end) ();
+      if ((file) && ((ret = e_p_exec (file, f, pic)) == 0))
+	{
+	  pic = NULL;
 /*
 #ifdef RANLIB
     ar_arg[0] = "ranlib";
@@ -1474,872 +1597,1025 @@ int e_make_library(char *library, char *ofile, FENSTER *f)
     if(file) ret = e_p_exec(file, f, pic);
 #endif
 */
-  }
- }
- return((!ret && file) ? 0 : -1);
+	}
+    }
+  return ((!ret && file) ? 0 : -1);
 }
 
-int e_system(char *estr, ECNT *cn)
+int
+e_system (char *estr, ECNT * cn)
 {
 #if MOUSE
- int g[4];
+  int g[4];
 #endif
- int ret;
- view *outp;
+  int ret;
+  view *outp;
 
 #if  MOUSE
- g[0] = 2;
- fk_mouse(g);
+  g[0] = 2;
+  fk_mouse (g);
 #endif
- outp = e_open_view(0,0,MAXSCOL-1,MAXSLNS-1,cn->fb->ws,1);
- fk_locate(0,0);
- fk_cursor(1);
- (*e_u_s_sys_ini)();
- ret = system(estr);
- if (!WpeIsXwin())
- {
-  printf("%s", e_msg[ERR_HITCR]);
-  fflush(stdout);
-  fk_getch();
- }
- (*e_u_s_sys_end)();
- e_close_view(outp, 1);
- fk_cursor(0);
+  outp = e_open_view (0, 0, MAXSCOL - 1, MAXSLNS - 1, cn->fb->ws, 1);
+  fk_locate (0, 0);
+  fk_cursor (1);
+  (*e_u_s_sys_ini) ();
+  ret = system (estr);
+  if (!WpeIsXwin ())
+    {
+      printf ("%s", e_msg[ERR_HITCR]);
+      fflush (stdout);
+      fk_getch ();
+    }
+  (*e_u_s_sys_end) ();
+  e_close_view (outp, 1);
+  fk_cursor (0);
 #if  MOUSE
- g[0] = 1;
- fk_mouse(g);
+  g[0] = 1;
+  fk_mouse (g);
 #endif
- return(ret);
+  return (ret);
 }
 
 /* arranges string str into buffer b and eventually wrappes string around
  wrap_limit columns */
-int print_to_end_of_buffer(BUFFER * b,char * str,int wrap_limit)
+int
+print_to_end_of_buffer (BUFFER * b, char *str, int wrap_limit)
 {
- int i,k,j;
+  int i, k, j;
 
- k = 0;
- do
- {
-  if (wrap_limit != 0)
-   for (j = 0;
-     ((j < wrap_limit) && (!((str[j + k] == '\n') || (str[j + k] == '\0'))));
-     j++)
-    ;
-  else
-   for (j = 0; (!((str[j + k] == '\n') || (str[j + k] == '\0'))); j++)
-    ;
-  /* Don't add blank lines */
-  if (j == k)
-   break;
+  k = 0;
+  do
+    {
+      if (wrap_limit != 0)
+	for (j = 0;
+	     ((j < wrap_limit)
+	      && (!((str[j + k] == '\n') || (str[j + k] == '\0')))); j++)
+	  ;
+      else
+	for (j = 0; (!((str[j + k] == '\n') || (str[j + k] == '\0'))); j++)
+	  ;
+      /* Don't add blank lines */
+      if (j == k)
+	break;
 
 /* b->mxlines - count of lines in b
    so add one more line at the end of buffer */
-  e_new_line(b->mxlines, b);
-  i = b->mxlines-1;
+      e_new_line (b->mxlines, b);
+      i = b->mxlines - 1;
 
 /* copy char from string (str) to buffer */
 
-  if (str[j + k]!='\0')
-   b->bf[i].s = realloc(b->bf[i].s, j + 2);
-  else
-   b->bf[i].s = realloc(b->bf[i].s, j + 1);
-  strncpy((char *)b->bf[i].s,str + k,j);
+      if (str[j + k] != '\0')
+	b->bf[i].s = realloc (b->bf[i].s, j + 2);
+      else
+	b->bf[i].s = realloc (b->bf[i].s, j + 1);
+      strncpy ((char *) b->bf[i].s, str + k, j);
 
 /* if this is not end of string, then we created substring
  if *(b->bf[i].s+j) is not '\0' then it is soft break is not written to file */
 
-  if (str[j + k]!='\0')
-  {
-   *(b->bf[i].s + j) = '\n';
-   *(b->bf[i].s + j + 1) = '\0';
-  }
-  else
-  {
-   *(b->bf[i].s + j) = '\0';
-  }
+      if (str[j + k] != '\0')
+	{
+	  *(b->bf[i].s + j) = '\n';
+	  *(b->bf[i].s + j + 1) = '\0';
+	}
+      else
+	{
+	  *(b->bf[i].s + j) = '\0';
+	}
 /* update len of line in buffer */
-  b->bf[i].len = j;
-  b->bf[i].nrc = j + 1;
+      b->bf[i].len = j;
+      b->bf[i].nrc = j + 1;
 
-  if (str[j + k]=='\n')
-  {
-   j++;
-  }
+      if (str[j + k] == '\n')
+	{
+	  j++;
+	}
 
-  k += j;
+      k += j;
 
 /* loop until end of string
  } while (str[k] != '\n' && str[k] != '\0');*/
- } while (str[k] != '\0');
+    }
+  while (str[k] != '\0');
 
- return 0;
+  return 0;
 }
 
 /* print to message window */
-int e_d_p_message(char *str, FENSTER *f, int sw)
+int
+e_d_p_message (char *str, FENSTER * f, int sw)
 {
- ECNT *cn = f->ed;
- BUFFER *b;
- int i;
+  ECNT *cn = f->ed;
+  BUFFER *b;
+  int i;
 
- if (str[0] == '\0' || str[0] == '\n')
-  return(0);
- for (i = cn->mxedt; i > 0 && strcmp(cn->f[i]->datnam, "Messages"); i--)
-  ;
- if (i == 0)
- {
-  if (e_edit(cn, "Messages"))
-   return(-1);
-  else
-   i = cn->mxedt;
- }
+  if (str[0] == '\0' || str[0] == '\n')
+    return (0);
+  for (i = cn->mxedt; i > 0 && strcmp (cn->f[i]->datnam, "Messages"); i--)
+    ;
+  if (i == 0)
+    {
+      if (e_edit (cn, "Messages"))
+	return (-1);
+      else
+	i = cn->mxedt;
+    }
 
 /* f - window */
- f = cn->f[i];
+  f = cn->f[i];
 
 /* b - buffer */
- b = cn->f[i]->b;
+  b = cn->f[i]->b;
 
 /* s - content of window -----> not used */
 
- print_to_end_of_buffer(b, str, b->mx.x);
+  print_to_end_of_buffer (b, str, b->mx.x);
 
 /* place cursor on the last line */
- b->b.y = b->mxlines-1;
+  b->b.y = b->mxlines - 1;
 
- if (sw)
-  e_rep_win_tree(cn);
- else if (WpeIsXwin())
- {
-  e_schirm(f, 0);
-  e_cursor(f, 0);
-  e_refresh();
- }
- return(0);
+  if (sw)
+    e_rep_win_tree (cn);
+  else if (WpeIsXwin ())
+    {
+      e_schirm (f, 0);
+      e_cursor (f, 0);
+      e_refresh ();
+    }
+  return (0);
 }
 
 #if MOUSE
-int e_d_car_mouse(FENSTER *f)
+int
+e_d_car_mouse (FENSTER * f)
 {
- extern struct mouse e_mouse;
- BUFFER *b = f->ed->f[f->ed->mxedt]->b;
- SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
+  extern struct mouse e_mouse;
+  BUFFER *b = f->ed->f[f->ed->mxedt]->b;
+  SCHIRM *s = f->ed->f[f->ed->mxedt]->s;
 
- if (e_mouse.y-f->a.y+s->c.y-1 == b->b.y)
-  return(WPE_CR);
- else
- {
-  b->b.y = e_mouse.y-f->a.y+s->c.y-1;
-  b->b.x = e_mouse.x-f->a.x+s->c.x-1;
- }
- return(0);
+  if (e_mouse.y - f->a.y + s->c.y - 1 == b->b.y)
+    return (WPE_CR);
+  else
+    {
+      b->b.y = e_mouse.y - f->a.y + s->c.y - 1;
+      b->b.x = e_mouse.x - f->a.x + s->c.x - 1;
+    }
+  return (0);
 }
 #endif
 
-int e_exec_make(FENSTER *f)
+int
+e_exec_make (FENSTER * f)
 {
- ECNT *cn = f->ed;
- char **arg = NULL;
- int i, file, argc;
+  ECNT *cn = f->ed;
+  char **arg = NULL;
+  int i, file, argc;
 
- WpeMouseChangeShape(WpeWorkingShape);
- efildes[0] = efildes[1] = -1;
- wfildes[0] = wfildes[1] = -1;
- for (i = cn->mxedt; i > 0; i--)
-  if (!strcmp(cn->f[i]->datnam, "Makefile") ||
-    !strcmp(cn->f[i]->datnam, "makefile"))
-  {
-   e_switch_window(cn->edt[i], cn->f[cn->mxedt]);
-   e_save(cn->f[cn->mxedt]);
-  }
- if (e_new_message(f))
-  return(WPE_ESC);
- f = cn->f[cn->mxedt];
- (*e_u_sys_ini)();
- if (e_s_prog.compiler)
-  free(e_s_prog.compiler);
- e_s_prog.compiler = malloc(5*sizeof(char));
- strcpy(e_s_prog.compiler, "make");
- argc = e_make_arg(&arg, e_prog.arguments);
- if (argc == 0)
- {
-  arg[1] = NULL;
-  argc = 2;
- }
- else
- {
-  for (i = 1; i < argc; i++)
-   arg[i] = arg[i+1];
- }
- if ((file = e_exec_inf(f, arg, argc)) == 0)
- {
-  (*e_u_sys_end)();
-  WpeMouseRestoreShape();
-  return(WPE_ESC);
- }
- (*e_u_sys_end)();
- e_free_arg(arg, argc - 1);
- i = e_p_exec(file, f, NULL);
- WpeMouseRestoreShape();
- return(i);
+  WpeMouseChangeShape (WpeWorkingShape);
+  efildes[0] = efildes[1] = -1;
+  wfildes[0] = wfildes[1] = -1;
+  for (i = cn->mxedt; i > 0; i--)
+    if (!strcmp (cn->f[i]->datnam, "Makefile") ||
+	!strcmp (cn->f[i]->datnam, "makefile"))
+      {
+	e_switch_window (cn->edt[i], cn->f[cn->mxedt]);
+	e_save (cn->f[cn->mxedt]);
+      }
+  if (e_new_message (f))
+    return (WPE_ESC);
+  f = cn->f[cn->mxedt];
+  (*e_u_sys_ini) ();
+  if (e_s_prog.compiler)
+    free (e_s_prog.compiler);
+  e_s_prog.compiler = malloc (5 * sizeof (char));
+  strcpy (e_s_prog.compiler, "make");
+  argc = e_make_arg (&arg, e_prog.arguments);
+  if (argc == 0)
+    {
+      arg[1] = NULL;
+      argc = 2;
+    }
+  else
+    {
+      for (i = 1; i < argc; i++)
+	arg[i] = arg[i + 1];
+    }
+  if ((file = e_exec_inf (f, arg, argc)) == 0)
+    {
+      (*e_u_sys_end) ();
+      WpeMouseRestoreShape ();
+      return (WPE_ESC);
+    }
+  (*e_u_sys_end) ();
+  e_free_arg (arg, argc - 1);
+  i = e_p_exec (file, f, NULL);
+  WpeMouseRestoreShape ();
+  return (i);
 }
 
-int e_run_sh(FENSTER *f)
+int
+e_run_sh (FENSTER * f)
 {
- int ret, len = strlen(f->datnam);
- char estr[128];
+  int ret, len = strlen (f->datnam);
+  char estr[128];
 
- if (strcmp(f->datnam+len-3, ".sh"))
-  return(1);
+  if (strcmp (f->datnam + len - 3, ".sh"))
+    return (1);
 
- WpeMouseChangeShape(WpeWorkingShape);   
- f->filemode |= 0100;
- if (f->save)
-  e_save(f);
- strcpy(estr, f->datnam);
- strcat(estr, " ");
- if (e_prog.arguments)
-  strcat(estr, e_prog.arguments);
+  WpeMouseChangeShape (WpeWorkingShape);
+  f->filemode |= 0100;
+  if (f->save)
+    e_save (f);
+  strcpy (estr, f->datnam);
+  strcat (estr, " ");
+  if (e_prog.arguments)
+    strcat (estr, e_prog.arguments);
 #ifndef NO_XWINDOWS
- if (WpeIsXwin())
- {
-  ret = (*e_u_system)(estr);
- }
- else
+  if (WpeIsXwin ())
+    {
+      ret = (*e_u_system) (estr);
+    }
+  else
 #endif
- ret = e_system(estr, f->ed);
- UNUSED(ret);		// FIXME: can we use the return code from executing the program?
- WpeMouseRestoreShape();
- return(0);
+    ret = e_system (estr, f->ed);
+  UNUSED (ret);			// FIXME: can we use the return code from executing the program?
+  WpeMouseRestoreShape ();
+  return (0);
 }
 
 /*  new project   */
 
-struct proj_var {  char *var, *string;  }  **p_v = NULL;
+struct proj_var
+{
+  char *var, *string;
+} **p_v = NULL;
 int p_v_n = 0;
 
 
-char *e_interpr_var(char *string)
+char *
+e_interpr_var (char *string)
 {
- int i, j;
+  int i, j;
 
- for (i = 0; string[i]; i++)
- {
-  if (string[i] == '\\') 
-   for (j = i; (string[j] = string[j+1]) != '\0'; j++)
-    ;
-  else if (string[i] == '\'' || string[i] == '\"')
-  {
-   for(j = i; (string[j] = string[j+1]) != '\0'; j++)
-    ;
-   i--;
-  }
- }
- return(string);
-}
-
-char *e_expand_var(char *string, FENSTER *f)
-{
- int i, j = 0, k, len, kl = 0;
- char *var = NULL, *v_string, *tmp;
-
- for (i = 0; string[i]; i++)
- {
-  if (string[i] == '\'')
-  {
-   kl = kl ? 0 : 1;
-   for (j = i; (string[j] = string[j+1]) != '\0'; j++);
-   i--;
-   continue;
-  }
-  if (string[i] == '\\' && (string[i+1] == 'n' || string[i+1] == 'r'))
-  {
-   string[i] = string[i+1] == 'n' ? '\n' : '\r';
-   for (j = i+1; (string[j] = string[j+1]) != '\0'; j++);
-   continue;
-  }
-  if (string[i] == '$' && !kl && (!i || string[i-1] != '\\'))
-  {
-   if (string[i+1] == '(')
-   {
-    for (j = i+2; string[j] && string[j] != ')'; j++);
-    if (!string[j]) continue;
-   }
-   else if (string[i+1] == '{')
-   {
-    for (j = i+2; string[j] && string[j] != '}'; j++);
-    if (!string[j]) continue;
-   }
-   if (string[i+1] == '(' || string[i+1] == '{')
-   {
-    if (!(var = malloc((j-i-1) * sizeof(char))))
+  for (i = 0; string[i]; i++)
     {
-     e_error(e_msg[ERR_LOWMEM], 0, f->fb);
-     return(string);
-    }
-    for (k = i+2; k < j; k++) var[k-i-2] = string[k];
-    var[k-i-2] = '\0';
-   }
-   else
-   {
-    if (!(var = malloc(2 * sizeof(char))))
-    {  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(string);  }
-    var[0] = string[i+1];  var[1] = '\0';
-   }
-   if (!(v_string = getenv(var)))
-   {
-    for (k = 0; k < p_v_n - 1; k++)
-    {
-     if (!strcmp(p_v[k]->var, var))
-     {  v_string = p_v[k]->string;  break;  }
-    }
-   }
-   if (string[i+1] == '(' || string[i+1] == '{') len = (j-i+1);
-   else len = 2;
-   if (!v_string)
-   {
-    for(k = i; (string[k] = string[k+len]) != '\0'; k++);
-    if (!(string = realloc(tmp = string, (strlen(string) + 1) * sizeof(char))))
-    {  free(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
-   }
-   else
-   {
-    len = strlen(v_string) - len;
-    if (len >= 0)
-    {
-     if (!(string = realloc(tmp = string, (k = strlen(string) + len + 1) * sizeof(char))))
-     {  free(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
-     for (k--; k > j + len; k--) string[k] = string[k-len];
-     for (k = i; v_string[k-i]; k++) string[k] = v_string[k-i];
-    }
-    else
-    {
-     for (k = i; (string[k] = string[k-len]) != '\0'; k++);
-     for (k = i; v_string[k-i]; k++) string[k] = v_string[k-i];
-     if (!(string = realloc(tmp = string, (strlen(string) + 1) * sizeof(char))))
-     {  free(var);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(tmp);  }
-    }
-   }
-   free(var);
-  }
- }
- return(string);
-}
-
-int e_read_var(FENSTER *f)
-{
- struct proj_var **tmp;
- FILE *fp;
- char str[256], *sp1, *sp2, *stmp;
- int i;
-
- if ((fp = fopen(e_prog.project, "r")) == NULL) return(-1);
- if (p_v)
- {
-  for (i = 0; i < p_v_n; i++)
-  {
-   if (p_v[i])
-   {
-    if (p_v[i]->var) free(p_v[i]->var);
-    if (p_v[i]->string) free(p_v[i]->string);
-    free(p_v[i]);
-   }
-  }
-  free(p_v);
- }
- p_v_n = 0;
- if (!(p_v = malloc(sizeof(struct proj_var *))))
- {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
- while (!feof(fp) && fgets(str, 256, fp))
- {
-  for (i = 0; isspace(str[i]); i++);
-  if (!str[i]) continue;
-  else if (str[i] == '#')
-  {
-   while (str[strlen(str)-1] != '\n')
-   {  
-	if (!fgets(str, 256, fp)) {  
-		break;
+      if (string[i] == '\\')
+	for (j = i; (string[j] = string[j + 1]) != '\0'; j++)
+	  ;
+      else if (string[i] == '\'' || string[i] == '\"')
+	{
+	  for (j = i; (string[j] = string[j + 1]) != '\0'; j++)
+	    ;
+	  i--;
 	}
-   }
-   continue;
-  }
-  sp1 = str + i;
-  sp2 = strchr(sp1, '=');
-  if (sp2 == NULL) continue;
-  for (stmp = sp1; !((isspace(*stmp)) || (*stmp == '=')) && *stmp; stmp++)
-   ;
-  *stmp = 0;
-  for (sp2++; isspace(*sp2) && *sp2 != '\n'; sp2++);
-  p_v_n++;
-  if (!(p_v = realloc(tmp = p_v, sizeof(struct proj_var *) * p_v_n)))
-  {  p_v = tmp;  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-  if (!(p_v[p_v_n-1] = malloc(sizeof(struct proj_var))))
-  {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-  if (!(p_v[p_v_n-1]->var = malloc((strlen(sp1)+1) * sizeof(char))))
-  {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-  strcpy(p_v[p_v_n-1]->var, sp1);
-  if (!(p_v[p_v_n-1]->string = malloc((strlen(sp2)+1) * sizeof(char))))
-  {  fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);  }
-  strcpy(p_v[p_v_n-1]->string, sp2);
-  while (p_v[p_v_n-1]->string[i = strlen(p_v[p_v_n-1]->string) - 1] != '\n' || (i && p_v[p_v_n-1]->string[i-1] == '\\'))
-  {
-   if (p_v[p_v_n-1]->string[i-1] == '\\') p_v[p_v_n-1]->string[i-1] = '\0';
-   if (!fgets(str, 256, fp)) break;
-   if (!(p_v[p_v_n-1]->string = realloc(stmp = p_v[p_v_n-1]->string,
-		(strlen(p_v[p_v_n-1]->string)+strlen(str)+1) * sizeof(char))))
-   {
-    p_v[p_v_n-1]->string = stmp;
-    fclose(fp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(-1);
-   }
-   strcat(p_v[p_v_n-1]->string, str);
-  }
-  p_v[p_v_n-1]->string[strlen(p_v[p_v_n-1]->string) - 1] = '\0';
-  for (i = 0; p_v[p_v_n-1]->string[i]; i++)
-   if (p_v[p_v_n-1]->string[i] == '\t') p_v[p_v_n-1]->string[i] = ' ';
-  p_v[p_v_n-1]->string = e_expand_var(p_v[p_v_n-1]->string, f);
- }
- fclose(fp);
- return(0);
-}
-
-int e_install(FENSTER *f)
-{
- char *tp, *sp, *string, *tmp, text[256];
- FILE *fp;
- int i, j;
-
- if (e_p_make(f)) return(-1);
- if (!e__project) return(0);
- if ((fp = fopen(e_prog.project, "r")) == NULL)
- {
-  sprintf(text, e_msg[ERR_FOPEN], e_prog.project);
-  e_error(text, 0, f->fb);
-  return(WPE_ESC);
- }
- while ((tp = fgets(text, 256, fp)))
- {
-  if (text[0] == '\t') continue;
-  for (i = 0; isspace(text[i]); i++)
-   ;
-  if (!strncmp(text+i, "install:", 8))
-  {
-   while (tp && (text[j = strlen(text)-1] != '\n' || text[j-1] == '\\'))
-    tp = fgets(text, 256, fp);
-   break;
-  }
- }
- if (!tp)
- {
-  fclose(fp);
-  return(1);
- }
- while (tp && (tp = fgets(text, 256, fp)))
- {
-  for (i = 0; isspace(text[i]); i++)
-   ;
-  sp = text+i;
-  if (sp[0] == '#')
-  {
-   while (tp && (text[j = strlen(text)-1] != '\n' || text[j-1] == '\\'))
-    tp = fgets(text, 256, fp);
-   continue;
-  }
-  if (text[0] != '\t')
-   break;
-  if (!(string = malloc(strlen(sp) + 1)))
-  {
-   fclose(fp);
-   e_error(e_msg[ERR_LOWMEM], 0, f->fb);
-   return(-1);
-  }
-  strcpy(string, sp);
-  while (tp && (text[j = strlen(text)-1] != '\n' || text[j-1] == '\\'))
-  {
-   tp = fgets(text, 256, fp);
-   if (tp)
-   {
-    if (!(string = realloc(tmp = string, strlen(string) + strlen(text) + 1)))
-    {
-     fclose(fp);
-     free(tmp);
-     e_error(e_msg[ERR_LOWMEM], 0, f->fb);
-     return(-1);
     }
-    strcat(string, text);
-   }
-  }
-  if (p_v_n)
-   p_v_n++;
-  string = e_expand_var(string, f);
-  if (p_v_n) p_v_n--;
-  e_d_p_message(string, f, 1);
-  int ret = system(string);
-  if (WIFSIGNALED(ret) && (WTERMSIG(ret) == SIGINT || WTERMSIG(ret) == SIGQUIT)) {
-	// ignore interrupt
-  } else if (ret != 0) {
-        // ignore return status of child (or 127 if shell was not available)
-  }
-  free(string);
- }
- fclose(fp);
- return(0);
+  return (string);
 }
 
-struct dirfile *e_p_get_args(char *string)
+char *
+e_expand_var (char *string, FENSTER * f)
 {
- struct dirfile *df = malloc(sizeof(struct dirfile));
- char **tmp;
- int i, j, k;
+  int i, j = 0, k, len, kl = 0;
+  char *var = NULL, *v_string, *tmp;
 
- if (!df)
-  return(NULL);
- if (!(df->name = malloc(sizeof(char *))))
- {
-  free(df);
-  return(NULL);
- }
- df->anz = 0;
- for (i = 0; string[i]; )
- {
-  for (; isspace(string[i]); i++)
-   ;
-  for (j = i; string[j] && !isspace(string[j]); j++)
-   ;
-  if (j == i)
-   break;
-  df->anz++;
-  if (!(df->name = realloc(tmp = df->name, df->anz * sizeof(char *))))
-  {
-   df->anz--;
-   df->name = tmp;
-   return(df);
-  }
-  if (!(df->name[df->anz-1] = malloc((j-i+1)*sizeof(char))))
-  {
-   df->anz--;
-   return(df);
-  }
-  for (k = i; k < j; k++)
-   *(df->name[df->anz-1] + k - i) = string[k];
-  *(df->name[df->anz-1] + k - i) = '\0';
-  e_interpr_var(df->name[df->anz-1]);
-  i = j;
- }
- return(df);
+  for (i = 0; string[i]; i++)
+    {
+      if (string[i] == '\'')
+	{
+	  kl = kl ? 0 : 1;
+	  for (j = i; (string[j] = string[j + 1]) != '\0'; j++);
+	  i--;
+	  continue;
+	}
+      if (string[i] == '\\' && (string[i + 1] == 'n' || string[i + 1] == 'r'))
+	{
+	  string[i] = string[i + 1] == 'n' ? '\n' : '\r';
+	  for (j = i + 1; (string[j] = string[j + 1]) != '\0'; j++);
+	  continue;
+	}
+      if (string[i] == '$' && !kl && (!i || string[i - 1] != '\\'))
+	{
+	  if (string[i + 1] == '(')
+	    {
+	      for (j = i + 2; string[j] && string[j] != ')'; j++);
+	      if (!string[j])
+		continue;
+	    }
+	  else if (string[i + 1] == '{')
+	    {
+	      for (j = i + 2; string[j] && string[j] != '}'; j++);
+	      if (!string[j])
+		continue;
+	    }
+	  if (string[i + 1] == '(' || string[i + 1] == '{')
+	    {
+	      if (!(var = malloc ((j - i - 1) * sizeof (char))))
+		{
+		  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		  return (string);
+		}
+	      for (k = i + 2; k < j; k++)
+		var[k - i - 2] = string[k];
+	      var[k - i - 2] = '\0';
+	    }
+	  else
+	    {
+	      if (!(var = malloc (2 * sizeof (char))))
+		{
+		  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		  return (string);
+		}
+	      var[0] = string[i + 1];
+	      var[1] = '\0';
+	    }
+	  if (!(v_string = getenv (var)))
+	    {
+	      for (k = 0; k < p_v_n - 1; k++)
+		{
+		  if (!strcmp (p_v[k]->var, var))
+		    {
+		      v_string = p_v[k]->string;
+		      break;
+		    }
+		}
+	    }
+	  if (string[i + 1] == '(' || string[i + 1] == '{')
+	    len = (j - i + 1);
+	  else
+	    len = 2;
+	  if (!v_string)
+	    {
+	      for (k = i; (string[k] = string[k + len]) != '\0'; k++);
+	      if (!
+		  (string =
+		   realloc (tmp =
+			    string, (strlen (string) + 1) * sizeof (char))))
+		{
+		  free (var);
+		  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		  return (tmp);
+		}
+	    }
+	  else
+	    {
+	      len = strlen (v_string) - len;
+	      if (len >= 0)
+		{
+		  if (!
+		      (string =
+		       realloc (tmp =
+				string, (k =
+					 strlen (string) + len +
+					 1) * sizeof (char))))
+		    {
+		      free (var);
+		      e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		      return (tmp);
+		    }
+		  for (k--; k > j + len; k--)
+		    string[k] = string[k - len];
+		  for (k = i; v_string[k - i]; k++)
+		    string[k] = v_string[k - i];
+		}
+	      else
+		{
+		  for (k = i; (string[k] = string[k - len]) != '\0'; k++);
+		  for (k = i; v_string[k - i]; k++)
+		    string[k] = v_string[k - i];
+		  if (!
+		      (string =
+		       realloc (tmp =
+				string,
+				(strlen (string) + 1) * sizeof (char))))
+		    {
+		      free (var);
+		      e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		      return (tmp);
+		    }
+		}
+	    }
+	  free (var);
+	}
+    }
+  return (string);
 }
 
-struct dirfile *e_p_get_var(char *string)
+int
+e_read_var (FENSTER * f)
 {
- int i;
+  struct proj_var **tmp;
+  FILE *fp;
+  char str[256], *sp1, *sp2, *stmp;
+  int i;
 
- for (i = 0; i < p_v_n; i++)
- {
-  if(!strcmp(p_v[i]->var, string))
-   return(e_p_get_args(p_v[i]->string));
- }
- return(NULL);
+  if ((fp = fopen (e_prog.project, "r")) == NULL)
+    return (-1);
+  if (p_v)
+    {
+      for (i = 0; i < p_v_n; i++)
+	{
+	  if (p_v[i])
+	    {
+	      if (p_v[i]->var)
+		free (p_v[i]->var);
+	      if (p_v[i]->string)
+		free (p_v[i]->string);
+	      free (p_v[i]);
+	    }
+	}
+      free (p_v);
+    }
+  p_v_n = 0;
+  if (!(p_v = malloc (sizeof (struct proj_var *))))
+    {
+      fclose (fp);
+      e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+      return (-1);
+    }
+  while (!feof (fp) && fgets (str, 256, fp))
+    {
+      for (i = 0; isspace (str[i]); i++);
+      if (!str[i])
+	continue;
+      else if (str[i] == '#')
+	{
+	  while (str[strlen (str) - 1] != '\n')
+	    {
+	      if (!fgets (str, 256, fp))
+		{
+		  break;
+		}
+	    }
+	  continue;
+	}
+      sp1 = str + i;
+      sp2 = strchr (sp1, '=');
+      if (sp2 == NULL)
+	continue;
+      for (stmp = sp1; !((isspace (*stmp)) || (*stmp == '=')) && *stmp;
+	   stmp++)
+	;
+      *stmp = 0;
+      for (sp2++; isspace (*sp2) && *sp2 != '\n'; sp2++);
+      p_v_n++;
+      if (!(p_v = realloc (tmp = p_v, sizeof (struct proj_var *) * p_v_n)))
+	{
+	  p_v = tmp;
+	  fclose (fp);
+	  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+	  return (-1);
+	}
+      if (!(p_v[p_v_n - 1] = malloc (sizeof (struct proj_var))))
+	{
+	  fclose (fp);
+	  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+	  return (-1);
+	}
+      if (!
+	  (p_v[p_v_n - 1]->var = malloc ((strlen (sp1) + 1) * sizeof (char))))
+	{
+	  fclose (fp);
+	  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+	  return (-1);
+	}
+      strcpy (p_v[p_v_n - 1]->var, sp1);
+      if (!
+	  (p_v[p_v_n - 1]->string =
+	   malloc ((strlen (sp2) + 1) * sizeof (char))))
+	{
+	  fclose (fp);
+	  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+	  return (-1);
+	}
+      strcpy (p_v[p_v_n - 1]->string, sp2);
+      while (p_v[p_v_n - 1]->
+	     string[i = strlen (p_v[p_v_n - 1]->string) - 1] != '\n' || (i
+									 &&
+									 p_v
+									 [p_v_n
+									  -
+									  1]->
+									 string
+									 [i -
+									  1]
+									 ==
+									 '\\'))
+	{
+	  if (p_v[p_v_n - 1]->string[i - 1] == '\\')
+	    p_v[p_v_n - 1]->string[i - 1] = '\0';
+	  if (!fgets (str, 256, fp))
+	    break;
+	  if (!
+	      (p_v[p_v_n - 1]->string =
+	       realloc (stmp =
+			p_v[p_v_n - 1]->string,
+			(strlen (p_v[p_v_n - 1]->string) + strlen (str) +
+			 1) * sizeof (char))))
+	    {
+	      p_v[p_v_n - 1]->string = stmp;
+	      fclose (fp);
+	      e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+	      return (-1);
+	    }
+	  strcat (p_v[p_v_n - 1]->string, str);
+	}
+      p_v[p_v_n - 1]->string[strlen (p_v[p_v_n - 1]->string) - 1] = '\0';
+      for (i = 0; p_v[p_v_n - 1]->string[i]; i++)
+	if (p_v[p_v_n - 1]->string[i] == '\t')
+	  p_v[p_v_n - 1]->string[i] = ' ';
+      p_v[p_v_n - 1]->string = e_expand_var (p_v[p_v_n - 1]->string, f);
+    }
+  fclose (fp);
+  return (0);
 }
 
-int e_c_project(FENSTER *f)
+int
+e_install (FENSTER * f)
 {
- ECNT *cn = f->ed;
- struct dirfile *df = NULL;
- char **arg;
- int i, j, k, file= -1, len, elen, argc, libsw = 0, exlib = 0, sccs = 0;
- char ofile[128];
+  char *tp, *sp, *string, *tmp, text[256];
+  FILE *fp;
+  int i, j;
+
+  if (e_p_make (f))
+    return (-1);
+  if (!e__project)
+    return (0);
+  if ((fp = fopen (e_prog.project, "r")) == NULL)
+    {
+      sprintf (text, e_msg[ERR_FOPEN], e_prog.project);
+      e_error (text, 0, f->fb);
+      return (WPE_ESC);
+    }
+  while ((tp = fgets (text, 256, fp)))
+    {
+      if (text[0] == '\t')
+	continue;
+      for (i = 0; isspace (text[i]); i++)
+	;
+      if (!strncmp (text + i, "install:", 8))
+	{
+	  while (tp
+		 && (text[j = strlen (text) - 1] != '\n'
+		     || text[j - 1] == '\\'))
+	    tp = fgets (text, 256, fp);
+	  break;
+	}
+    }
+  if (!tp)
+    {
+      fclose (fp);
+      return (1);
+    }
+  while (tp && (tp = fgets (text, 256, fp)))
+    {
+      for (i = 0; isspace (text[i]); i++)
+	;
+      sp = text + i;
+      if (sp[0] == '#')
+	{
+	  while (tp
+		 && (text[j = strlen (text) - 1] != '\n'
+		     || text[j - 1] == '\\'))
+	    tp = fgets (text, 256, fp);
+	  continue;
+	}
+      if (text[0] != '\t')
+	break;
+      if (!(string = malloc (strlen (sp) + 1)))
+	{
+	  fclose (fp);
+	  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+	  return (-1);
+	}
+      strcpy (string, sp);
+      while (tp
+	     && (text[j = strlen (text) - 1] != '\n' || text[j - 1] == '\\'))
+	{
+	  tp = fgets (text, 256, fp);
+	  if (tp)
+	    {
+	      if (!
+		  (string =
+		   realloc (tmp =
+			    string, strlen (string) + strlen (text) + 1)))
+		{
+		  fclose (fp);
+		  free (tmp);
+		  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		  return (-1);
+		}
+	      strcat (string, text);
+	    }
+	}
+      if (p_v_n)
+	p_v_n++;
+      string = e_expand_var (string, f);
+      if (p_v_n)
+	p_v_n--;
+      e_d_p_message (string, f, 1);
+      int ret = system (string);
+      if (WIFSIGNALED (ret)
+	  && (WTERMSIG (ret) == SIGINT || WTERMSIG (ret) == SIGQUIT))
+	{
+	  // ignore interrupt
+	}
+      else if (ret != 0)
+	{
+	  // ignore return status of child (or 127 if shell was not available)
+	}
+      free (string);
+    }
+  fclose (fp);
+  return (0);
+}
+
+struct dirfile *
+e_p_get_args (char *string)
+{
+  struct dirfile *df = malloc (sizeof (struct dirfile));
+  char **tmp;
+  int i, j, k;
+
+  if (!df)
+    return (NULL);
+  if (!(df->name = malloc (sizeof (char *))))
+    {
+      free (df);
+      return (NULL);
+    }
+  df->anz = 0;
+  for (i = 0; string[i];)
+    {
+      for (; isspace (string[i]); i++)
+	;
+      for (j = i; string[j] && !isspace (string[j]); j++)
+	;
+      if (j == i)
+	break;
+      df->anz++;
+      if (!(df->name = realloc (tmp = df->name, df->anz * sizeof (char *))))
+	{
+	  df->anz--;
+	  df->name = tmp;
+	  return (df);
+	}
+      if (!(df->name[df->anz - 1] = malloc ((j - i + 1) * sizeof (char))))
+	{
+	  df->anz--;
+	  return (df);
+	}
+      for (k = i; k < j; k++)
+	*(df->name[df->anz - 1] + k - i) = string[k];
+      *(df->name[df->anz - 1] + k - i) = '\0';
+      e_interpr_var (df->name[df->anz - 1]);
+      i = j;
+    }
+  return (df);
+}
+
+struct dirfile *
+e_p_get_var (char *string)
+{
+  int i;
+
+  for (i = 0; i < p_v_n; i++)
+    {
+      if (!strcmp (p_v[i]->var, string))
+	return (e_p_get_args (p_v[i]->string));
+    }
+  return (NULL);
+}
+
+int
+e_c_project (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  struct dirfile *df = NULL;
+  char **arg;
+  int i, j, k, file = -1, len, elen, argc, libsw = 0, exlib = 0, sccs = 0;
+  char ofile[128];
 #ifdef CHECKHEADER
- struct stat lbuf[1], obuf[1];
+  struct stat lbuf[1], obuf[1];
 #else
- struct stat lbuf[1], cbuf[1], obuf[1];
+  struct stat lbuf[1], cbuf[1], obuf[1];
 #endif
- view *pic = NULL;
+  view *pic = NULL;
 
- last_time = (M_TIME) 0;
- e_p_l_comp = 0;
- if (e_new_message(f)) return(WPE_ESC);
- f = cn->f[cn->mxedt];
- if (e_s_prog.comp_str)
- {
-  free(e_s_prog.comp_str);
-  e_s_prog.comp_str = NULL;
- }
- e_s_prog.comp_sw &= ~1;
- e_argc = 1;
- argc = 1;
- for(i = f->ed->mxedt; i > 0 && (f->ed->f[i]->dtmd != DTMD_DATA ||
-   f->ed->f[i]->ins != 4 || !f->ed->f[i]->save); i--)
-  ;
- if (i > 0) e_p_update_prj_fl(f);
- if (e_read_var(f))
- {
-  sprintf(ofile, e_msg[ERR_FOPEN], e_prog.project);
-  e_error(ofile, 0, f->fb);
-  return(-1);
- }
- e_arg = (char **) malloc(e_argc*sizeof(char *));
- arg = (char **) malloc(argc*sizeof(char *));
- df = e_p_get_var("CMP");
- if (!df)
- {
-  e_error(e_p_msg[ERR_NOTHING], 0, f->fb);
-  e_free_arg(arg, argc);  e_free_arg(e_arg, e_argc);
-  return(-1);
- }
- for (k = 0; k < df->anz; k++, e_argc++, argc++)
- {
-  j = e_argc == 1 ? 1 : 0;
-  e_arg = realloc(e_arg, (e_argc+2)*sizeof(char *));
-  e_arg[e_argc-j] = malloc(strlen(df->name[k]) + 1);
-  strcpy(e_arg[e_argc-j], df->name[k]);
-  arg = realloc(arg, (argc+2)*sizeof(char *));
-  arg[argc-j] = malloc(strlen(df->name[k]) + 1);
-  strcpy(arg[argc-j], df->name[k]);
-  if (e_argc > 1)
-   e_s_prog.comp_str = e_cat_string(e_s_prog.comp_str, e_arg[e_argc-j]);
- }
- freedf(df);
- arg[1] = malloc(3);
- strcpy(arg[1], "-c");
- e_arg[1] = malloc(3);
- strcpy(e_arg[1], "-o");
- df = e_p_get_var("CMPFLAGS");
- if (df)
- {
+  last_time = (M_TIME) 0;
+  e_p_l_comp = 0;
+  if (e_new_message (f))
+    return (WPE_ESC);
+  f = cn->f[cn->mxedt];
+  if (e_s_prog.comp_str)
+    {
+      free (e_s_prog.comp_str);
+      e_s_prog.comp_str = NULL;
+    }
+  e_s_prog.comp_sw &= ~1;
+  e_argc = 1;
+  argc = 1;
+  for (i = f->ed->mxedt; i > 0 && (f->ed->f[i]->dtmd != DTMD_DATA ||
+				   f->ed->f[i]->ins != 4
+				   || !f->ed->f[i]->save); i--)
+    ;
+  if (i > 0)
+    e_p_update_prj_fl (f);
+  if (e_read_var (f))
+    {
+      sprintf (ofile, e_msg[ERR_FOPEN], e_prog.project);
+      e_error (ofile, 0, f->fb);
+      return (-1);
+    }
+  e_arg = (char **) malloc (e_argc * sizeof (char *));
+  arg = (char **) malloc (argc * sizeof (char *));
+  df = e_p_get_var ("CMP");
+  if (!df)
+    {
+      e_error (e_p_msg[ERR_NOTHING], 0, f->fb);
+      e_free_arg (arg, argc);
+      e_free_arg (e_arg, e_argc);
+      return (-1);
+    }
   for (k = 0; k < df->anz; k++, e_argc++, argc++)
-  {
-   j = e_argc == 1 ? 1 : 0;
-   e_arg = realloc(e_arg, (e_argc+2)*sizeof(char *));
-   e_arg[e_argc-j] = malloc(strlen(df->name[k]) + 1);
-   strcpy(e_arg[e_argc-j], df->name[k]);
-   arg = realloc(arg, (argc+2)*sizeof(char *));
-   arg[argc-j] = malloc(strlen(df->name[k]) + 1);
-   strcpy(arg[argc-j], df->name[k]);
-   if (e_argc > 1)
-    e_s_prog.comp_str = e_cat_string(e_s_prog.comp_str, e_arg[e_argc-j]);
-  }
-  freedf(df);
- }
- df = e_p_get_var("EXENAME");
- elen = strlen(e_prog.exedir)-1;
- if (e_prog.exedir[elen] == '/')
-  sprintf(ofile, "%s%s", e_prog.exedir,
-    (df && df->anz > 0 && df->name[0][0]) ? df->name[0] : "a.out");
- else
-  sprintf(ofile, "%s/%s", e_prog.exedir,
-    (df && df->anz > 0 && df->name[0][0]) ? df->name[0] : "a.out");
- if (df) freedf(df);
- if (e_s_prog.exe_name) free(e_s_prog.exe_name);
- e_s_prog.exe_name = WpeStrdup(ofile);
- e_argc = e_add_arg(&e_arg, e_s_prog.exe_name, 2, e_argc);
- df = e_p_get_var("LIBNAME");
- if (df)
- {
-  strcpy(library, df->name[0]);
-  if (access(library, F_OK)) exlib = 1;
-  else stat(library, lbuf);
-  freedf(df);
- }
- else
-  library[0] = '\0';
- df = e_p_get_var("CMPSWTCH");
- if (df)
- {
-  if (!strcmp(df->name[0], "other"))
-   e_s_prog.comp_sw = 1;
-  freedf(df);
- }
- df = e_p_get_var("CMPMESSAGE");
- if (df)
- {
-  char *tmpstr = malloc(1);
-  tmpstr[0] = '\0';
-  for (k = 0; k < df->anz; k++)
-  {
-   tmpstr = realloc(tmpstr,
-     (strlen(tmpstr)+strlen(df->name[k])+2)*sizeof(char));
-   if (k) strcat(tmpstr, " ");
-   strcat(tmpstr, df->name[k]);
-  }
-  if (e_s_prog.intstr) free(e_s_prog.intstr);
-  e_s_prog.intstr = WpeStrdup(tmpstr);
-  free(tmpstr);
-  freedf(df);
- }
- else
- {
-  if (e_s_prog.intstr) free(e_s_prog.intstr);
-  e_s_prog.intstr = WpeStrdup(cc_intstr);
- }
- df = e_p_get_var("FILES");
- if (!df)
- {
-  e_error(e_p_msg[ERR_NOTHING], 0, cn->fb);
-  e_free_arg(arg, argc);  e_free_arg(e_arg, e_argc);
-  return(-1);
- }
- arg[argc] = NULL;
- elen = strlen(e_prog.exedir)-1;
- for (k = 0; k < df->anz; k++)
- {
-  for (j = cn->mxedt; j > 0; j--)
-   if (!strcmp(cn->f[j]->datnam, df->name[k]) && cn->f[j]->save)
-    e_save(cn->f[j]);
-  for (j = strlen(df->name[k])-1; j >= 0 && df->name[k][j] != DIRC; j--)
-   ;
+    {
+      j = e_argc == 1 ? 1 : 0;
+      e_arg = realloc (e_arg, (e_argc + 2) * sizeof (char *));
+      e_arg[e_argc - j] = malloc (strlen (df->name[k]) + 1);
+      strcpy (e_arg[e_argc - j], df->name[k]);
+      arg = realloc (arg, (argc + 2) * sizeof (char *));
+      arg[argc - j] = malloc (strlen (df->name[k]) + 1);
+      strcpy (arg[argc - j], df->name[k]);
+      if (e_argc > 1)
+	e_s_prog.comp_str =
+	  e_cat_string (e_s_prog.comp_str, e_arg[e_argc - j]);
+    }
+  freedf (df);
+  arg[1] = malloc (3);
+  strcpy (arg[1], "-c");
+  e_arg[1] = malloc (3);
+  strcpy (e_arg[1], "-o");
+  df = e_p_get_var ("CMPFLAGS");
+  if (df)
+    {
+      for (k = 0; k < df->anz; k++, e_argc++, argc++)
+	{
+	  j = e_argc == 1 ? 1 : 0;
+	  e_arg = realloc (e_arg, (e_argc + 2) * sizeof (char *));
+	  e_arg[e_argc - j] = malloc (strlen (df->name[k]) + 1);
+	  strcpy (e_arg[e_argc - j], df->name[k]);
+	  arg = realloc (arg, (argc + 2) * sizeof (char *));
+	  arg[argc - j] = malloc (strlen (df->name[k]) + 1);
+	  strcpy (arg[argc - j], df->name[k]);
+	  if (e_argc > 1)
+	    e_s_prog.comp_str =
+	      e_cat_string (e_s_prog.comp_str, e_arg[e_argc - j]);
+	}
+      freedf (df);
+    }
+  df = e_p_get_var ("EXENAME");
+  elen = strlen (e_prog.exedir) - 1;
   if (e_prog.exedir[elen] == '/')
-   sprintf(ofile, "%s%s ", e_prog.exedir, df->name[k]+j+1);
-  else sprintf(ofile, "%s/%s ", e_prog.exedir, df->name[k]+j+1);
-  for (j = strlen(ofile); j > 0 && ofile[j] != '.'; j--)
-   ;
-  ofile[j+1] = 'o';
-  ofile[j+2] = '\0';
-  if (!stat(ofile, obuf))
-  {
-   if (obuf->st_mtime > last_time) last_time = obuf->st_mtime;
-#ifdef CHECKHEADER
-   if (!e_check_header(df->name[k], obuf->st_mtime, cn, 0)) goto gt_library;
-#else
-   stat(df->name[k], cbuf);
-   if (obuf->st_mtime >= cbuf->st_mtime) goto gt_library;
-#endif
-  }
-  argc = e_add_arg(&arg, df->name[k], argc, argc);
-#ifndef NO_MINUS_C_MINUS_O
-  argc = e_add_arg(&arg, "-o", argc, argc);
-  argc = e_add_arg(&arg, ofile, argc, argc);
-#endif
+    sprintf (ofile, "%s%s", e_prog.exedir,
+	     (df && df->anz > 0 && df->name[0][0]) ? df->name[0] : "a.out");
+  else
+    sprintf (ofile, "%s/%s", e_prog.exedir,
+	     (df && df->anz > 0 && df->name[0][0]) ? df->name[0] : "a.out");
+  if (df)
+    freedf (df);
+  if (e_s_prog.exe_name)
+    free (e_s_prog.exe_name);
+  e_s_prog.exe_name = WpeStrdup (ofile);
+  e_argc = e_add_arg (&e_arg, e_s_prog.exe_name, 2, e_argc);
+  df = e_p_get_var ("LIBNAME");
+  if (df)
+    {
+      strcpy (library, df->name[0]);
+      if (access (library, F_OK))
+	exlib = 1;
+      else
+	stat (library, lbuf);
+      freedf (df);
+    }
+  else
+    library[0] = '\0';
+  df = e_p_get_var ("CMPSWTCH");
+  if (df)
+    {
+      if (!strcmp (df->name[0], "other"))
+	e_s_prog.comp_sw = 1;
+      freedf (df);
+    }
+  df = e_p_get_var ("CMPMESSAGE");
+  if (df)
+    {
+      char *tmpstr = malloc (1);
+      tmpstr[0] = '\0';
+      for (k = 0; k < df->anz; k++)
+	{
+	  tmpstr = realloc (tmpstr,
+			    (strlen (tmpstr) + strlen (df->name[k]) +
+			     2) * sizeof (char));
+	  if (k)
+	    strcat (tmpstr, " ");
+	  strcat (tmpstr, df->name[k]);
+	}
+      if (e_s_prog.intstr)
+	free (e_s_prog.intstr);
+      e_s_prog.intstr = WpeStrdup (tmpstr);
+      free (tmpstr);
+      freedf (df);
+    }
+  else
+    {
+      if (e_s_prog.intstr)
+	free (e_s_prog.intstr);
+      e_s_prog.intstr = WpeStrdup (cc_intstr);
+    }
+  df = e_p_get_var ("FILES");
+  if (!df)
+    {
+      e_error (e_p_msg[ERR_NOTHING], 0, cn->fb);
+      e_free_arg (arg, argc);
+      e_free_arg (e_arg, e_argc);
+      return (-1);
+    }
   arg[argc] = NULL;
-  remove(ofile);
-  sccs = 1;
-  j = e_p_mess_win("Compiling", argc, arg, &pic, f);
-  (*e_u_sys_ini)();
-  if (j != 0 || (file = e_exec_inf(f, arg, argc)) == 0)
-  {
-   (*e_u_sys_end)();
-   e_free_arg(arg, argc);
-   freedf(df);
-   e_free_arg(e_arg, e_argc);
-   if (pic) e_close_view(pic, 1);
-   return(WPE_ESC);
-  }
-  (*e_u_sys_end)();
-  e_p_l_comp = 1;
-  if (e_p_exec(file, f, pic))
-  {
-   e_free_arg(arg, argc);
-   e_free_arg(e_arg, e_argc);
-   freedf(df);
-   return(-1);
-  }
-  pic = NULL;
-  for (j = strlen(ofile); j >= 0 && ofile[j] != '/'; j--)
-   ;
-  if (!exlib && library[0] != '\0' && strcmp(ofile+j+1, "main.o") &&
-    (strncmp(e_s_prog.exe_name, ofile+j+1,(len = strlen(e_s_prog.exe_name))) ||
-    ofile[len] == '.'))
-  {
-   if(e_make_library(library, ofile, f))
-   {
-    e_free_arg(arg, argc);
-    e_free_arg(e_arg, e_argc);
-    freedf(df);
-    return(-1);  
-   }
-   else libsw = 1;
-  }
-  for (j = 0; j < 3; j++) free(arg[argc-j-1])
-   ;
-  argc -= 3;
-gt_library:
-  for (j = strlen(ofile); j >= 0 && ofile[j] != '/'; j--)
-   ;
-  if (library[0] == '\0' || !strcmp(ofile+j+1, "main.o") ||
-    (!strncmp(e_s_prog.exe_name, ofile+j+1,(len = strlen(e_s_prog.exe_name))) &&
-    ofile[len] == '.'))
-   e_argc = e_add_arg(&e_arg, ofile, e_argc, e_argc);
-  else if (exlib || obuf->st_mtime >= lbuf->st_mtime)
-  {
-   if (e_make_library(library, ofile, f))
-   {
-    e_free_arg(arg, argc);
-    e_free_arg(e_arg, e_argc);
-    freedf(df);
-    return(-1);
-   }
-   else libsw = 1;
-  }
- }
+  elen = strlen (e_prog.exedir) - 1;
+  for (k = 0; k < df->anz; k++)
+    {
+      for (j = cn->mxedt; j > 0; j--)
+	if (!strcmp (cn->f[j]->datnam, df->name[k]) && cn->f[j]->save)
+	  e_save (cn->f[j]);
+      for (j = strlen (df->name[k]) - 1; j >= 0 && df->name[k][j] != DIRC;
+	   j--)
+	;
+      if (e_prog.exedir[elen] == '/')
+	sprintf (ofile, "%s%s ", e_prog.exedir, df->name[k] + j + 1);
+      else
+	sprintf (ofile, "%s/%s ", e_prog.exedir, df->name[k] + j + 1);
+      for (j = strlen (ofile); j > 0 && ofile[j] != '.'; j--)
+	;
+      ofile[j + 1] = 'o';
+      ofile[j + 2] = '\0';
+      if (!stat (ofile, obuf))
+	{
+	  if (obuf->st_mtime > last_time)
+	    last_time = obuf->st_mtime;
+#ifdef CHECKHEADER
+	  if (!e_check_header (df->name[k], obuf->st_mtime, cn, 0))
+	    goto gt_library;
+#else
+	  stat (df->name[k], cbuf);
+	  if (obuf->st_mtime >= cbuf->st_mtime)
+	    goto gt_library;
+#endif
+	}
+      argc = e_add_arg (&arg, df->name[k], argc, argc);
+#ifndef NO_MINUS_C_MINUS_O
+      argc = e_add_arg (&arg, "-o", argc, argc);
+      argc = e_add_arg (&arg, ofile, argc, argc);
+#endif
+      arg[argc] = NULL;
+      remove (ofile);
+      sccs = 1;
+      j = e_p_mess_win ("Compiling", argc, arg, &pic, f);
+      (*e_u_sys_ini) ();
+      if (j != 0 || (file = e_exec_inf (f, arg, argc)) == 0)
+	{
+	  (*e_u_sys_end) ();
+	  e_free_arg (arg, argc);
+	  freedf (df);
+	  e_free_arg (e_arg, e_argc);
+	  if (pic)
+	    e_close_view (pic, 1);
+	  return (WPE_ESC);
+	}
+      (*e_u_sys_end) ();
+      e_p_l_comp = 1;
+      if (e_p_exec (file, f, pic))
+	{
+	  e_free_arg (arg, argc);
+	  e_free_arg (e_arg, e_argc);
+	  freedf (df);
+	  return (-1);
+	}
+      pic = NULL;
+      for (j = strlen (ofile); j >= 0 && ofile[j] != '/'; j--)
+	;
+      if (!exlib && library[0] != '\0' && strcmp (ofile + j + 1, "main.o") &&
+	  (strncmp
+	   (e_s_prog.exe_name, ofile + j + 1,
+	    (len = strlen (e_s_prog.exe_name))) || ofile[len] == '.'))
+	{
+	  if (e_make_library (library, ofile, f))
+	    {
+	      e_free_arg (arg, argc);
+	      e_free_arg (e_arg, e_argc);
+	      freedf (df);
+	      return (-1);
+	    }
+	  else
+	    libsw = 1;
+	}
+      for (j = 0; j < 3; j++)
+	free (arg[argc - j - 1]);
+      argc -= 3;
+    gt_library:
+      for (j = strlen (ofile); j >= 0 && ofile[j] != '/'; j--)
+	;
+      if (library[0] == '\0' || !strcmp (ofile + j + 1, "main.o") ||
+	  (!strncmp
+	   (e_s_prog.exe_name, ofile + j + 1,
+	    (len = strlen (e_s_prog.exe_name))) && ofile[len] == '.'))
+	e_argc = e_add_arg (&e_arg, ofile, e_argc, e_argc);
+      else if (exlib || obuf->st_mtime >= lbuf->st_mtime)
+	{
+	  if (e_make_library (library, ofile, f))
+	    {
+	      e_free_arg (arg, argc);
+	      e_free_arg (e_arg, e_argc);
+	      freedf (df);
+	      return (-1);
+	    }
+	  else
+	    libsw = 1;
+	}
+    }
 #ifndef RANLIB
-#   warning "RANLIB should be defined: we are using libtool. LT_INIT defines RANLIB."
+#warning "RANLIB should be defined: we are using libtool. LT_INIT defines RANLIB."
 #endif
 #ifdef RANLIB
- if (libsw && library[0] != '\0')
- {
-  char *ar_arg[3];
-  ar_arg[0] = "ranlib";
-  ar_arg[1] = library;
-  ar_arg[2] = NULL;
-  if (!(j = e_p_mess_win("Convert Archive", 2, ar_arg, &pic, f)))
-  {
-   (*e_u_sys_ini)();
-   file = e_exec_inf(f, ar_arg, 2);
-   (*e_u_sys_end)();
-   if (file) j = e_p_exec(file, f, pic);
-  }
-  if (j || !file)
-  {
-   e_free_arg(arg, argc);
-   e_free_arg(e_arg, e_argc);
-   freedf(df);
-   return(-1);
-  }
- }
+  if (libsw && library[0] != '\0')
+    {
+      char *ar_arg[3];
+      ar_arg[0] = "ranlib";
+      ar_arg[1] = library;
+      ar_arg[2] = NULL;
+      if (!(j = e_p_mess_win ("Convert Archive", 2, ar_arg, &pic, f)))
+	{
+	  (*e_u_sys_ini) ();
+	  file = e_exec_inf (f, ar_arg, 2);
+	  (*e_u_sys_end) ();
+	  if (file)
+	    j = e_p_exec (file, f, pic);
+	}
+      if (j || !file)
+	{
+	  e_free_arg (arg, argc);
+	  e_free_arg (e_arg, e_argc);
+	  freedf (df);
+	  return (-1);
+	}
+    }
 #endif
- if (library[0] != '\0')
-  e_argc = e_add_arg(&e_arg, library, e_argc, e_argc);
- freedf(df);
- df = e_p_get_var("LDFLAGS");
- if (df)
- {
-  free(e_s_prog.libraries);
-  e_s_prog.libraries = NULL;
-  for (k = 0; k < df->anz; k++, e_argc++)
-  {
-   e_arg = realloc(e_arg, (e_argc+2)*sizeof(char *));
-   e_arg[e_argc] = malloc(strlen(df->name[k]) + 1);
-   strcpy(e_arg[e_argc], df->name[k]);
-   e_s_prog.libraries = e_cat_string(e_s_prog.libraries, e_arg[e_argc]);
-  }
-  freedf(df);
- }
- e_arg[e_argc] = NULL;
- e_free_arg(arg, argc);
- if (!sccs) e_p_exec(file, f, pic);
- return(0);
+  if (library[0] != '\0')
+    e_argc = e_add_arg (&e_arg, library, e_argc, e_argc);
+  freedf (df);
+  df = e_p_get_var ("LDFLAGS");
+  if (df)
+    {
+      free (e_s_prog.libraries);
+      e_s_prog.libraries = NULL;
+      for (k = 0; k < df->anz; k++, e_argc++)
+	{
+	  e_arg = realloc (e_arg, (e_argc + 2) * sizeof (char *));
+	  e_arg[e_argc] = malloc (strlen (df->name[k]) + 1);
+	  strcpy (e_arg[e_argc], df->name[k]);
+	  e_s_prog.libraries =
+	    e_cat_string (e_s_prog.libraries, e_arg[e_argc]);
+	}
+      freedf (df);
+    }
+  e_arg[e_argc] = NULL;
+  e_free_arg (arg, argc);
+  if (!sccs)
+    e_p_exec (file, f, pic);
+  return (0);
 }
 
-int e_free_arg(char **arg, int argc)
+int
+e_free_arg (char **arg, int argc)
 {
- int i;
+  int i;
 
- for(i = 0; i < argc; i++)
-  if(arg[i])
-   free(arg[i]);
- free(arg);
- return(i);
+  for (i = 0; i < argc; i++)
+    if (arg[i])
+      free (arg[i]);
+  free (arg);
+  return (i);
 }
 
-char *e_find_var(char *var)
+char *
+e_find_var (char *var)
 {
- int i;
+  int i;
 
- for(i = 0; i < p_v_n && strcmp(p_v[i]->var, var); i++);
- if(i >= p_v_n)
-  return(NULL);
- else
-  return(p_v[i]->string);
+  for (i = 0; i < p_v_n && strcmp (p_v[i]->var, var); i++);
+  if (i >= p_v_n)
+    return (NULL);
+  else
+    return (p_v[i]->string);
 }
 
 /****************************************************/
@@ -2350,24 +2626,25 @@ char *e_find_var(char *var)
   this function is called only on project opening.
   It is used for additional parsing variables from
   project file, ie for loading BREAKPOINTS and WATCHES.
-****/  
-  
-int e_rel_brkwtch(FENSTER *f)
-{
- int i;
+****/
 
- for (i = 0; i < p_v_n; i++)
- {
-  if (!strcmp(p_v[i]->var, "BREAKPOINTS"))
-  {
-   e_d_reinit_brks(f,p_v[i]->string);
-  }
-  else if (!strcmp(p_v[i]->var, "WATCHES"))
-  {
-   e_d_reinit_watches(f,p_v[i]->string);
-  }
- }
- return 0;
+int
+e_rel_brkwtch (FENSTER * f)
+{
+  int i;
+
+  for (i = 0; i < p_v_n; i++)
+    {
+      if (!strcmp (p_v[i]->var, "BREAKPOINTS"))
+	{
+	  e_d_reinit_brks (f, p_v[i]->string);
+	}
+      else if (!strcmp (p_v[i]->var, "WATCHES"))
+	{
+	  e_d_reinit_watches (f, p_v[i]->string);
+	}
+    }
+  return 0;
 }
 
 /****************************************************/
@@ -2377,84 +2654,108 @@ int e_rel_brkwtch(FENSTER *f)
   is opened. But unfortunately also reloads variables
   from project file, which is not good for WATCHES
   and BREAKPOINTS.
-****/  
-struct dirfile **e_make_prj_opt(FENSTER *f)
+****/
+struct dirfile **
+e_make_prj_opt (FENSTER * f)
 {
- int i, j, ret;
- char **tmp, *sp, *tp, text[256];
- FILE *fp;
- struct dirfile *save_df = NULL;
+  int i, j, ret;
+  char **tmp, *sp, *tp, text[256];
+  FILE *fp;
+  struct dirfile *save_df = NULL;
 
- for (i = f->ed->mxedt; i > 0
-	&& (f->ed->f[i]->dtmd != DTMD_DATA || f->ed->f[i]->ins != 4
-				     || !f->ed->f[i]->save); i--);
- if (i > 0) {  save_df = e_p_df[0];  e_p_df[0] = NULL;  }
- if (e_p_df) freedfN(e_p_df, 3);
- e_p_df = malloc(3 * sizeof(struct dirfile *));
- if (!e_p_df) return(e_p_df);
- for (i = 0; i < 3; i++) e_p_df[i] = NULL;
- e_s_prog.comp_sw = 0;
- ret = e_read_var(f);
- if (ret)
- {
-  if (e_s_prog.compiler) free(e_s_prog.compiler);
-  e_s_prog.compiler = WpeStrdup("gcc");
-  if (e_s_prog.comp_str) free(e_s_prog.comp_str);
-  e_s_prog.comp_str = WpeStrdup("-g");
-  if (e_s_prog.libraries) free(e_s_prog.libraries);
-  e_s_prog.libraries = WpeStrdup("");
-  if (e_s_prog.exe_name) free(e_s_prog.exe_name);
-  /* Project my_prog.prj defaults to an executable of my_prog BD */
-  strcpy(text, e_prog.project);
-  e_s_prog.exe_name = WpeStrdup(WpeStringCutChar(text, '.'));
-  /*e_s_prog.exe_name = WpeStrdup("a.out");*/
-  if (e_s_prog.intstr) free(e_s_prog.intstr);
-  e_s_prog.intstr = WpeStrdup(cc_intstr);
-  strcpy(library, "");
-  for (i = !save_df ? 0 : 1; i < 3; i++)
-  {
-   e_p_df[i] = malloc(sizeof(struct dirfile));
-   e_p_df[i]->name = malloc(sizeof(char *));
-   e_p_df[i]->name[0] = malloc(2 * sizeof(char));
-   *e_p_df[i]->name[0] = ' '; *(e_p_df[i]->name[0] + 1) = '\0';
-   e_p_df[i]->anz = 1;
-  }
-  if (save_df) e_p_df[0] = save_df;
-  return(e_p_df);
- }
- if (!(e_p_df[1] = malloc(sizeof(struct dirfile)))) return(e_p_df);
- if (!(e_p_df[1]->name = malloc(sizeof(char *)))) return(e_p_df);
- e_p_df[1]->anz = 0;
- if (!(e_p_df[2] = malloc(sizeof(struct dirfile)))) return(e_p_df);
- if (!(e_p_df[2]->name = malloc(sizeof(char *)))) return(e_p_df);
- e_p_df[2]->anz = 0;
- for (i = 0; i < p_v_n; i++)
- {
-  if (!strcmp(p_v[i]->var, "CMP"))
-  {
-   if (e_s_prog.compiler) free(e_s_prog.compiler);
-   e_s_prog.compiler = WpeStrdup(p_v[i]->string);
-  }
-  else if (!strcmp(p_v[i]->var, "CMPFLAGS"))
-  {
-   if (e_s_prog.comp_str) free(e_s_prog.comp_str);
-   e_s_prog.comp_str = WpeStrdup(p_v[i]->string);
-  }
-  else if (!strcmp(p_v[i]->var, "LDFLAGS"))
-  {
-   if (e_s_prog.libraries) free(e_s_prog.libraries);
-   e_s_prog.libraries = WpeStrdup(p_v[i]->string);
-  }
-  else if (!strcmp(p_v[i]->var, "EXENAME"))
-  {
-   if (e_s_prog.exe_name) free(e_s_prog.exe_name);
-   e_s_prog.exe_name = WpeStrdup(p_v[i]->string);
-  }
-  else if (!strcmp(p_v[i]->var, "CMPMESSAGE"))
-  {
-   if (e_s_prog.intstr) free(e_s_prog.intstr);
-   e_s_prog.intstr = WpeStrdup(e_interpr_var(p_v[i]->string));
-  }
+  for (i = f->ed->mxedt; i > 0
+       && (f->ed->f[i]->dtmd != DTMD_DATA || f->ed->f[i]->ins != 4
+	   || !f->ed->f[i]->save); i--);
+  if (i > 0)
+    {
+      save_df = e_p_df[0];
+      e_p_df[0] = NULL;
+    }
+  if (e_p_df)
+    freedfN (e_p_df, 3);
+  e_p_df = malloc (3 * sizeof (struct dirfile *));
+  if (!e_p_df)
+    return (e_p_df);
+  for (i = 0; i < 3; i++)
+    e_p_df[i] = NULL;
+  e_s_prog.comp_sw = 0;
+  ret = e_read_var (f);
+  if (ret)
+    {
+      if (e_s_prog.compiler)
+	free (e_s_prog.compiler);
+      e_s_prog.compiler = WpeStrdup ("gcc");
+      if (e_s_prog.comp_str)
+	free (e_s_prog.comp_str);
+      e_s_prog.comp_str = WpeStrdup ("-g");
+      if (e_s_prog.libraries)
+	free (e_s_prog.libraries);
+      e_s_prog.libraries = WpeStrdup ("");
+      if (e_s_prog.exe_name)
+	free (e_s_prog.exe_name);
+      /* Project my_prog.prj defaults to an executable of my_prog BD */
+      strcpy (text, e_prog.project);
+      e_s_prog.exe_name = WpeStrdup (WpeStringCutChar (text, '.'));
+      /*e_s_prog.exe_name = WpeStrdup("a.out"); */
+      if (e_s_prog.intstr)
+	free (e_s_prog.intstr);
+      e_s_prog.intstr = WpeStrdup (cc_intstr);
+      strcpy (library, "");
+      for (i = !save_df ? 0 : 1; i < 3; i++)
+	{
+	  e_p_df[i] = malloc (sizeof (struct dirfile));
+	  e_p_df[i]->name = malloc (sizeof (char *));
+	  e_p_df[i]->name[0] = malloc (2 * sizeof (char));
+	  *e_p_df[i]->name[0] = ' ';
+	  *(e_p_df[i]->name[0] + 1) = '\0';
+	  e_p_df[i]->anz = 1;
+	}
+      if (save_df)
+	e_p_df[0] = save_df;
+      return (e_p_df);
+    }
+  if (!(e_p_df[1] = malloc (sizeof (struct dirfile))))
+    return (e_p_df);
+  if (!(e_p_df[1]->name = malloc (sizeof (char *))))
+    return (e_p_df);
+  e_p_df[1]->anz = 0;
+  if (!(e_p_df[2] = malloc (sizeof (struct dirfile))))
+    return (e_p_df);
+  if (!(e_p_df[2]->name = malloc (sizeof (char *))))
+    return (e_p_df);
+  e_p_df[2]->anz = 0;
+  for (i = 0; i < p_v_n; i++)
+    {
+      if (!strcmp (p_v[i]->var, "CMP"))
+	{
+	  if (e_s_prog.compiler)
+	    free (e_s_prog.compiler);
+	  e_s_prog.compiler = WpeStrdup (p_v[i]->string);
+	}
+      else if (!strcmp (p_v[i]->var, "CMPFLAGS"))
+	{
+	  if (e_s_prog.comp_str)
+	    free (e_s_prog.comp_str);
+	  e_s_prog.comp_str = WpeStrdup (p_v[i]->string);
+	}
+      else if (!strcmp (p_v[i]->var, "LDFLAGS"))
+	{
+	  if (e_s_prog.libraries)
+	    free (e_s_prog.libraries);
+	  e_s_prog.libraries = WpeStrdup (p_v[i]->string);
+	}
+      else if (!strcmp (p_v[i]->var, "EXENAME"))
+	{
+	  if (e_s_prog.exe_name)
+	    free (e_s_prog.exe_name);
+	  e_s_prog.exe_name = WpeStrdup (p_v[i]->string);
+	}
+      else if (!strcmp (p_v[i]->var, "CMPMESSAGE"))
+	{
+	  if (e_s_prog.intstr)
+	    free (e_s_prog.intstr);
+	  e_s_prog.intstr = WpeStrdup (e_interpr_var (p_v[i]->string));
+	}
 
 /**************************/
 /**** 
@@ -2462,750 +2763,833 @@ struct dirfile **e_make_prj_opt(FENSTER *f)
   BREAKPOINTS and WATCHES are project variables.
   These variables will be processed later on in e_rel_brkwtch
   function.
-****/  
-  else if (!strcmp(p_v[i]->var, "BREAKPOINTS"))
-  {
-  }
-  else if (!strcmp(p_v[i]->var, "WATCHES"))
-  {
-  }
+****/
+      else if (!strcmp (p_v[i]->var, "BREAKPOINTS"))
+	{
+	}
+      else if (!strcmp (p_v[i]->var, "WATCHES"))
+	{
+	}
 /**************************/
 
-  else if (!strcmp(p_v[i]->var, "LIBNAME"))
-   strcpy(library, p_v[i]->string);
-  else if (!strcmp(p_v[i]->var, "CMPSWTCH"))
-  {
-   if (!strcmp(p_v[i]->string, "other")) e_s_prog.comp_sw = 1;
-  }
-  else if (!strcmp(p_v[i]->var, "FILES"))
-   e_p_df[0] = e_p_get_args(p_v[i]->string);
-  else
-  {
-   e_p_df[1]->anz++;
-   if (!(e_p_df[1]->name = realloc(tmp =
-				e_p_df[1]->name, e_p_df[1]->anz * sizeof(char *))))
-   {  e_p_df[1]->anz--;  e_p_df[1]->name = tmp;  return(e_p_df);  }
-   if (!(e_p_df[1]->name[e_p_df[1]->anz-1] = malloc((strlen(p_v[i]->var)
-			+ strlen(p_v[i]->string) + 2)*sizeof(char))))
-   {  e_p_df[1]->anz--;  return(e_p_df);  }
-   sprintf(e_p_df[1]->name[e_p_df[1]->anz-1], "%s=%s",
-					p_v[i]->var, p_v[i]->string);
-  }
- }
- if (!e_s_prog.compiler)
-  e_s_prog.compiler = WpeStrdup("gcc");
- if (!e_s_prog.comp_str)
-  e_s_prog.comp_str = WpeStrdup("-g");
- if (!e_s_prog.libraries)
-  e_s_prog.libraries = WpeStrdup("");
- if (!e_s_prog.exe_name)
- {
-  /* Project my_prog.prj defaults to an executable of my_prog BD */
-  strcpy(text, e_prog.project);
-  e_s_prog.exe_name = WpeStrdup(WpeStringCutChar(text, '.'));
-  /*e_s_prog.exe_name = WpeStrdup("a.out");*/
- }
- if (!e_s_prog.intstr)
-  e_s_prog.intstr = WpeStrdup(cc_intstr);
- if (!e_p_df[0])
- {
-  e_p_df[0] = malloc(sizeof(struct dirfile));
-  e_p_df[0]->anz = 0;
- }
- if ((fp = fopen(e_prog.project, "r")) == NULL)
- {
-  sprintf(text, e_msg[ERR_FOPEN], e_prog.project);
-  e_error(text, 0, f->fb);
-  return(e_p_df);
- }
- while ((tp = fgets(text, 256, fp)))
- {
-  if (text[0] == '\t') continue;
-  for (i = 0; isspace(text[i]); i++);
-  if (!strncmp(text+i, "install:", 8))
-  {
-   while(tp && (text[j = strlen(text)-1] != '\n' || text[j-1] == '\\'))
-    tp = fgets(text, 256, fp);
-   break;
-  }
- }
- if (!tp) {  fclose(fp);  return(e_p_df);  }
- while(tp && (tp = fgets(text, 256, fp)))
- {
-  for (i = 0; isspace(text[i]); i++);
-  sp = text+i;
-  if (sp[0] == '#')
-  {
-   while(tp && (text[j = strlen(text)-1] != '\n' || text[j-1] == '\\'))
-    tp = fgets(text, 256, fp);
-   continue;
-  }
-  if (text[0] != '\t') break;
-  if (sp[0] == '\0') continue;
-  e_p_df[2]->anz++;
-  if (!(e_p_df[2]->name = realloc(tmp =
-				e_p_df[2]->name, e_p_df[2]->anz * sizeof(char *))))
-  {  e_p_df[2]->anz--;  e_p_df[2]->name = tmp;  fclose(fp);  return(e_p_df);  }
-  if (!(e_p_df[2]->name[e_p_df[2]->anz-1] = malloc((strlen(sp) + 1))))
-  {  e_p_df[2]->anz--;  fclose(fp);  return(e_p_df);  }
-
-  strcpy(e_p_df[2]->name[e_p_df[2]->anz-1], sp);
-  while(tp && (text[j = strlen(text)-1] != '\n' || text[j-1] == '\\'))
-  {
-   tp = fgets(text, 256, fp);
-   if (tp)
-   {
-    j = strlen(e_p_df[2]->name[e_p_df[2]->anz-1]);
-    *(e_p_df[2]->name[e_p_df[2]->anz-1]+j-2) = '\0';
-    if (!(e_p_df[2]->name[e_p_df[2]->anz-1] =
-		    realloc(sp = e_p_df[2]->name[e_p_df[2]->anz-1],
-			strlen(e_p_df[2]->name[e_p_df[2]->anz-1])
-			+ strlen(text) + 1)))
-    {  fclose(fp);  free(sp);  e_error(e_msg[ERR_LOWMEM], 0, f->fb);
-	       return(e_p_df);
+      else if (!strcmp (p_v[i]->var, "LIBNAME"))
+	strcpy (library, p_v[i]->string);
+      else if (!strcmp (p_v[i]->var, "CMPSWTCH"))
+	{
+	  if (!strcmp (p_v[i]->string, "other"))
+	    e_s_prog.comp_sw = 1;
+	}
+      else if (!strcmp (p_v[i]->var, "FILES"))
+	e_p_df[0] = e_p_get_args (p_v[i]->string);
+      else
+	{
+	  e_p_df[1]->anz++;
+	  if (!(e_p_df[1]->name = realloc (tmp =
+					   e_p_df[1]->name,
+					   e_p_df[1]->anz * sizeof (char *))))
+	    {
+	      e_p_df[1]->anz--;
+	      e_p_df[1]->name = tmp;
+	      return (e_p_df);
+	    }
+	  if (!
+	      (e_p_df[1]->name[e_p_df[1]->anz - 1] =
+	       malloc ((strlen (p_v[i]->var) + strlen (p_v[i]->string) +
+			2) * sizeof (char))))
+	    {
+	      e_p_df[1]->anz--;
+	      return (e_p_df);
+	    }
+	  sprintf (e_p_df[1]->name[e_p_df[1]->anz - 1], "%s=%s",
+		   p_v[i]->var, p_v[i]->string);
+	}
     }
-    strcat(e_p_df[2]->name[e_p_df[2]->anz-1], text);
-   }
-  }
-  j = strlen(e_p_df[2]->name[e_p_df[2]->anz-1]);
-  if (*(e_p_df[2]->name[e_p_df[2]->anz-1]+j-1) == '\n')
-   *(e_p_df[2]->name[e_p_df[2]->anz-1]+j-1) = '\0';
- }
- fclose(fp);
- for (i = 0; i < 3; i++)
- {
-  if (!e_p_df[i])
-  {
-   e_p_df[i] = malloc(sizeof(struct dirfile));
-   e_p_df[i]->name = malloc(sizeof(char *));
-   e_p_df[i]->anz = 0;
-  }
-  e_p_df[i]->name = realloc(e_p_df[i]->name,
-				(e_p_df[i]->anz + 1) * sizeof(char *));
-  e_p_df[i]->name[e_p_df[i]->anz] = malloc(2*sizeof(char));
-  *e_p_df[i]->name[e_p_df[i]->anz] = ' ';
-  *(e_p_df[i]->name[e_p_df[i]->anz] + 1) = '\0';
-  e_p_df[i]->anz++;
- }
- if (save_df) {  freedf(e_p_df[0]);  e_p_df[0] = save_df;  }
- return(e_p_df);
+  if (!e_s_prog.compiler)
+    e_s_prog.compiler = WpeStrdup ("gcc");
+  if (!e_s_prog.comp_str)
+    e_s_prog.comp_str = WpeStrdup ("-g");
+  if (!e_s_prog.libraries)
+    e_s_prog.libraries = WpeStrdup ("");
+  if (!e_s_prog.exe_name)
+    {
+      /* Project my_prog.prj defaults to an executable of my_prog BD */
+      strcpy (text, e_prog.project);
+      e_s_prog.exe_name = WpeStrdup (WpeStringCutChar (text, '.'));
+      /*e_s_prog.exe_name = WpeStrdup("a.out"); */
+    }
+  if (!e_s_prog.intstr)
+    e_s_prog.intstr = WpeStrdup (cc_intstr);
+  if (!e_p_df[0])
+    {
+      e_p_df[0] = malloc (sizeof (struct dirfile));
+      e_p_df[0]->anz = 0;
+    }
+  if ((fp = fopen (e_prog.project, "r")) == NULL)
+    {
+      sprintf (text, e_msg[ERR_FOPEN], e_prog.project);
+      e_error (text, 0, f->fb);
+      return (e_p_df);
+    }
+  while ((tp = fgets (text, 256, fp)))
+    {
+      if (text[0] == '\t')
+	continue;
+      for (i = 0; isspace (text[i]); i++);
+      if (!strncmp (text + i, "install:", 8))
+	{
+	  while (tp
+		 && (text[j = strlen (text) - 1] != '\n'
+		     || text[j - 1] == '\\'))
+	    tp = fgets (text, 256, fp);
+	  break;
+	}
+    }
+  if (!tp)
+    {
+      fclose (fp);
+      return (e_p_df);
+    }
+  while (tp && (tp = fgets (text, 256, fp)))
+    {
+      for (i = 0; isspace (text[i]); i++);
+      sp = text + i;
+      if (sp[0] == '#')
+	{
+	  while (tp
+		 && (text[j = strlen (text) - 1] != '\n'
+		     || text[j - 1] == '\\'))
+	    tp = fgets (text, 256, fp);
+	  continue;
+	}
+      if (text[0] != '\t')
+	break;
+      if (sp[0] == '\0')
+	continue;
+      e_p_df[2]->anz++;
+      if (!(e_p_df[2]->name = realloc (tmp =
+				       e_p_df[2]->name,
+				       e_p_df[2]->anz * sizeof (char *))))
+	{
+	  e_p_df[2]->anz--;
+	  e_p_df[2]->name = tmp;
+	  fclose (fp);
+	  return (e_p_df);
+	}
+      if (!(e_p_df[2]->name[e_p_df[2]->anz - 1] = malloc ((strlen (sp) + 1))))
+	{
+	  e_p_df[2]->anz--;
+	  fclose (fp);
+	  return (e_p_df);
+	}
+
+      strcpy (e_p_df[2]->name[e_p_df[2]->anz - 1], sp);
+      while (tp
+	     && (text[j = strlen (text) - 1] != '\n' || text[j - 1] == '\\'))
+	{
+	  tp = fgets (text, 256, fp);
+	  if (tp)
+	    {
+	      j = strlen (e_p_df[2]->name[e_p_df[2]->anz - 1]);
+	      *(e_p_df[2]->name[e_p_df[2]->anz - 1] + j - 2) = '\0';
+	      if (!(e_p_df[2]->name[e_p_df[2]->anz - 1] =
+		    realloc (sp = e_p_df[2]->name[e_p_df[2]->anz - 1],
+			     strlen (e_p_df[2]->name[e_p_df[2]->anz - 1])
+			     + strlen (text) + 1)))
+		{
+		  fclose (fp);
+		  free (sp);
+		  e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+		  return (e_p_df);
+		}
+	      strcat (e_p_df[2]->name[e_p_df[2]->anz - 1], text);
+	    }
+	}
+      j = strlen (e_p_df[2]->name[e_p_df[2]->anz - 1]);
+      if (*(e_p_df[2]->name[e_p_df[2]->anz - 1] + j - 1) == '\n')
+	*(e_p_df[2]->name[e_p_df[2]->anz - 1] + j - 1) = '\0';
+    }
+  fclose (fp);
+  for (i = 0; i < 3; i++)
+    {
+      if (!e_p_df[i])
+	{
+	  e_p_df[i] = malloc (sizeof (struct dirfile));
+	  e_p_df[i]->name = malloc (sizeof (char *));
+	  e_p_df[i]->anz = 0;
+	}
+      e_p_df[i]->name = realloc (e_p_df[i]->name,
+				 (e_p_df[i]->anz + 1) * sizeof (char *));
+      e_p_df[i]->name[e_p_df[i]->anz] = malloc (2 * sizeof (char));
+      *e_p_df[i]->name[e_p_df[i]->anz] = ' ';
+      *(e_p_df[i]->name[e_p_df[i]->anz] + 1) = '\0';
+      e_p_df[i]->anz++;
+    }
+  if (save_df)
+    {
+      freedf (e_p_df[0]);
+      e_p_df[0] = save_df;
+    }
+  return (e_p_df);
 }
 
-int freedfN(struct dirfile **df, int n)
+int
+freedfN (struct dirfile **df, int n)
 {
- int i;
+  int i;
 
- for(i = 0; i < n; i++)
-  if(df[i])
-   freedf(df[i]);
- free(df);
- return(0);
+  for (i = 0; i < n; i++)
+    if (df[i])
+      freedf (df[i]);
+  free (df);
+  return (0);
 }
 
-int e_wrt_prj_fl(FENSTER *f)
+int
+e_wrt_prj_fl (FENSTER * f)
 {
- int i, len;
- FILE *fp;
- char text[256];
+  int i, len;
+  FILE *fp;
+  char text[256];
 
- for (i = f->ed->mxedt;
-   i > 0 &&  (f->ed->f[i]->dtmd != DTMD_DATA || f->ed->f[i]->ins != 4); i--)
-  ;
- if (i == 0 || e_prog.project[0] == DIRC)
-  strcpy(text, e_prog.project);
- else
-  sprintf(text, "%s/%s", f->ed->f[i]->dirct, e_prog.project);
- if ((fp = fopen(text, "w")) == NULL)
- {
-  sprintf(text, e_msg[ERR_FOPEN], e_prog.project);
-  e_error(text, 0, f->fb);
-  return(-1);
- }
- fprintf(fp, "#\n# xwpe - project-file: %s\n", e_prog.project);
- fprintf(fp, "# created by xwpe version %s\n#\n", VERSION);
- for (i = 0; i < e_p_df[1]->anz; i++)
-  fprintf(fp, "%s\n", e_p_df[1]->name[i]);
- fprintf(fp, "\nCMP=\t%s\n", e_s_prog.compiler);
- fprintf(fp, "CMPFLAGS=\t%s\n", e_s_prog.comp_str);
- fprintf(fp, "LDFLAGS=\t%s\n", e_s_prog.libraries);
- fprintf(fp, "EXENAME=\t%s\n", e_s_prog.exe_name);
- if (library[0])
-  fprintf(fp, "LIBNAME=\t%s\n", library);
- fprintf(fp, "CMPSWTCH=\t%s\n", e_s_prog.comp_sw ? "other" : "gnu");
- fprintf(fp, "CMPMESSAGE=\t\'");
- for (i = 0; e_s_prog.intstr[i]; i++)
- {
-  if (e_s_prog.intstr[i] == '\n')
-   fprintf(fp, "\\n");
-  else if (e_s_prog.intstr[i] == '\r')
-   fprintf(fp, "\\r");
-  else if (e_s_prog.intstr[i] == '\\' || e_s_prog.intstr[i] == '\'' ||
-    e_s_prog.intstr[i] == '\"' )
-  {
-   fputc('\\', fp);
-   fputc(e_s_prog.intstr[i], fp);
-  }
-  else fputc(e_s_prog.intstr[i], fp);
- }
- fprintf(fp, "\'\n");
- fprintf(fp, "\nFILES=\t");
- for (i = 0, len = 8; i < e_p_df[0]->anz; i++)
- {
-  len += strlen(e_p_df[0]->name[i]);
-  if (len > 80)
-  {
-   fprintf(fp, " \\\n\t");
-   len = 1;
-  }
-  fprintf(fp, "%s ", e_p_df[0]->name[i]);
- }
- fprintf(fp, "\n");
-   
-/*****************************************/   
+  for (i = f->ed->mxedt;
+       i > 0 && (f->ed->f[i]->dtmd != DTMD_DATA || f->ed->f[i]->ins != 4);
+       i--)
+    ;
+  if (i == 0 || e_prog.project[0] == DIRC)
+    strcpy (text, e_prog.project);
+  else
+    sprintf (text, "%s/%s", f->ed->f[i]->dirct, e_prog.project);
+  if ((fp = fopen (text, "w")) == NULL)
+    {
+      sprintf (text, e_msg[ERR_FOPEN], e_prog.project);
+      e_error (text, 0, f->fb);
+      return (-1);
+    }
+  fprintf (fp, "#\n# xwpe - project-file: %s\n", e_prog.project);
+  fprintf (fp, "# created by xwpe version %s\n#\n", VERSION);
+  for (i = 0; i < e_p_df[1]->anz; i++)
+    fprintf (fp, "%s\n", e_p_df[1]->name[i]);
+  fprintf (fp, "\nCMP=\t%s\n", e_s_prog.compiler);
+  fprintf (fp, "CMPFLAGS=\t%s\n", e_s_prog.comp_str);
+  fprintf (fp, "LDFLAGS=\t%s\n", e_s_prog.libraries);
+  fprintf (fp, "EXENAME=\t%s\n", e_s_prog.exe_name);
+  if (library[0])
+    fprintf (fp, "LIBNAME=\t%s\n", library);
+  fprintf (fp, "CMPSWTCH=\t%s\n", e_s_prog.comp_sw ? "other" : "gnu");
+  fprintf (fp, "CMPMESSAGE=\t\'");
+  for (i = 0; e_s_prog.intstr[i]; i++)
+    {
+      if (e_s_prog.intstr[i] == '\n')
+	fprintf (fp, "\\n");
+      else if (e_s_prog.intstr[i] == '\r')
+	fprintf (fp, "\\r");
+      else if (e_s_prog.intstr[i] == '\\' || e_s_prog.intstr[i] == '\'' ||
+	       e_s_prog.intstr[i] == '\"')
+	{
+	  fputc ('\\', fp);
+	  fputc (e_s_prog.intstr[i], fp);
+	}
+      else
+	fputc (e_s_prog.intstr[i], fp);
+    }
+  fprintf (fp, "\'\n");
+  fprintf (fp, "\nFILES=\t");
+  for (i = 0, len = 8; i < e_p_df[0]->anz; i++)
+    {
+      len += strlen (e_p_df[0]->name[i]);
+      if (len > 80)
+	{
+	  fprintf (fp, " \\\n\t");
+	  len = 1;
+	}
+      fprintf (fp, "%s ", e_p_df[0]->name[i]);
+    }
+  fprintf (fp, "\n");
+
+/*****************************************/
 /****  save WATCHES and BREAKPOINTS   ****/
- if (e_d_nbrpts > 0)
- {
-  fprintf(fp, "\nBREAKPOINTS=\t");
-  for (i = 0; i < (e_d_nbrpts-1); i++)
-  {
-   fprintf(fp, "%s:%d;",e_d_sbrpts[i],e_d_ybrpts[i]);
-  }
-  fprintf(fp, "%s:%d",e_d_sbrpts[e_d_nbrpts-1],e_d_ybrpts[e_d_nbrpts-1]);
- }
+  if (e_d_nbrpts > 0)
+    {
+      fprintf (fp, "\nBREAKPOINTS=\t");
+      for (i = 0; i < (e_d_nbrpts - 1); i++)
+	{
+	  fprintf (fp, "%s:%d;", e_d_sbrpts[i], e_d_ybrpts[i]);
+	}
+      fprintf (fp, "%s:%d", e_d_sbrpts[e_d_nbrpts - 1],
+	       e_d_ybrpts[e_d_nbrpts - 1]);
+    }
 
- if (e_d_nwtchs > 0)
- {
-  fprintf(fp, "\nWATCHES=\t");
-  for (i = 0; i < (e_d_nwtchs-1); i++)
-  {
-   fprintf(fp, "%s;",e_d_swtchs[i]);
-  }
-  fprintf(fp, "%s",e_d_swtchs[e_d_nwtchs-1]);
- }   
- fprintf(fp, "\n");
-/*****************************************/   
+  if (e_d_nwtchs > 0)
+    {
+      fprintf (fp, "\nWATCHES=\t");
+      for (i = 0; i < (e_d_nwtchs - 1); i++)
+	{
+	  fprintf (fp, "%s;", e_d_swtchs[i]);
+	}
+      fprintf (fp, "%s", e_d_swtchs[e_d_nwtchs - 1]);
+    }
+  fprintf (fp, "\n");
+/*****************************************/
 
- if (e_p_df[2]->anz > 0)
-  fprintf(fp, "\ninstall:\n");
- for (i = 0; i < e_p_df[2]->anz; i++)
-  fprintf(fp, "\t%s\n", e_p_df[2]->name[i]);
- fclose(fp);
- return(0);
+  if (e_p_df[2]->anz > 0)
+    fprintf (fp, "\ninstall:\n");
+  for (i = 0; i < e_p_df[2]->anz; i++)
+    fprintf (fp, "\t%s\n", e_p_df[2]->name[i]);
+  fclose (fp);
+  return (0);
 }
 
-int e_p_update_prj_fl(FENSTER *f)
+int
+e_p_update_prj_fl (FENSTER * f)
 {
- if(!e_make_prj_opt(f))
-  return(-1);
- if(e_wrt_prj_fl(f))
-  return(-1);
- return(0);
+  if (!e_make_prj_opt (f))
+    return (-1);
+  if (e_wrt_prj_fl (f))
+    return (-1);
+  return (0);
 }
 
-int e_p_add_df(FLWND *fw, int sw)
+int
+e_p_add_df (FLWND * fw, int sw)
 {
- char *title = NULL, str[256];
- int i;
+  char *title = NULL, str[256];
+  int i;
 
- if (sw == 4)
-  title = "Add File";
- else if (sw == 5)
-  title = "Add Variable";
- else if (sw == 6)
-  title = "Add Command";
- str[0] = '\0'; /* terminate new string to prevent garbage in display */
- if (e_add_arguments(str, title, fw->f, 0, AltA, NULL))
- {
-  fw->df->anz++;
-  fw->df->name = realloc(fw->df->name, fw->df->anz * sizeof(char *));
-  for (i = fw->df->anz - 1; i > fw->nf; i--)
-   fw->df->name[i] = fw->df->name[i-1];
-  fw->df->name[i] = malloc(strlen(str)+1);
-  strcpy(fw->df->name[i], str);
- }
- return(0);
+  if (sw == 4)
+    title = "Add File";
+  else if (sw == 5)
+    title = "Add Variable";
+  else if (sw == 6)
+    title = "Add Command";
+  str[0] = '\0';		/* terminate new string to prevent garbage in display */
+  if (e_add_arguments (str, title, fw->f, 0, AltA, NULL))
+    {
+      fw->df->anz++;
+      fw->df->name = realloc (fw->df->name, fw->df->anz * sizeof (char *));
+      for (i = fw->df->anz - 1; i > fw->nf; i--)
+	fw->df->name[i] = fw->df->name[i - 1];
+      fw->df->name[i] = malloc (strlen (str) + 1);
+      strcpy (fw->df->name[i], str);
+    }
+  return (0);
 }
 
-int e_p_edit_df(FLWND *fw, int sw)
+int
+e_p_edit_df (FLWND * fw, int sw)
 {
- char *title = NULL, str[256];
- int new = 0;
- if (sw == 4)
-  title = "Change Filename";
- else if (sw == 5)
-  title = "Change Variable";
- else if (sw == 6)
-  title = "Change Command";
- if (fw->nf < fw->df->anz-1 && fw->df->name[fw->nf])
-  strcpy(str, fw->df->name[fw->nf]);
- else
- {
-  new = 1;
-  str[0] = '\0';
- }
- if (e_add_arguments(str, title, fw->f, 0, AltA, NULL))
- {
-  if (fw->nf > fw->df->anz-2)
-  {
-   fw->nf = fw->df->anz-1;
-   fw->df->anz++;
-   fw->df->name = realloc(fw->df->name, fw->df->anz * sizeof(char *));
-   fw->df->name[fw->df->anz-1] = fw->df->name[fw->df->anz-2];
-  }
-  if (!new)
-   free(fw->df->name[fw->nf]);
-  fw->df->name[fw->nf] = malloc(strlen(str)+1);
-  if (fw->df->name[fw->nf])
-   strcpy(fw->df->name[fw->nf], str);
- }
- return(0);
+  char *title = NULL, str[256];
+  int new = 0;
+  if (sw == 4)
+    title = "Change Filename";
+  else if (sw == 5)
+    title = "Change Variable";
+  else if (sw == 6)
+    title = "Change Command";
+  if (fw->nf < fw->df->anz - 1 && fw->df->name[fw->nf])
+    strcpy (str, fw->df->name[fw->nf]);
+  else
+    {
+      new = 1;
+      str[0] = '\0';
+    }
+  if (e_add_arguments (str, title, fw->f, 0, AltA, NULL))
+    {
+      if (fw->nf > fw->df->anz - 2)
+	{
+	  fw->nf = fw->df->anz - 1;
+	  fw->df->anz++;
+	  fw->df->name =
+	    realloc (fw->df->name, fw->df->anz * sizeof (char *));
+	  fw->df->name[fw->df->anz - 1] = fw->df->name[fw->df->anz - 2];
+	}
+      if (!new)
+	free (fw->df->name[fw->nf]);
+      fw->df->name[fw->nf] = malloc (strlen (str) + 1);
+      if (fw->df->name[fw->nf])
+	strcpy (fw->df->name[fw->nf], str);
+    }
+  return (0);
 }
 
-int e_p_del_df(FLWND *fw, int sw)
+int
+e_p_del_df (FLWND * fw, int sw)
 {
- UNUSED(sw);
- int i;
+  UNUSED (sw);
+  int i;
 
- if (fw->nf > fw->df->anz-2)
-  return(0);
- fw->df->anz--;
- for (i = fw->nf; i < fw->df->anz; i++)
-  fw->df->name[i] = fw->df->name[i+1];
- return(0);
+  if (fw->nf > fw->df->anz - 2)
+    return (0);
+  fw->df->anz--;
+  for (i = fw->nf; i < fw->df->anz; i++)
+    fw->df->name[i] = fw->df->name[i + 1];
+  return (0);
 }
 
-int e_p_mess_win(char *header, int argc, char **argv, view **pic, FENSTER *f)
+int
+e_p_mess_win (char *header, int argc, char **argv, view ** pic, FENSTER * f)
 {
- char *tmp = malloc(sizeof(char));
- int i, ret;
+  char *tmp = malloc (sizeof (char));
+  int i, ret;
 
- fk_cursor(0);
- tmp[0] = '\0';
- for (i = 0; i < argc && argv[i] != NULL; i++)
- {
-  if(!(tmp = realloc(tmp, (strlen(tmp)+strlen(argv[i])+2)*sizeof(char))))
-   return(-2);
-  strcat(tmp, argv[i]);
-  strcat(tmp, " ");
- }
- ret = e_mess_win(header, tmp, pic, f);
- free(tmp);
- fk_cursor(1);
- return(ret);
+  fk_cursor (0);
+  tmp[0] = '\0';
+  for (i = 0; i < argc && argv[i] != NULL; i++)
+    {
+      if (!
+	  (tmp =
+	   realloc (tmp,
+		    (strlen (tmp) + strlen (argv[i]) + 2) * sizeof (char))))
+	return (-2);
+      strcat (tmp, argv[i]);
+      strcat (tmp, " ");
+    }
+  ret = e_mess_win (header, tmp, pic, f);
+  free (tmp);
+  fk_cursor (1);
+  return (ret);
 }
 
 /* After this function b has exactly 1 line allocated (b->mxlines==1).
    This line is initialized to the string WPE_WR,0 */
-int e_p_red_buffer(BUFFER *b)
+int
+e_p_red_buffer (BUFFER * b)
 {
- int i;
+  int i;
 
- for (i = 1; i < b->mxlines; i++)
-  if (b->bf[i].s != NULL)
-   free( b->bf[i].s );
- if (b->mxlines==0) e_new_line(0,b);
- b->bf[0].s[0] = WPE_WR;
- b->bf[0].s[1] = '\0';
- b->bf[0].len = 0;
- b->bf[0].nrc = 1;
- b->mxlines = 1;
- return(0);
+  for (i = 1; i < b->mxlines; i++)
+    if (b->bf[i].s != NULL)
+      free (b->bf[i].s);
+  if (b->mxlines == 0)
+    e_new_line (0, b);
+  b->bf[0].s[0] = WPE_WR;
+  b->bf[0].s[1] = '\0';
+  b->bf[0].len = 0;
+  b->bf[0].nrc = 1;
+  b->mxlines = 1;
+  return (0);
 }
 
-int e_new_message(FENSTER *f)
+int
+e_new_message (FENSTER * f)
 {
- int i;
+  int i;
 
- if (e_p_m_buffer)
-  e_p_red_buffer(e_p_m_buffer);
- for (i = f->ed->mxedt; i > 0; i--)
-  if (!strcmp(f->ed->f[i]->datnam, "Messages"))
-  {
-   e_switch_window(f->ed->edt[i], f->ed->f[f->ed->mxedt]);
-   e_close_window(f->ed->f[f->ed->mxedt]);
-  }
- if (access("Messages", F_OK) == 0)
-  remove("Messages");
- if (e_edit(f->ed, "Messages"))
-  return(WPE_ESC);
- return(0);
+  if (e_p_m_buffer)
+    e_p_red_buffer (e_p_m_buffer);
+  for (i = f->ed->mxedt; i > 0; i--)
+    if (!strcmp (f->ed->f[i]->datnam, "Messages"))
+      {
+	e_switch_window (f->ed->edt[i], f->ed->f[f->ed->mxedt]);
+	e_close_window (f->ed->f[f->ed->mxedt]);
+      }
+  if (access ("Messages", F_OK) == 0)
+    remove ("Messages");
+  if (e_edit (f->ed, "Messages"))
+    return (WPE_ESC);
+  return (0);
 }
 
-int e_p_show_messages(FENSTER *f)
+int
+e_p_show_messages (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0; i--)
-  if (!strcmp(f->ed->f[i]->datnam, "Messages"))
-  {
-   e_switch_window(f->ed->edt[i], f->ed->f[f->ed->mxedt]);
-   break;
-  }
- if (i <= 0 && e_edit(f->ed, "Messages"))
- {
-  return(-1);
- }
- f = f->ed->f[f->ed->mxedt];
- if (f->b->mxlines == 0)
- {
-  e_new_line(0, f->b);
-  e_ins_nchar(f->b, f->s, (unsigned char *)"No Messages", 0, 0, 11);
-  e_schirm(f, 1);
- }
- return(0);
-}
-
-int e_p_konv_mess(char *var, char *str, char *txt, char *file, char *cmp,
-  int *y, int *x)
-{
- int i;
- char *cp;
-
- if (!strncmp(var, "FILE", 4) && !isalnum(var[4]))
- {
-  for (i = strlen(str) - 1; i >= 0 && !isspace(str[i]); i--)
-   ;
-  strcpy(file, str+i+1);
- }
- else if (!strncmp(var, "CMPTEXT", 7) && !isalnum(var[7]))
-  strcpy(cmp, str);
- else if (!strncmp(var, "LINE", 4) && !isalnum(var[4]))
- {
-  if (!isdigit(str[0]))
-   return(1);
-  *y = atoi(str);
-  if (var[4] == '+')
-   *y += atoi(var+5);
-  else if (var[4] == '-')
-   *y -= atoi(var+5);
- }
- else if (!strncmp(var, "COLUMN", 6) && !isalnum(var[6]))
- {
-  if (!strncmp(var+6, "=BEFORE", 7))
-  {
-   txt[0] = 'B';
-   strcpy(txt+1, str);
-   *x = 0;
-   var += 13;
-  }
-  else if (!strncmp(var+6, "=AFTER", 6))
-  {
-   txt[0] = 'A';
-   strcpy(txt+1, str);
-   *x = strlen(str);
-   var += 12;
-  }
-  else if (!strncmp(var+6, "=PREVIOUS?", 10))
-  {
-   if (!str[0])
-    return(1);
-   for (i = 0; (txt[i] = var[16+i]) && txt[i] != '+' && txt[i] != '-'; i++)
-    ;
-   txt[i] = '\0';
-   var += (16+i);
-   cp = strstr(str, txt);
-   for (i = 0; str+i < cp; i++)
-    ;
-   *x = i;
-   txt[0] = 'P'; txt[1] = '\0';
-  }
-  else if (!isdigit(str[0]))
-   return(1);
-  else
-  {
-   *x = atoi(str);
-   txt[0] = '\0';
-   var += 6;
-  }
-  if (var[0] == '+')
-   *x += atoi(var+1);
-  else if (var[0] == '-')
-   *x -= atoi(var+1);
- }
- return(0);
-}
-
-int e_p_comp_mess(char *a, char *b, char *c, char *txt, char *file, char *cmp,
-  int *y, int *x)
-{
- int i, n, k = 0, bsl = 0;
- char *ctmp, *cp, *var = NULL, *str = NULL;
-
- if (c > b)
-  return(0);
- if (a[0] == '*' && !a[1])
-  return(2);
- if (!a[0] && !b[0])
-  return(2);
- if (!a[0] || !b[0])
-  return(0);
- if (a[0] == '*' && (a[1] == '*' || a[1] == '$'))
-  return(e_p_comp_mess(++a, b, c, txt, file, cmp, y, x));
- if (a[0] == '$' && a[1] == '{')
- {
-  for (k = 2; a[k] && a[k] != '}'; k++);
-  var = malloc((k-1) * sizeof(char));
-  for (i = 2; i < k; i++)
-   var[i-2] = a[i];
-  var[k-2] = '\0';
-  if (a[k])
-   k++;
-  if (!a[k])
-   return(!e_p_konv_mess(var, b, txt, file, cmp, y, x));
-  n = a[k] == '\\' ? k : k+1;
- }
- else if (a[0] == '*'&& a[1] != '\\')
- {
-  k = 1;
-  n = 2;
- }
- else
-  n = 1;
- for(; bsl || (a[n] && a[n] != '*' && a[n] != '?' && a[n] != '[' &&
-   (a[n] != '$' || a[n+1] != '{' )); n++)
-  bsl = a[n] == '\\' ? !bsl : 0;
- if (a[0] == '*' || a[0] == '$')
- {
-  if (a[k] == '?')
-  {
-   cp = malloc((strlen(a)+1)*sizeof(char));
-   for (i = 0; i < k && (cp[i] = a[i]); i++);
-   for (i++; (cp[i-1] = a[i]) != '\0'; i++);
-   free(var);
-   n = e_p_comp_mess(cp, ++b, ++c, txt, file, cmp, y, x);
-   free(cp);
-   return(n);
-  }
-  if (a[k] == '[')
-  {
-   for (i = 0; b[i] &&
-     !(n = e_p_comp_mess(a+k, b+i, c+i, txt, file, cmp, y, x)); i++)
-    ;
-   if (!b[i])
-    return(0);
-   if (a[0] == '$')
-   {
-    str = malloc((i+1)*sizeof(char));
-    for (k = 0; k < i; k++)
-     str[k] = b[k];
-    str[i] = '\0';
-    e_p_konv_mess(var, str, txt, file, cmp, y, x);
-    free(var);
-    free(str);
-   }
-   return(n);
-  }
-  n -= k;
-  ctmp = malloc(n+1);
-  for (i = 0; i < n; i++)
-   ctmp[i] = a[i+k];
-  ctmp[n] = '\0';
-  cp = strstr(b, ctmp);
-  free(ctmp);
-  if (cp == NULL)
-   return(0);
-  if (a[0] == '$')
-  {
-   for (i = 0; c + i < cp; i++);
-   str = malloc((i+1)*sizeof(char));
-   for (i = 0; c + i < cp; i++)
-    str[i] = c[i];
-   str[i] = '\0';
-   i = e_p_konv_mess(var, str, txt, file, cmp, y, x);
-   free(var);  
-   free(str);
-   if (i)
-    return(0);
-  }
-  if (!a[k+n] && !cp[n])
-   return(2);
-  if (!a[k+n])
-   return(e_p_comp_mess(a, cp+1, cp+1, txt, file, cmp, y, x));
-  if ((i = e_p_comp_mess(a+k+n, cp+n, cp+n, txt, file, cmp, y, x)))
-   return(i);
-  if (file[0] && *y > -1)
-   return(0);
-  return(e_p_comp_mess(a, cp+1, a[0] == '$' ? c : cp+1, txt, file, cmp, y, x));
- }
- else if (a[0] == '?')
- {
-  n--;
-  a++;
-  b++;
- }
- else if (a[0] == '[')
- {
-  if (a[1] == '!')
-  {
-   for (k = 2; a[k] && (a[k] != ']' || k == 2) && a[k] != b[0]; k++)
-    if (a[k+1] == '-' && b[0] >= a[k] && b[0] <= a[k+2])
-     return(-b[0]);
-   if (a[k] != ']')
-    return(-b[0]);
-   n-=(k+1);
-   a+=(k+1);
-   b++;
-  }
-  else
-  {
-   for (k = 1; a[k] && (a[k] != ']' || k == 1) && a[k] != b[0]; k++)
-    if (a[k+1] == '-' && b[0] >= a[k] && b[0] <= a[k+2])
-     break;
-   if (a[k] == ']' || a[k] == '\0')
-    return(0);
-   for(; a[k] && (a[k] != ']'); k++);
-   n-=(k+1);
-   a+=(k+1);
-   b++;
-  }
- }
- if (n <= 0)
-  return(e_p_comp_mess(a, b, c, txt, file, cmp, y, x));
- if ((k = strncmp(a, b, n)) != 0)
-  return(0);
- return(e_p_comp_mess(a+n, b+n, c+n, txt, file, cmp, y, x));
-}
-
-int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret)
-{
- char *cp, cmp[128], file[128], search[80], tmp[4][128], **wtxt = NULL;
- int j, l, m, n, iy, iorig, i = *ii, k = *kk, x = 0, y = -1, wnum = 0;
- int *wn = NULL;
-
- cmp[0] = search[0] = file[0] = '\0';
- wtxt = malloc(1);
- wn = malloc(1);
- for (j = 0, n = 0; n < 4 && srch[j]; n++)
- {
-  for (l = 0; (tmp[n][l] = srch[j]); j++, l++)
-  {
-   if (j > 1 && srch[j] == '?' && srch[j-1] == '{' && srch[j-2] == '$')
-   {
-    wnum++;
-    wn = realloc(wn, wnum * sizeof(int));
-    wtxt = realloc(wtxt, wnum * sizeof(char *));
-    if (srch[j+1] == '*')
-     wn[wnum-1] = -1;
-    else
-     wn[wnum-1] = atoi(srch+j+1);
-    for (j++; srch[j] && srch[j] != ':'; j++);
-    if (!srch[j])
+  for (i = f->ed->mxedt; i > 0; i--)
+    if (!strcmp (f->ed->f[i]->datnam, "Messages"))
+      {
+	e_switch_window (f->ed->edt[i], f->ed->f[f->ed->mxedt]);
+	break;
+      }
+  if (i <= 0 && e_edit (f->ed, "Messages"))
     {
-     wnum--;
-     break;
+      return (-1);
     }
-    for (m = 0; srch[j+m] && srch[j+m] != '}'; m++);
-    wtxt[wnum-1] = malloc((m+1) * sizeof(char));
-    for (m = 0, j++; (wtxt[wnum-1][m] = srch[j]) && srch[j] != '}'; j++, m++);
-    wtxt[wnum-1][m] = '\0';
-    l -= 3;
-   }
-   else if (srch[j] == '\r' || srch[j] == '\n')
-   {
-    if (srch[j+1] == '\r' || srch[j+1] == '\n')
+  f = f->ed->f[f->ed->mxedt];
+  if (f->b->mxlines == 0)
     {
-     tmp[n][l] = '\n';
-     tmp[n][l+1] = '\0';
-     j++;
+      e_new_line (0, f->b);
+      e_ins_nchar (f->b, f->s, (unsigned char *) "No Messages", 0, 0, 11);
+      e_schirm (f, 1);
     }
-    else
-     tmp[n][l] = '\0';
-    j++;
-    break;
-   }
-  }
- }
- e_p_comp_mess(tmp[0], (char *)b->bf[i].s, (char *)b->bf[i].s, search, file, cmp, &y, &x);
- iy = i;
- iorig = i;
- do
- {
-  if (n > 1 && file[0] && i < b->mxlines-1)
-  {
-   y = -1;
-   while (b->bf[i].s[b->bf[i].len-1] == '\\')
-    i++;
-   i++;
-   e_p_comp_mess(tmp[1], (char *)b->bf[i].s, (char *)b->bf[i].s, search, file, cmp, &y, &x);
-   iy = i;
-  }
+  return (0);
+}
+
+int
+e_p_konv_mess (char *var, char *str, char *txt, char *file, char *cmp,
+	       int *y, int *x)
+{
+  int i;
+  char *cp;
+
+  if (!strncmp (var, "FILE", 4) && !isalnum (var[4]))
+    {
+      for (i = strlen (str) - 1; i >= 0 && !isspace (str[i]); i--)
+	;
+      strcpy (file, str + i + 1);
+    }
+  else if (!strncmp (var, "CMPTEXT", 7) && !isalnum (var[7]))
+    strcpy (cmp, str);
+  else if (!strncmp (var, "LINE", 4) && !isalnum (var[4]))
+    {
+      if (!isdigit (str[0]))
+	return (1);
+      *y = atoi (str);
+      if (var[4] == '+')
+	*y += atoi (var + 5);
+      else if (var[4] == '-')
+	*y -= atoi (var + 5);
+    }
+  else if (!strncmp (var, "COLUMN", 6) && !isalnum (var[6]))
+    {
+      if (!strncmp (var + 6, "=BEFORE", 7))
+	{
+	  txt[0] = 'B';
+	  strcpy (txt + 1, str);
+	  *x = 0;
+	  var += 13;
+	}
+      else if (!strncmp (var + 6, "=AFTER", 6))
+	{
+	  txt[0] = 'A';
+	  strcpy (txt + 1, str);
+	  *x = strlen (str);
+	  var += 12;
+	}
+      else if (!strncmp (var + 6, "=PREVIOUS?", 10))
+	{
+	  if (!str[0])
+	    return (1);
+	  for (i = 0;
+	       (txt[i] = var[16 + i]) && txt[i] != '+' && txt[i] != '-'; i++)
+	    ;
+	  txt[i] = '\0';
+	  var += (16 + i);
+	  cp = strstr (str, txt);
+	  for (i = 0; str + i < cp; i++)
+	    ;
+	  *x = i;
+	  txt[0] = 'P';
+	  txt[1] = '\0';
+	}
+      else if (!isdigit (str[0]))
+	return (1);
+      else
+	{
+	  *x = atoi (str);
+	  txt[0] = '\0';
+	  var += 6;
+	}
+      if (var[0] == '+')
+	*x += atoi (var + 1);
+      else if (var[0] == '-')
+	*x -= atoi (var + 1);
+    }
+  return (0);
+}
+
+int
+e_p_comp_mess (char *a, char *b, char *c, char *txt, char *file, char *cmp,
+	       int *y, int *x)
+{
+  int i, n, k = 0, bsl = 0;
+  char *ctmp, *cp, *var = NULL, *str = NULL;
+
+  if (c > b)
+    return (0);
+  if (a[0] == '*' && !a[1])
+    return (2);
+  if (!a[0] && !b[0])
+    return (2);
+  if (!a[0] || !b[0])
+    return (0);
+  if (a[0] == '*' && (a[1] == '*' || a[1] == '$'))
+    return (e_p_comp_mess (++a, b, c, txt, file, cmp, y, x));
+  if (a[0] == '$' && a[1] == '{')
+    {
+      for (k = 2; a[k] && a[k] != '}'; k++);
+      var = malloc ((k - 1) * sizeof (char));
+      for (i = 2; i < k; i++)
+	var[i - 2] = a[i];
+      var[k - 2] = '\0';
+      if (a[k])
+	k++;
+      if (!a[k])
+	return (!e_p_konv_mess (var, b, txt, file, cmp, y, x));
+      n = a[k] == '\\' ? k : k + 1;
+    }
+  else if (a[0] == '*' && a[1] != '\\')
+    {
+      k = 1;
+      n = 2;
+    }
+  else
+    n = 1;
+  for (; bsl || (a[n] && a[n] != '*' && a[n] != '?' && a[n] != '[' &&
+		 (a[n] != '$' || a[n + 1] != '{')); n++)
+    bsl = a[n] == '\\' ? !bsl : 0;
+  if (a[0] == '*' || a[0] == '$')
+    {
+      if (a[k] == '?')
+	{
+	  cp = malloc ((strlen (a) + 1) * sizeof (char));
+	  for (i = 0; i < k && (cp[i] = a[i]); i++);
+	  for (i++; (cp[i - 1] = a[i]) != '\0'; i++);
+	  free (var);
+	  n = e_p_comp_mess (cp, ++b, ++c, txt, file, cmp, y, x);
+	  free (cp);
+	  return (n);
+	}
+      if (a[k] == '[')
+	{
+	  for (i = 0; b[i] &&
+	       !(n =
+		 e_p_comp_mess (a + k, b + i, c + i, txt, file, cmp, y, x));
+	       i++)
+	    ;
+	  if (!b[i])
+	    return (0);
+	  if (a[0] == '$')
+	    {
+	      str = malloc ((i + 1) * sizeof (char));
+	      for (k = 0; k < i; k++)
+		str[k] = b[k];
+	      str[i] = '\0';
+	      e_p_konv_mess (var, str, txt, file, cmp, y, x);
+	      free (var);
+	      free (str);
+	    }
+	  return (n);
+	}
+      n -= k;
+      ctmp = malloc (n + 1);
+      for (i = 0; i < n; i++)
+	ctmp[i] = a[i + k];
+      ctmp[n] = '\0';
+      cp = strstr (b, ctmp);
+      free (ctmp);
+      if (cp == NULL)
+	return (0);
+      if (a[0] == '$')
+	{
+	  for (i = 0; c + i < cp; i++);
+	  str = malloc ((i + 1) * sizeof (char));
+	  for (i = 0; c + i < cp; i++)
+	    str[i] = c[i];
+	  str[i] = '\0';
+	  i = e_p_konv_mess (var, str, txt, file, cmp, y, x);
+	  free (var);
+	  free (str);
+	  if (i)
+	    return (0);
+	}
+      if (!a[k + n] && !cp[n])
+	return (2);
+      if (!a[k + n])
+	return (e_p_comp_mess (a, cp + 1, cp + 1, txt, file, cmp, y, x));
+      if ((i =
+	   e_p_comp_mess (a + k + n, cp + n, cp + n, txt, file, cmp, y, x)))
+	return (i);
+      if (file[0] && *y > -1)
+	return (0);
+      return (e_p_comp_mess
+	      (a, cp + 1, a[0] == '$' ? c : cp + 1, txt, file, cmp, y, x));
+    }
+  else if (a[0] == '?')
+    {
+      n--;
+      a++;
+      b++;
+    }
+  else if (a[0] == '[')
+    {
+      if (a[1] == '!')
+	{
+	  for (k = 2; a[k] && (a[k] != ']' || k == 2) && a[k] != b[0]; k++)
+	    if (a[k + 1] == '-' && b[0] >= a[k] && b[0] <= a[k + 2])
+	      return (-b[0]);
+	  if (a[k] != ']')
+	    return (-b[0]);
+	  n -= (k + 1);
+	  a += (k + 1);
+	  b++;
+	}
+      else
+	{
+	  for (k = 1; a[k] && (a[k] != ']' || k == 1) && a[k] != b[0]; k++)
+	    if (a[k + 1] == '-' && b[0] >= a[k] && b[0] <= a[k + 2])
+	      break;
+	  if (a[k] == ']' || a[k] == '\0')
+	    return (0);
+	  for (; a[k] && (a[k] != ']'); k++);
+	  n -= (k + 1);
+	  a += (k + 1);
+	  b++;
+	}
+    }
+  if (n <= 0)
+    return (e_p_comp_mess (a, b, c, txt, file, cmp, y, x));
+  if ((k = strncmp (a, b, n)) != 0)
+    return (0);
+  return (e_p_comp_mess (a + n, b + n, c + n, txt, file, cmp, y, x));
+}
+
+int
+e_p_cmp_mess (char *srch, BUFFER * b, int *ii, int *kk, int ret)
+{
+  char *cp, cmp[128], file[128], search[80], tmp[4][128], **wtxt = NULL;
+  int j, l, m, n, iy, iorig, i = *ii, k = *kk, x = 0, y = -1, wnum = 0;
+  int *wn = NULL;
+
+  cmp[0] = search[0] = file[0] = '\0';
+  wtxt = malloc (1);
+  wn = malloc (1);
+  for (j = 0, n = 0; n < 4 && srch[j]; n++)
+    {
+      for (l = 0; (tmp[n][l] = srch[j]); j++, l++)
+	{
+	  if (j > 1 && srch[j] == '?' && srch[j - 1] == '{'
+	      && srch[j - 2] == '$')
+	    {
+	      wnum++;
+	      wn = realloc (wn, wnum * sizeof (int));
+	      wtxt = realloc (wtxt, wnum * sizeof (char *));
+	      if (srch[j + 1] == '*')
+		wn[wnum - 1] = -1;
+	      else
+		wn[wnum - 1] = atoi (srch + j + 1);
+	      for (j++; srch[j] && srch[j] != ':'; j++);
+	      if (!srch[j])
+		{
+		  wnum--;
+		  break;
+		}
+	      for (m = 0; srch[j + m] && srch[j + m] != '}'; m++);
+	      wtxt[wnum - 1] = malloc ((m + 1) * sizeof (char));
+	      for (m = 0, j++;
+		   (wtxt[wnum - 1][m] = srch[j]) && srch[j] != '}'; j++, m++);
+	      wtxt[wnum - 1][m] = '\0';
+	      l -= 3;
+	    }
+	  else if (srch[j] == '\r' || srch[j] == '\n')
+	    {
+	      if (srch[j + 1] == '\r' || srch[j + 1] == '\n')
+		{
+		  tmp[n][l] = '\n';
+		  tmp[n][l + 1] = '\0';
+		  j++;
+		}
+	      else
+		tmp[n][l] = '\0';
+	      j++;
+	      break;
+	    }
+	}
+    }
+  e_p_comp_mess (tmp[0], (char *) b->bf[i].s, (char *) b->bf[i].s, search,
+		 file, cmp, &y, &x);
+  iy = i;
+  iorig = i;
   do
-  {
-   if (n > 2 && file[0] && y >= 0 && i < b->mxlines-1)
-   {
-    while (b->bf[i].s[b->bf[i].len-1] == '\\')
-     i++;
-    i++;
-    l = e_p_comp_mess(tmp[2], (char *)b->bf[i].s, (char *)b->bf[i].s, search, file, cmp, &y, &x);
-    if (!l && n > 3)
-     l = e_p_comp_mess(tmp[3], (char *)b->bf[i].s, (char *)b->bf[i].s, search, file, cmp, &y, &x);
-   }
-   else
-    l = 1;
-   if (file[0] && y >= 0 && l != 0)
-   {
-    err_li[k].file = malloc((strlen(file)+1)*sizeof(char));
-    strcpy(err_li[k].file, file);
-    err_li[k].line = y;
-    if (search[0] == 'P')
     {
-     cp = strstr((const char *)b->bf[iy].s, cmp);
-     if (!cp)
-      x = 0;
-     else
-     {
-      for (m = 0; b->bf[iy].s + m < (unsigned char *)cp; m++);
-      x -= m;
-     }
-     err_li[k].srch = malloc((strlen(cmp)+2)*sizeof(char));
-     err_li[k].srch[0] = 'P';
-     strcpy(err_li[k].srch+1, cmp);
+      if (n > 1 && file[0] && i < b->mxlines - 1)
+	{
+	  y = -1;
+	  while (b->bf[i].s[b->bf[i].len - 1] == '\\')
+	    i++;
+	  i++;
+	  e_p_comp_mess (tmp[1], (char *) b->bf[i].s, (char *) b->bf[i].s,
+			 search, file, cmp, &y, &x);
+	  iy = i;
+	}
+      do
+	{
+	  if (n > 2 && file[0] && y >= 0 && i < b->mxlines - 1)
+	    {
+	      while (b->bf[i].s[b->bf[i].len - 1] == '\\')
+		i++;
+	      i++;
+	      l =
+		e_p_comp_mess (tmp[2], (char *) b->bf[i].s,
+			       (char *) b->bf[i].s, search, file, cmp, &y,
+			       &x);
+	      if (!l && n > 3)
+		l =
+		  e_p_comp_mess (tmp[3], (char *) b->bf[i].s,
+				 (char *) b->bf[i].s, search, file, cmp, &y,
+				 &x);
+	    }
+	  else
+	    l = 1;
+	  if (file[0] && y >= 0 && l != 0)
+	    {
+	      err_li[k].file = malloc ((strlen (file) + 1) * sizeof (char));
+	      strcpy (err_li[k].file, file);
+	      err_li[k].line = y;
+	      if (search[0] == 'P')
+		{
+		  cp = strstr ((const char *) b->bf[iy].s, cmp);
+		  if (!cp)
+		    x = 0;
+		  else
+		    {
+		      for (m = 0; b->bf[iy].s + m < (unsigned char *) cp;
+			   m++);
+		      x -= m;
+		    }
+		  err_li[k].srch =
+		    malloc ((strlen (cmp) + 2) * sizeof (char));
+		  err_li[k].srch[0] = 'P';
+		  strcpy (err_li[k].srch + 1, cmp);
+		}
+	      else if (search[0])
+		{
+		  err_li[k].srch =
+		    malloc ((strlen (search) + 1) * sizeof (char));
+		  strcpy (err_li[k].srch, search);
+		}
+	      else
+		err_li[k].srch = NULL;
+	      err_li[k].x = x;
+	      err_li[k].y = iorig;
+	      err_li[k].text = malloc (strlen ((char *) b->bf[i].s) + 1);
+	      strcpy (err_li[k].text, (char *) b->bf[i].s);
+	      err_li[k].text[b->bf[i].len] = '\0';
+	      k++;
+	      err_num++;
+	      if (!ret)
+		{
+		  for (ret = -1, m = 0; ret && m < wnum; m++)
+		    {
+		      if (wn[m] == -1 && !(b->cn->edopt & ED_MESSAGES_STOP_AT)
+			  && strstr ((const char *) b->bf[i].s, wtxt[m]))
+			ret = 0;
+		      else if (wn[m] > -1
+			       && !(b->cn->edopt & ED_MESSAGES_STOP_AT)
+			       && !strncmp ((const char *) b->bf[i].s + wn[m],
+					    wtxt[m], strlen (wtxt[m])))
+			ret = 0;
+		    }
+		}
+	      if (!ret && wnum <= 0)
+		ret = -1;
+	      while (b->bf[i].s[b->bf[i].len - 1] == '\\')
+		i++;
+	    }
+	}
+      while (n > 2 && file[0] && y >= 0 && l != 0 && i < b->mxlines - 1);
+      if (n > 2 && file[0] && y >= 0 && l == 0)
+	i--;
     }
-    else if (search[0])
-    {
-     err_li[k].srch = malloc((strlen(search)+1)*sizeof(char));
-     strcpy(err_li[k].srch, search);
-    }
-    else
-     err_li[k].srch = NULL;
-    err_li[k].x = x;
-    err_li[k].y = iorig;
-    err_li[k].text = malloc(strlen((char *)b->bf[i].s) + 1);
-    strcpy(err_li[k].text, (char *)b->bf[i].s);
-    err_li[k].text[b->bf[i].len] = '\0';
-    k++;
-    err_num++;
-    if (!ret)
-    {
-     for (ret = -1, m = 0; ret && m < wnum; m++)
-     {
-      if (wn[m] == -1 && !(b->cn->edopt & ED_MESSAGES_STOP_AT) &&
-        strstr((const char *)b->bf[i].s, wtxt[m]))
-       ret = 0;
-      else if (wn[m] > -1 && !(b->cn->edopt & ED_MESSAGES_STOP_AT) &&
-        !strncmp((const char *)b->bf[i].s+wn[m], wtxt[m], strlen(wtxt[m])))
-       ret = 0;
-     }
-    }
-    if (!ret && wnum <= 0)
-     ret = -1;
-    while (b->bf[i].s[b->bf[i].len-1] == '\\')
-     i++;
-   }
-  } while (n > 2 && file[0] && y >= 0 && l != 0 && i < b->mxlines-1);
-  if (n > 2 && file[0] && y >= 0 && l == 0)
-   i--;
- } while (n > 1 && file[0] && y >= 0 && i < b->mxlines-1);
- if (n > 1 && file[0] && y < 0)
-  i--;
- *ii = i;
- *kk = k;
- for (m = 0; m < wnum; m++)
-  free(wtxt[m]);
- free(wn);
- free(wtxt);
- return(ret);
+  while (n > 1 && file[0] && y >= 0 && i < b->mxlines - 1);
+  if (n > 1 && file[0] && y < 0)
+    i--;
+  *ii = i;
+  *kk = k;
+  for (m = 0; m < wnum; m++)
+    free (wtxt[m]);
+  free (wn);
+  free (wtxt);
+  return (ret);
 }
 
 #endif
-

--- a/src/we_prog.h
+++ b/src/we_prog.h
@@ -11,75 +11,77 @@ typedef time_t M_TIME;
 
 extern int e__project;
 
-struct e_s_prog {
- char *language, *compiler, *comp_str, *libraries,
-   *exe_name, *intstr, key;
- char **filepostfix; /* Expandable array */ 
- int	comp_sw, x;
+struct e_s_prog
+{
+  char *language, *compiler, *comp_str, *libraries, *exe_name, *intstr, key;
+  char **filepostfix;		/* Expandable array */
+  int comp_sw, x;
 };
 extern struct e_s_prog e_s_prog;
 
-int e_ini_prog(ECNT *cn);
+int e_ini_prog (ECNT * cn);
 
-struct e_prog {
- int num;  
- char *arguments, *project, *exedir, *sys_include;
- struct e_s_prog **comp;
+struct e_prog
+{
+  int num;
+  char *arguments, *project, *exedir, *sys_include;
+  struct e_s_prog **comp;
 };
 extern struct e_prog e_prog;
 
 /********** prototypes ****************/
-struct dirfile **e_make_prj_opt(FENSTER *f);
-int e_rel_brkwtch(FENSTER *f);
-int e_prj_ob_file(FENSTER *f);
-int e_make_error_list(FENSTER *f);
-int e_d_car_ret(FENSTER *f);
-int e_prog_switch(FENSTER *f, int c);
+struct dirfile **e_make_prj_opt (FENSTER * f);
+int e_rel_brkwtch (FENSTER * f);
+int e_prj_ob_file (FENSTER * f);
+int e_make_error_list (FENSTER * f);
+int e_d_car_ret (FENSTER * f);
+int e_prog_switch (FENSTER * f, int c);
 
-int print_to_end_of_buffer(BUFFER * b,char * str,int wrap_limit);
+int print_to_end_of_buffer (BUFFER * b, char *str, int wrap_limit);
 
 /*   we_prog.c   */
 
-int e_compile(FENSTER *f);
-int e_p_make(FENSTER *f);
-int e_run(FENSTER *f);
-int e_c_project(FENSTER *f);
-int e_free_arg(char **arg, int argc);
-int e_comp(FENSTER *f);
-int e_exec_inf(FENSTER *f, char **argv, int n);
-int e_print_arg(FILE *fp, char *s, char **argv, int n);
-int e_show_error(int n, FENSTER *f);
-int e_previous_error(FENSTER *f);
-int e_next_error(FENSTER *f);
-int e_line_read(int n, char *s, int max);
-int e_arguments(FENSTER *f);
-int e_check_c_file(char *name);
-int e_check_header(char *file, M_TIME otime, ECNT *cn, int sw);
-char *e_cat_string(char *p, char *str);
-int e_make_arg(char ***arg, char *str);
-int e_copy_prog(struct e_s_prog *out, struct e_s_prog *in);
-int e_run_options(FENSTER *f);
-int e_run_c_options(FENSTER *f);
-int e_project_options(FENSTER *f);
-int e_system(char *estr, ECNT *cn);
-int e_d_p_message(char *str, FENSTER *f, int sw);
-int e_install(FENSTER *f);
-int e_exec_make(FENSTER *f);
-int e_run_sh(FENSTER *f);
-int e_project(FENSTER *f);
-int e_p_mess_win(char *header, int argc, char **argv, view **pic, FENSTER *f);
-int e_p_add_df(FLWND *fw, int sw);
-int e_p_del_df(FLWND *fw, int sw);
-int e_p_edit_df(FLWND *fw, int sw);
-int e_d_car_mouse(FENSTER *f);
-int e_add_arg(char ***arg, char *str, int n, int argc);
-int e_new_message(FENSTER *f);
-int e_p_cmp_mess(char *srch, BUFFER *b, int *ii, int *kk, int ret);
-int e_project_name(FENSTER *f);
-int e_wrt_prj_fl(FENSTER *f);
-int e_p_update_prj_fl(FENSTER *f);
-int freedfN(struct dirfile **df, int n);
-int e_p_red_buffer(BUFFER *b);
-int e_read_var(FENSTER *f);
+int e_compile (FENSTER * f);
+int e_p_make (FENSTER * f);
+int e_run (FENSTER * f);
+int e_c_project (FENSTER * f);
+int e_free_arg (char **arg, int argc);
+int e_comp (FENSTER * f);
+int e_exec_inf (FENSTER * f, char **argv, int n);
+int e_print_arg (FILE * fp, char *s, char **argv, int n);
+int e_show_error (int n, FENSTER * f);
+int e_previous_error (FENSTER * f);
+int e_next_error (FENSTER * f);
+int e_line_read (int n, char *s, int max);
+int e_arguments (FENSTER * f);
+int e_check_c_file (char *name);
+int e_check_header (char *file, M_TIME otime, ECNT * cn, int sw);
+char *e_cat_string (char *p, char *str);
+int e_make_arg (char ***arg, char *str);
+int e_copy_prog (struct e_s_prog *out, struct e_s_prog *in);
+int e_run_options (FENSTER * f);
+int e_run_c_options (FENSTER * f);
+int e_project_options (FENSTER * f);
+int e_system (char *estr, ECNT * cn);
+int e_d_p_message (char *str, FENSTER * f, int sw);
+int e_install (FENSTER * f);
+int e_exec_make (FENSTER * f);
+int e_run_sh (FENSTER * f);
+int e_project (FENSTER * f);
+int e_p_mess_win (char *header, int argc, char **argv, view ** pic,
+		  FENSTER * f);
+int e_p_add_df (FLWND * fw, int sw);
+int e_p_del_df (FLWND * fw, int sw);
+int e_p_edit_df (FLWND * fw, int sw);
+int e_d_car_mouse (FENSTER * f);
+int e_add_arg (char ***arg, char *str, int n, int argc);
+int e_new_message (FENSTER * f);
+int e_p_cmp_mess (char *srch, BUFFER * b, int *ii, int *kk, int ret);
+int e_project_name (FENSTER * f);
+int e_wrt_prj_fl (FENSTER * f);
+int e_p_update_prj_fl (FENSTER * f);
+int freedfN (struct dirfile **df, int n);
+int e_p_red_buffer (BUFFER * b);
+int e_read_var (FENSTER * f);
 
 #endif

--- a/src/we_progn.c
+++ b/src/we_progn.c
@@ -18,7 +18,7 @@
 #include "WeString.h"
 
 #ifdef UNIX
-# include <unistd.h>
+#include <unistd.h>
 #endif
 
 #undef TESTSDEF
@@ -26,14 +26,14 @@
 #ifdef PROG
 #include "makro.h"
 
-extern struct dirfile *e_p_get_var(char *string);
+extern struct dirfile *e_p_get_var (char *string);
 extern char *e_p_msg[];
 
-#define FRB1 s->fb->cr.fb  /*  key words etc  */
-#define FRB2 s->fb->ck.fb  /*  constants           */
-#define FRB3 s->fb->cp.fb  /*  pre-processor A.     */
-#define FRB4 s->fb->cc.fb  /*  comments           */
-#define FRB5 s->fb->ct.fb  /*  text                 */
+#define FRB1 s->fb->cr.fb	/*  key words etc  */
+#define FRB2 s->fb->ck.fb	/*  constants           */
+#define FRB3 s->fb->cp.fb	/*  pre-processor A.     */
+#define FRB4 s->fb->cc.fb	/*  comments           */
+#define FRB5 s->fb->ct.fb	/*  text                 */
 
 #define iscase(s) ( (!strncmp(s, "case", 4) && !isalnum1(*(s+4)))	      \
 		 || (!strncmp(s, "default", 7) && !isalnum1(*(s+7))) )
@@ -72,875 +72,1102 @@ extern char *e_p_msg[];
  * This function is in desparate need of refactoring. But testing first.
  *
  */
-void e_mk_col(unsigned char *str, int l, int n, int *frb,
-		struct wpeSyntaxRule *cs, int n_nd, int *n_bg, int *mcsw, int *bssw, int *svmsw,
-		SCHIRM *s)
+void
+e_mk_col (unsigned char *str, int l, int n, int *frb,
+	  struct wpeSyntaxRule *cs, int n_nd, int *n_bg, int *mcsw, int *bssw,
+	  int *svmsw, SCHIRM * s)
 {
- if (n < l)
- {
-  if (n == cs->special_column)
-  {
-   int ii;
-   for (ii = 0; cs->special_comment[ii] &&
-     cs->special_comment[ii] != toupper(str[n]); ii++)
-    ;
-   if (cs->special_comment[ii])
-    *mcsw = 7;
-  }
-  if (*mcsw == 6 && (isalnum(str[n]) || str[n] == '_'))
-   *frb = FRB1;
-  else if(*mcsw == 7) *frb = FRB4;
-  else if(*mcsw == 3 && (isalnum(str[n]) || str[n] == '.')) *frb = FRB2;
-  else if(*mcsw == 5)
-  {
-   if (str[n] == cs->begin_comment[0])
-   {
-    int jj;
-    for (jj = 1; cs->begin_comment[jj] &&
-      str[n+jj] == cs->begin_comment[jj]; jj++)
-     ;
-    if (!cs->begin_comment[jj])
-    {  *mcsw = 4;  *n_bg = n+jj-1;  *frb = FRB4;  }
-   }
-   if (*mcsw == 5 && str[n] == cs->line_comment[0])
-   {
-    int jj;
-    for (jj = 1; cs->line_comment[jj] &&
-      str[n+jj] == cs->line_comment[jj]; jj++);
-    if (!cs->line_comment[jj]) {  *mcsw = 7;  *frb = FRB4;  }
-   }
-   if (*mcsw == 5) *frb = FRB3;
-  }
-  else if (*mcsw == 1)
-  {
-   if (str[n] == cs->string_constant && !*bssw) *mcsw = 0;
-   *frb = FRB2;
-  }
-  else if (*mcsw == 2)
-  {
-   if (str[n] == cs->char_constant && !*bssw) *mcsw = 0;
-   *frb = FRB2;
-  }
-  else if (*mcsw == 4)
-  {
-   if (n_nd < n-*n_bg && str[n] == cs->end_comment[n_nd])
-   {
-    int jj;
-    for (jj = 1; jj <= n_nd && n-jj >= 0 &&
-      str[n-jj] == cs->end_comment[n_nd-jj]; jj++);
-    if (jj > n_nd) *mcsw = *svmsw;
-   }
-   *frb = FRB4;
-  }
-  else
-  {
-   if (n >= cs->comment_column) {  *mcsw = 7;  *frb = FRB4;  }
-   else if (isdigit(str[n]))
-   {
-    if (n == 0 || (!isalnum(str[n-1]) && str[n-1] != '_'))
-    {  *mcsw = 3;  *frb = FRB2;  }
-    else *frb = FRB5;
-   }
-   else if (isalpha(str[n]))
-   {
-    if(cs->insensitive && (n == 0 || (!isalnum(str[n-1]) &&
-      str[n-1] != '_')))
+  if (n < l)
     {
-     int ii, jj;
-     int kk = strlen((const char *)cs->line_comment);
-     if ((WpeStrnccmp((char *)cs->line_comment, (const char *)str + n, kk) == 0) &&
-       (!isalnum(str[n +kk])) && (str[n + kk] != '_'))
-     {
-      *mcsw = 7;
-      *frb = FRB4;
-     }
-     else
-     {
-      for (ii = 0; cs->reserved_word[ii] &&
-        cs->reserved_word[ii][0] < toupper(str[n]);
-        ii++);
-      for ( ; cs->reserved_word[ii] &&
-        cs->reserved_word[ii][0] == toupper(str[n]);
-        ii++)
-      {
-       for (jj = 0; cs->reserved_word[ii][jj] &&
-         cs->reserved_word[ii][jj] == toupper(str[n+jj]);
-         jj++);
-       if (!cs->reserved_word[ii][jj] && !isalnum(str[n+jj]) &&
-         str[n+jj] != '_')
-       {  *mcsw = 6;  *frb = FRB1;  break;  }
-      }
-     }
-    }
-    else if (!cs->insensitive && (n == 0 || (!isalnum(str[n-1]) &&
-      str[n-1] != '_')))
-    {
-     int ii, jj;
-     int kk = strlen((const char *)cs->line_comment);
-     if ((strncmp((const char *)cs->line_comment, (const char *)str + n, kk) == 0) &&
-       (!isalnum(str[n +kk])) && (str[n + kk] != '_'))
-     {
-      *mcsw = 7;
-      *frb = FRB4;
-     }
-     else
-     {
-      for (ii = 0; cs->reserved_word[ii] &&
-        cs->reserved_word[ii][0] < str[n]; ii++);
-      for( ; cs->reserved_word[ii] &&
-        cs->reserved_word[ii][0] == str[n]; ii++)
-      {
-       for (jj = 0; cs->reserved_word[ii][jj] &&
-         cs->reserved_word[ii][jj] == str[n+jj]; jj++);
-       if (!cs->reserved_word[ii][jj] && !isalnum(str[n+jj]) &&
-         str[n+jj] != '_')
-       {  *mcsw = 6;  *frb = FRB1;  break;  }
-      }
-     }
-    }
-    if (!*mcsw) *frb = FRB5;
-   }
-   else if (isspace(str[n]))
-   {  *mcsw = 0;  *frb = FRB5;  }
-   else
-   {
-    if (str[n] == cs->string_constant)
-    {  *mcsw = 1;  *frb = FRB2;  }
-    else if (str[n] == cs->char_constant)
-    {  *mcsw = 2;  *frb = FRB2;  }
-    else if (str[n] == cs->preproc_cmd)
-    {  *svmsw = *mcsw = 5;  *frb = FRB3;  }
-    else
-    {
-     *mcsw = 0;
-     if (str[n] == cs->begin_comment[0])
-     {
-      int jj;
-      for(jj = 1; cs->begin_comment[jj] &&
-        str[n+jj] == cs->begin_comment[jj]; jj++);
-      if (!cs->begin_comment[jj])
-      {  *mcsw = 4;  *n_bg = n+jj-1;  *frb = FRB4;  }
-     }
-     if (!*mcsw && str[n] == cs->line_comment[0])
-     {
-      int jj;
-      for (jj = 1; cs->line_comment[jj] &&
-        str[n+jj] == cs->line_comment[jj]; jj++);
-      if (!cs->line_comment[jj]) {  *mcsw = 7;  *frb = FRB4; }
-     }
-     if (cs->long_operator && !*mcsw)
-     {
-      if(cs->insensitive)
-      {
-       int ii, jj;
-       for (ii = 0; cs->long_operator[ii] &&
-         cs->long_operator[ii][0] < str[n]; ii++);
-       for ( ; cs->long_operator[ii] &&
-         cs->long_operator[ii][0] == str[n]; ii++)
-       {
-        for (jj = 0; cs->long_operator[ii][jj] &&
-          cs->long_operator[ii][jj] == toupper(str[n+jj]); jj++);
-        if (!cs->long_operator[ii][jj])
-        {  *mcsw = 6;  *frb = FRB1;  break;  }
-       }
-      }
+      if (n == cs->special_column)
+	{
+	  int ii;
+	  for (ii = 0; cs->special_comment[ii] &&
+	       cs->special_comment[ii] != toupper (str[n]); ii++)
+	    ;
+	  if (cs->special_comment[ii])
+	    *mcsw = 7;
+	}
+      if (*mcsw == 6 && (isalnum (str[n]) || str[n] == '_'))
+	*frb = FRB1;
+      else if (*mcsw == 7)
+	*frb = FRB4;
+      else if (*mcsw == 3 && (isalnum (str[n]) || str[n] == '.'))
+	*frb = FRB2;
+      else if (*mcsw == 5)
+	{
+	  if (str[n] == cs->begin_comment[0])
+	    {
+	      int jj;
+	      for (jj = 1; cs->begin_comment[jj] &&
+		   str[n + jj] == cs->begin_comment[jj]; jj++)
+		;
+	      if (!cs->begin_comment[jj])
+		{
+		  *mcsw = 4;
+		  *n_bg = n + jj - 1;
+		  *frb = FRB4;
+		}
+	    }
+	  if (*mcsw == 5 && str[n] == cs->line_comment[0])
+	    {
+	      int jj;
+	      for (jj = 1; cs->line_comment[jj] &&
+		   str[n + jj] == cs->line_comment[jj]; jj++);
+	      if (!cs->line_comment[jj])
+		{
+		  *mcsw = 7;
+		  *frb = FRB4;
+		}
+	    }
+	  if (*mcsw == 5)
+	    *frb = FRB3;
+	}
+      else if (*mcsw == 1)
+	{
+	  if (str[n] == cs->string_constant && !*bssw)
+	    *mcsw = 0;
+	  *frb = FRB2;
+	}
+      else if (*mcsw == 2)
+	{
+	  if (str[n] == cs->char_constant && !*bssw)
+	    *mcsw = 0;
+	  *frb = FRB2;
+	}
+      else if (*mcsw == 4)
+	{
+	  if (n_nd < n - *n_bg && str[n] == cs->end_comment[n_nd])
+	    {
+	      int jj;
+	      for (jj = 1; jj <= n_nd && n - jj >= 0 &&
+		   str[n - jj] == cs->end_comment[n_nd - jj]; jj++);
+	      if (jj > n_nd)
+		*mcsw = *svmsw;
+	    }
+	  *frb = FRB4;
+	}
       else
-      {
-       int ii, jj;
-       for (ii = 0; cs->long_operator[ii] &&
-         cs->long_operator[ii][0] < str[n]; ii++);
-       for ( ; cs->long_operator[ii] &&
-         cs->long_operator[ii][0] == str[n]; ii++)
-       {
-        for (jj = 0; cs->long_operator[ii][jj] &&
-          cs->long_operator[ii][jj] == str[n+jj]; jj++);
-        if (!cs->long_operator[ii][jj])
-        {  *mcsw = 6;  *frb = FRB1;  break;  }
-       }
-      }
-     }
-     if (!*mcsw)
-     {
-      int jj;
-      for (jj = 0; cs->single_operator[jj] &&
-        str[n] != cs->single_operator[jj]; jj++);
-      if (!cs->single_operator[jj]) *frb = FRB5;
-      else *frb = FRB1;
-     }
+	{
+	  if (n >= cs->comment_column)
+	    {
+	      *mcsw = 7;
+	      *frb = FRB4;
+	    }
+	  else if (isdigit (str[n]))
+	    {
+	      if (n == 0 || (!isalnum (str[n - 1]) && str[n - 1] != '_'))
+		{
+		  *mcsw = 3;
+		  *frb = FRB2;
+		}
+	      else
+		*frb = FRB5;
+	    }
+	  else if (isalpha (str[n]))
+	    {
+	      if (cs->insensitive && (n == 0 || (!isalnum (str[n - 1]) &&
+						 str[n - 1] != '_')))
+		{
+		  int ii, jj;
+		  int kk = strlen ((const char *) cs->line_comment);
+		  if ((WpeStrnccmp
+		       ((char *) cs->line_comment, (const char *) str + n,
+			kk) == 0) && (!isalnum (str[n + kk]))
+		      && (str[n + kk] != '_'))
+		    {
+		      *mcsw = 7;
+		      *frb = FRB4;
+		    }
+		  else
+		    {
+		      for (ii = 0; cs->reserved_word[ii] &&
+			   cs->reserved_word[ii][0] < toupper (str[n]); ii++);
+		      for (; cs->reserved_word[ii] &&
+			   cs->reserved_word[ii][0] == toupper (str[n]); ii++)
+			{
+			  for (jj = 0; cs->reserved_word[ii][jj] &&
+			       cs->reserved_word[ii][jj] ==
+			       toupper (str[n + jj]); jj++);
+			  if (!cs->reserved_word[ii][jj]
+			      && !isalnum (str[n + jj]) && str[n + jj] != '_')
+			    {
+			      *mcsw = 6;
+			      *frb = FRB1;
+			      break;
+			    }
+			}
+		    }
+		}
+	      else if (!cs->insensitive
+		       && (n == 0
+			   || (!isalnum (str[n - 1]) && str[n - 1] != '_')))
+		{
+		  int ii, jj;
+		  int kk = strlen ((const char *) cs->line_comment);
+		  if ((strncmp
+		       ((const char *) cs->line_comment,
+			(const char *) str + n, kk) == 0)
+		      && (!isalnum (str[n + kk])) && (str[n + kk] != '_'))
+		    {
+		      *mcsw = 7;
+		      *frb = FRB4;
+		    }
+		  else
+		    {
+		      for (ii = 0; cs->reserved_word[ii] &&
+			   cs->reserved_word[ii][0] < str[n]; ii++);
+		      for (; cs->reserved_word[ii] &&
+			   cs->reserved_word[ii][0] == str[n]; ii++)
+			{
+			  for (jj = 0; cs->reserved_word[ii][jj] &&
+			       cs->reserved_word[ii][jj] == str[n + jj];
+			       jj++);
+			  if (!cs->reserved_word[ii][jj]
+			      && !isalnum (str[n + jj]) && str[n + jj] != '_')
+			    {
+			      *mcsw = 6;
+			      *frb = FRB1;
+			      break;
+			    }
+			}
+		    }
+		}
+	      if (!*mcsw)
+		*frb = FRB5;
+	    }
+	  else if (isspace (str[n]))
+	    {
+	      *mcsw = 0;
+	      *frb = FRB5;
+	    }
+	  else
+	    {
+	      if (str[n] == cs->string_constant)
+		{
+		  *mcsw = 1;
+		  *frb = FRB2;
+		}
+	      else if (str[n] == cs->char_constant)
+		{
+		  *mcsw = 2;
+		  *frb = FRB2;
+		}
+	      else if (str[n] == cs->preproc_cmd)
+		{
+		  *svmsw = *mcsw = 5;
+		  *frb = FRB3;
+		}
+	      else
+		{
+		  *mcsw = 0;
+		  if (str[n] == cs->begin_comment[0])
+		    {
+		      int jj;
+		      for (jj = 1; cs->begin_comment[jj] &&
+			   str[n + jj] == cs->begin_comment[jj]; jj++);
+		      if (!cs->begin_comment[jj])
+			{
+			  *mcsw = 4;
+			  *n_bg = n + jj - 1;
+			  *frb = FRB4;
+			}
+		    }
+		  if (!*mcsw && str[n] == cs->line_comment[0])
+		    {
+		      int jj;
+		      for (jj = 1; cs->line_comment[jj] &&
+			   str[n + jj] == cs->line_comment[jj]; jj++);
+		      if (!cs->line_comment[jj])
+			{
+			  *mcsw = 7;
+			  *frb = FRB4;
+			}
+		    }
+		  if (cs->long_operator && !*mcsw)
+		    {
+		      if (cs->insensitive)
+			{
+			  int ii, jj;
+			  for (ii = 0; cs->long_operator[ii] &&
+			       cs->long_operator[ii][0] < str[n]; ii++);
+			  for (; cs->long_operator[ii] &&
+			       cs->long_operator[ii][0] == str[n]; ii++)
+			    {
+			      for (jj = 0; cs->long_operator[ii][jj] &&
+				   cs->long_operator[ii][jj] ==
+				   toupper (str[n + jj]); jj++);
+			      if (!cs->long_operator[ii][jj])
+				{
+				  *mcsw = 6;
+				  *frb = FRB1;
+				  break;
+				}
+			    }
+			}
+		      else
+			{
+			  int ii, jj;
+			  for (ii = 0; cs->long_operator[ii] &&
+			       cs->long_operator[ii][0] < str[n]; ii++);
+			  for (; cs->long_operator[ii] &&
+			       cs->long_operator[ii][0] == str[n]; ii++)
+			    {
+			      for (jj = 0; cs->long_operator[ii][jj] &&
+				   cs->long_operator[ii][jj] == str[n + jj];
+				   jj++);
+			      if (!cs->long_operator[ii][jj])
+				{
+				  *mcsw = 6;
+				  *frb = FRB1;
+				  break;
+				}
+			    }
+			}
+		    }
+		  if (!*mcsw)
+		    {
+		      int jj;
+		      for (jj = 0; cs->single_operator[jj] &&
+			   str[n] != cs->single_operator[jj]; jj++);
+		      if (!cs->single_operator[jj])
+			*frb = FRB5;
+		      else
+			*frb = FRB1;
+		    }
+		}
+	    }
+	}
+      if (str[n] == cs->quoting_char)
+	*bssw = !*bssw;
+      else
+	*bssw = 0;
     }
-   }
-  }
-  if (str[n] == cs->quoting_char) *bssw = !*bssw;
-  else *bssw = 0;
- }
- else
- {
-  if ((*mcsw == 7) || (*mcsw == 4)) *frb = FRB4;
-  else if ((*mcsw == 1) || (*mcsw == 2)) *frb = FRB2;
-  else if (*mcsw == 5) *frb = FRB3;
   else
-   *frb = FRB5;
- }
+    {
+      if ((*mcsw == 7) || (*mcsw == 4))
+	*frb = FRB4;
+      else if ((*mcsw == 1) || (*mcsw == 2))
+	*frb = FRB2;
+      else if (*mcsw == 5)
+	*frb = FRB3;
+      else
+	*frb = FRB5;
+    }
 }
 
 /*************************************************************************/
 
-int e_scfbol(int n, int mcsw, unsigned char *str, WpeSyntaxRule *cs)
+int
+e_scfbol (int n, int mcsw, unsigned char *str, WpeSyntaxRule * cs)
 {
- int bssw = 0, svmsw = 0, nla = 0, i, j;
+  int bssw = 0, svmsw = 0, nla = 0, i, j;
 
- for (i = 0; i < n && isspace(str[i]); i++)
-  ;
- if (mcsw == 5)
-  svmsw = 5;
- else if (mcsw == 0 && str[i] == cs->preproc_cmd)
- {
-  svmsw = mcsw = 5;
-  i++;
- }
- for (; i < n; i++)
- {
-  if (i == cs->special_column)
-   return(0);
-  else if (mcsw == 4)
-  {
-   if (str[i] == cs->end_comment[0])
-   {
-    for (j = 1; cs->end_comment[j] && str[i+j] == cs->end_comment[j]; j++)
-     ;
-    if (!cs->end_comment[j])
+  for (i = 0; i < n && isspace (str[i]); i++)
+    ;
+  if (mcsw == 5)
+    svmsw = 5;
+  else if (mcsw == 0 && str[i] == cs->preproc_cmd)
     {
-     i += (j-1);
-     mcsw = svmsw;
+      svmsw = mcsw = 5;
+      i++;
     }
-   }
-  }
-  else if (mcsw == 1)
-  {
-   if (str[i] == cs->string_constant && !bssw)
-    mcsw = svmsw;
-  }
-  else if (str[i] == cs->string_constant && !bssw)
-   mcsw = 1;
+  for (; i < n; i++)
+    {
+      if (i == cs->special_column)
+	return (0);
+      else if (mcsw == 4)
+	{
+	  if (str[i] == cs->end_comment[0])
+	    {
+	      for (j = 1;
+		   cs->end_comment[j] && str[i + j] == cs->end_comment[j];
+		   j++)
+		;
+	      if (!cs->end_comment[j])
+		{
+		  i += (j - 1);
+		  mcsw = svmsw;
+		}
+	    }
+	}
+      else if (mcsw == 1)
+	{
+	  if (str[i] == cs->string_constant && !bssw)
+	    mcsw = svmsw;
+	}
+      else if (str[i] == cs->string_constant && !bssw)
+	mcsw = 1;
+      else
+	{
+	  if (str[i] == cs->line_comment[0])
+	    {
+	      for (j = 1;
+		   cs->line_comment[j] && str[i + j] == cs->line_comment[j];
+		   j++)
+		;
+	      if (!cs->line_comment[j])
+		return (0);
+	    }
+	  if (str[i] == cs->begin_comment[0])
+	    {
+	      for (j = 1;
+		   cs->begin_comment[j] && str[i + j] == cs->begin_comment[j];
+		   j++)
+		;
+	      if (!cs->begin_comment[j])
+		mcsw = 4;
+	      i += (j - 1);
+	    }
+	}
+      if (str[i] == cs->quoting_char)
+	bssw = !bssw;
+      else
+	bssw = 0;
+    }
+  return ((mcsw == 4 || (bssw && n > 0 && str[n - 1] == cs->continue_char) ||
+	   nla || cs->continue_column >= 0) ? mcsw : 0);
+}
+
+int
+e_sc_all (FENSTER * f, int sw)
+{
+  int i;
+
+  if (!WpeIsProg () || !WpeIsXwin ())
+    return (0);
+  if (!sw)
+    {
+      for (i = 0; i <= f->ed->mxedt; i++)
+	if (f->ed->f[i]->c_sw)
+	  {
+	    free (f->ed->f[i]->c_sw);
+	    f->ed->f[i]->c_sw = NULL;
+	  }
+    }
   else
-  {
-   if (str[i] == cs->line_comment[0])
-   {
-    for (j = 1; cs->line_comment[j] && str[i+j] == cs->line_comment[j]; j++)
-     ;
-    if (!cs->line_comment[j])
-     return(0);
-   }
-   if (str[i] == cs->begin_comment[0])
-   {
-    for (j = 1; cs->begin_comment[j] && str[i+j] == cs->begin_comment[j]; j++)
-     ;
-    if (!cs->begin_comment[j])
-     mcsw = 4;
-    i += (j-1);
-   }
-  }
-  if (str[i] == cs->quoting_char)
-   bssw = !bssw;
+    {
+      for (i = 0; i <= f->ed->mxedt; i++)
+	{
+	  if (f->ed->f[i]->c_sw)
+	    free (f->ed->f[i]->c_sw);
+	  e_add_synt_tl (f->ed->f[i]->datnam, f->ed->f[i]);
+	  if (f->ed->f[i]->c_st)
+	    {
+	      if (f->ed->f[i]->c_sw)
+		free (f->ed->f[i]->c_sw);
+	      f->ed->f[i]->c_sw = e_sc_txt (NULL, f->ed->f[i]->b);
+	    }
+	}
+    }
+  e_rep_win_tree (f->ed);
+  return (0);
+}
+
+int
+e_program_opt (FENSTER * f)
+{
+  int ret, sw = f->ed->edopt & ED_SYNTAX_HIGHLIGHT ? 1 : 0;
+  W_OPTSTR *o = e_init_opt_kst (f);
+
+  if (!o)
+    return (-1);
+  o->xa = 17;
+  o->ya = 4;
+  o->xe = 59;
+  o->ye = 18;
+  o->bgsw = AltO;
+  o->name = "Programming-Options";
+  o->crsw = AltO;
+  e_add_txtstr (21, 2, "Screen:", o);
+  e_add_txtstr (4, 2, "Stop at", o);
+  e_add_sswstr (5, 3, 0, AltE, f->ed->edopt & ED_ERRORS_STOP_AT ? 1 : 0,
+		"Errors  ", o);
+  e_add_sswstr (5, 4, 0, AltM, f->ed->edopt & ED_MESSAGES_STOP_AT ? 1 : 0,
+		"Messages", o);
+  e_add_sswstr (22, 3, 0, AltD, f->ed->edopt & ED_SYNTAX_HIGHLIGHT ? 1 : 0,
+		"Diff. Colors", o);
+  e_add_wrstr (4, 6, 4, 7, 35, 128, 1, AltX, "EXecution-Directory:",
+	       e_prog.exedir, NULL, o);
+  e_add_wrstr (4, 9, 4, 10, 35, 128, 0, AltS, "System-Include-Path:",
+	       e_prog.sys_include, NULL, o);
+  e_add_bttstr (10, 12, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (26, 12, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      if (e_prog.exedir)
+	free (e_prog.exedir);
+      e_prog.exedir = WpeStrdup (o->wstr[0]->txt);
+      if (e_prog.sys_include)
+	free (e_prog.sys_include);
+      e_prog.sys_include = WpeStrdup (o->wstr[1]->txt);
+      f->ed->edopt = (f->ed->edopt & ~ED_PROGRAMMING_OPTIONS) +
+	(o->sstr[0]->num ? ED_ERRORS_STOP_AT : 0) +
+	(o->sstr[1]->num ? ED_MESSAGES_STOP_AT : 0) +
+	(o->sstr[2]->num ? ED_SYNTAX_HIGHLIGHT : 0);
+      if (sw != o->sstr[2]->num)
+	e_sc_all (f, o->sstr[2]->num);
+    }
+  freeostr (o);
+  return (0);
+}
+
+int
+e_sc_nw_txt (int y, BUFFER * b, int sw)
+{
+  int i, out;
+
+  if (sw < 0)
+    {
+      out = b->f->c_sw[y + 1];
+      for (i = y + 1; i < b->mxlines; i++)
+	b->f->c_sw[i] = b->f->c_sw[i + 1];
+      if (out == b->f->c_sw[y])
+	return (0);
+    }
+  else if (sw > 0)
+    for (i = b->mxlines - 1; i > y; i--)
+      b->f->c_sw[i] = b->f->c_sw[i - 1];
+
+  if (b->f->c_st->continue_column < 0)
+    {
+      for (i = y; i < b->mxlines - 1; i++)
+	{
+	  if ((out =
+	       e_scfbol (b->bf[i].len, b->f->c_sw[i], b->bf[i].s,
+			 b->f->c_st)) == b->f->c_sw[i + 1])
+	    break;
+	  else
+	    b->f->c_sw[i + 1] = out;
+	}
+    }
   else
-   bssw = 0;
- }
- return ((mcsw == 4 || (bssw && n > 0 && str[n-1] == cs->continue_char) ||
-   nla ||  cs->continue_column >= 0 ) ? mcsw : 0);
+    {
+      if (y != 0)		/* Quick fix to continue line check - Dennis */
+	{
+	  b->f->c_sw[y] =
+	    isspace (b->bf[y].
+		     s[b->f->c_st->continue_column]) ? 0 : e_scfbol (b->bf[y -
+									   1].
+								     len,
+								     b->f->
+								     c_sw[y -
+									  1],
+								     b->bf[y -
+									   1].
+								     s,
+								     b->f->
+								     c_st);
+	  for (i = y; i < b->mxlines - 1; i++)
+	    {
+	      out =
+		isspace (b->bf[i + 1].
+			 s[b->f->c_st->continue_column]) ? 0 : e_scfbol (b->
+									 bf
+									 [i].
+									 len,
+									 b->
+									 f->
+									 c_sw
+									 [i],
+									 b->
+									 bf
+									 [i].
+									 s,
+									 b->
+									 f->
+									 c_st);
+	      if (out == b->f->c_sw[i + 1])
+		break;
+	      else
+		b->f->c_sw[i + 1] = out;
+	    }
+	}
+    }
+  return (0);
 }
 
-int e_sc_all(FENSTER *f, int sw)
+int *
+e_sc_txt (int *c_sw, BUFFER * b)
 {
- int i;
+  int i;
 
- if (!WpeIsProg() || !WpeIsXwin())
-  return(0);
- if (!sw)
- {
-  for (i = 0; i <= f->ed->mxedt; i++)
-  if (f->ed->f[i]->c_sw)
-  {
-   free(f->ed->f[i]->c_sw);
-   f->ed->f[i]->c_sw = NULL;
-  }
- }
- else
- {
-  for (i = 0; i <= f->ed->mxedt; i++)
-  {
-   if (f->ed->f[i]->c_sw)
-    free(f->ed->f[i]->c_sw);
-   e_add_synt_tl(f->ed->f[i]->datnam, f->ed->f[i]);
-   if (f->ed->f[i]->c_st)
-   {
-    if (f->ed->f[i]->c_sw)
-     free(f->ed->f[i]->c_sw);
-    f->ed->f[i]->c_sw = e_sc_txt(NULL, f->ed->f[i]->b);
-   }
-  }
- }
- e_rep_win_tree(f->ed);
- return(0);
-}
-
-int e_program_opt(FENSTER *f)
-{
- int ret, sw = f->ed->edopt & ED_SYNTAX_HIGHLIGHT ? 1 : 0;
- W_OPTSTR *o = e_init_opt_kst(f);
-
- if (!o) return(-1);
- o->xa = 17;  o->ya = 4;  o->xe = 59;  o->ye = 18;
- o->bgsw = AltO;
- o->name = "Programming-Options";
- o->crsw = AltO;
- e_add_txtstr(21, 2, "Screen:", o);
- e_add_txtstr(4, 2, "Stop at", o);
- e_add_sswstr(5, 3, 0, AltE, f->ed->edopt & ED_ERRORS_STOP_AT ? 1 : 0,
-   "Errors  ", o);
- e_add_sswstr(5, 4, 0, AltM, f->ed->edopt & ED_MESSAGES_STOP_AT ? 1 : 0,
-   "Messages", o);
- e_add_sswstr(22, 3, 0, AltD, f->ed->edopt & ED_SYNTAX_HIGHLIGHT ? 1 : 0,
-   "Diff. Colors", o);
- e_add_wrstr(4, 6, 4, 7, 35, 128, 1, AltX, "EXecution-Directory:",
-   e_prog.exedir, NULL, o);
- e_add_wrstr(4, 9, 4, 10, 35, 128, 0, AltS, "System-Include-Path:",
-   e_prog.sys_include, NULL, o);
- e_add_bttstr(10, 12, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(26, 12, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
-  if (e_prog.exedir)
-   free(e_prog.exedir);
-  e_prog.exedir = WpeStrdup(o->wstr[0]->txt);
-  if (e_prog.sys_include)
-   free(e_prog.sys_include);
-  e_prog.sys_include = WpeStrdup(o->wstr[1]->txt);
-  f->ed->edopt = (f->ed->edopt & ~ED_PROGRAMMING_OPTIONS) +
-    (o->sstr[0]->num ? ED_ERRORS_STOP_AT : 0) +
-    (o->sstr[1]->num ? ED_MESSAGES_STOP_AT : 0) +
-    (o->sstr[2]->num ? ED_SYNTAX_HIGHLIGHT : 0);
-  if (sw != o->sstr[2]->num)
-   e_sc_all(f, o->sstr[2]->num);
- }
- freeostr(o);
- return(0);
-}
-
-int e_sc_nw_txt(int y, BUFFER *b, int sw)
-{
- int i, out;
-
- if (sw < 0)
- {
-  out = b->f->c_sw[y+1];
-  for (i = y+1; i < b->mxlines; i++)
-   b->f->c_sw[i] = b->f->c_sw[i+1];
-  if (out == b->f->c_sw[y])
-   return(0);
- }
- else if (sw > 0)
-  for (i = b->mxlines-1; i > y; i--)
-   b->f->c_sw[i] = b->f->c_sw[i-1];
-
- if (b->f->c_st->continue_column < 0)
- {
-  for (i = y; i < b->mxlines-1; i++)
-  {
-   if ((out = e_scfbol(b->bf[i].len, b->f->c_sw[i], b->bf[i].s, b->f->c_st)) == b->f->c_sw[i+1])
-    break;
-   else
-    b->f->c_sw[i+1] = out;
-  }
- }
- else
- {
-  if (y != 0) /* Quick fix to continue line check - Dennis */
-  {
-   b->f->c_sw[y] = isspace(b->bf[y].s[b->f->c_st->continue_column]) ? 0 :
-     e_scfbol(b->bf[y-1].len, b->f->c_sw[y-1], b->bf[y-1].s, b->f->c_st);
-   for (i = y; i < b->mxlines-1; i++)
-   {
-    out = isspace(b->bf[i+1].s[b->f->c_st->continue_column]) ? 0 :
-      e_scfbol(b->bf[i].len, b->f->c_sw[i], b->bf[i].s, b->f->c_st);
-    if (out == b->f->c_sw[i+1])
-     break;
-    else
-     b->f->c_sw[i+1] = out;
-   }
-  }
- }
- return(0);
-}
-
-int *e_sc_txt(int *c_sw, BUFFER *b)
-{
- int i;
-
- if (!c_sw)
-  c_sw = malloc(b->mx.y * sizeof(int));
- c_sw[0] = 0;
- if (b->f->c_st->continue_column < 0)
- {
-  for (i = 0; i < b->mxlines-1; i++)
-   c_sw[i+1] = e_scfbol(b->bf[i].len, c_sw[i], b->bf[i].s, b->f->c_st);
- }
- else
- {
-  for (i = 0; i < b->mxlines-1; i++)
-  {
-   c_sw[i+1] = isspace(b->bf[i+1].s[b->f->c_st->continue_column]) ? 0 :
-     e_scfbol(b->bf[i].len, c_sw[i], b->bf[i].s, b->f->c_st);
-  }
- }
- return(c_sw);
+  if (!c_sw)
+    c_sw = malloc (b->mx.y * sizeof (int));
+  c_sw[0] = 0;
+  if (b->f->c_st->continue_column < 0)
+    {
+      for (i = 0; i < b->mxlines - 1; i++)
+	c_sw[i + 1] =
+	  e_scfbol (b->bf[i].len, c_sw[i], b->bf[i].s, b->f->c_st);
+    }
+  else
+    {
+      for (i = 0; i < b->mxlines - 1; i++)
+	{
+	  c_sw[i + 1] =
+	    isspace (b->bf[i + 1].
+		     s[b->f->c_st->continue_column]) ? 0 : e_scfbol (b->bf[i].
+								     len,
+								     c_sw[i],
+								     b->bf[i].
+								     s,
+								     b->f->
+								     c_st);
+	}
+    }
+  return (c_sw);
 }
 
 /*       Writing of a line (content of a screen)      */
-void e_pr_c_line(int y, FENSTER *f)
+void
+e_pr_c_line (int y, FENSTER * f)
 {
- BUFFER *b = f->b;
- SCHIRM *s = f->s;
- int i, j, k, frb = 0;
- int mcsw = f->c_sw[y], svmsw = f->c_sw[y] == 5 ? 5 : 0, bssw = 0;
- int n_bg = -1, n_nd = strlen((const char *)f->c_st->end_comment)-1;
+  BUFFER *b = f->b;
+  SCHIRM *s = f->s;
+  int i, j, k, frb = 0;
+  int mcsw = f->c_sw[y], svmsw = f->c_sw[y] == 5 ? 5 : 0, bssw = 0;
+  int n_bg = -1, n_nd = strlen ((const char *) f->c_st->end_comment) - 1;
 #ifdef DEBUGGER
- int fsw = 0;
+  int fsw = 0;
 #endif
 
- for (i = j = 0; j < s->c.x; j++, i++)
- {
-  if (*(b->bf[y].s + i) == WPE_TAB)
-   j += (f->ed->tabn - j % f->ed->tabn - 1);
+  for (i = j = 0; j < s->c.x; j++, i++)
+    {
+      if (*(b->bf[y].s + i) == WPE_TAB)
+	j += (f->ed->tabn - j % f->ed->tabn - 1);
 #ifdef UNIX
-  else if (((unsigned char) *(b->bf[y].s + i)) > 126)
-  {
-   j++;
-   if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' ')
-    j++;
-  }
-  else if (*(b->bf[y].s + i) < ' ')
-   j++;
+      else if (((unsigned char) *(b->bf[y].s + i)) > 126)
+	{
+	  j++;
+	  if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' ')
+	    j++;
+	}
+      else if (*(b->bf[y].s + i) < ' ')
+	j++;
 #endif
- }
- if (j > s->c.x)
-  i--;
- for (k = 0; k < i; k++)
-  e_mk_col(b->bf[y].s, b->bf[y].len, k, &frb, f->c_st, n_nd, &n_bg, &mcsw, &bssw, &svmsw, s);
+    }
+  if (j > s->c.x)
+    i--;
+  for (k = 0; k < i; k++)
+    e_mk_col (b->bf[y].s, b->bf[y].len, k, &frb, f->c_st, n_nd, &n_bg, &mcsw,
+	      &bssw, &svmsw, s);
 #ifdef DEBUGGER
- for (j = 1; j <= s->brp[0]; j++)
-  if (s->brp[j] == y)
-  {
-   fsw = 1;
-   break;
-  }
- for (j = s->c.x; i < b->bf[y].len && j < NUM_COLS_ON_SCREEN_SAFE + s->c.x - 1; i++, j++)
- {
-  e_mk_col(b->bf[y].s, b->bf[y].len, i, &frb, f->c_st, n_nd, &n_bg, &mcsw, &bssw, &svmsw, s);
-  if ( y == s->da.y && i >= s->da.x && i < s->de.x )
-   frb = s->fb->dy.fb;
-  else if (fsw)
-   frb = s->fb->db.fb;
-  else if ( y == s->fa.y && i >= s->fa.x && i < s->fe.x )
-   frb = s->fb->ek.fb;
+  for (j = 1; j <= s->brp[0]; j++)
+    if (s->brp[j] == y)
+      {
+	fsw = 1;
+	break;
+      }
+  for (j = s->c.x;
+       i < b->bf[y].len && j < NUM_COLS_ON_SCREEN_SAFE + s->c.x - 1; i++, j++)
+    {
+      e_mk_col (b->bf[y].s, b->bf[y].len, i, &frb, f->c_st, n_nd, &n_bg,
+		&mcsw, &bssw, &svmsw, s);
+      if (y == s->da.y && i >= s->da.x && i < s->de.x)
+	frb = s->fb->dy.fb;
+      else if (fsw)
+	frb = s->fb->db.fb;
+      else if (y == s->fa.y && i >= s->fa.x && i < s->fe.x)
+	frb = s->fb->ek.fb;
 #else
- for (j = s->c.x; i < b->bf[y].len && j < NUM_COLS_ON_SCREEN_SAFE + s->c.x - 1; i++, j++)
- {
-  e_mk_col(b->bf[y].s, b->bf[y].len, i, &frb, f->c_st, n_nd, &n_bg, &mcsw, &bssw, &svmsw, s);
-  if ( y == s->fa.y && i >= s->fa.x && i < s->fe.x )
-   frb = s->fb->ek.fb;
+  for (j = s->c.x;
+       i < b->bf[y].len && j < NUM_COLS_ON_SCREEN_SAFE + s->c.x - 1; i++, j++)
+    {
+      e_mk_col (b->bf[y].s, b->bf[y].len, i, &frb, f->c_st, n_nd, &n_bg,
+		&mcsw, &bssw, &svmsw, s);
+      if (y == s->fa.y && i >= s->fa.x && i < s->fe.x)
+	frb = s->fb->ek.fb;
 #endif
-  else if ((y < s->mark_end.y && ( y > s->mark_begin.y ||
-           (y == s->mark_begin.y && i >= s->mark_begin.x))) ||
-           (y == s->mark_end.y && i < s->mark_end.x && ( y > s->mark_begin.y ||
-           (y == s->mark_begin.y && i >= s->mark_begin.x))))
-   frb = s->fb->ez.fb;
-  if (*(b->bf[y].s + i) == WPE_TAB)
-   for (k = f->ed->tabn - j % f->ed->tabn;
-     k > 1 && j < NUM_COLS_ON_SCREEN + s->c.x - 2; k--, j++)
-    e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1, ' ', frb);
+      else if ((y < s->mark_end.y && (y > s->mark_begin.y ||
+				      (y == s->mark_begin.y
+				       && i >= s->mark_begin.x)))
+	       || (y == s->mark_end.y && i < s->mark_end.x
+		   && (y > s->mark_begin.y
+		       || (y == s->mark_begin.y && i >= s->mark_begin.x))))
+	frb = s->fb->ez.fb;
+      if (*(b->bf[y].s + i) == WPE_TAB)
+	for (k = f->ed->tabn - j % f->ed->tabn;
+	     k > 1 && j < NUM_COLS_ON_SCREEN + s->c.x - 2; k--, j++)
+	  e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1, ' ',
+		     frb);
 #ifdef UNIX
-  else if (!WpeIsXwin() && ((unsigned char)*(b->bf[y].s + i)) > 126)
-  {
-   e_pr_char(f->a.x - s->c.x + j +1, y - s->c.y + f->a.y + 1, '@', frb);
-   if (++j >= NUM_COLS_ON_SCREEN + s->c.x - 1)
-    return;
-   if (((unsigned char)*(b->bf[y].s + i)) < 128 + ' ' && j < NUM_COLS_ON_SCREEN + s->c.x - 1)
-   {
-    e_pr_char(f->a.x - s->c.x + j +1, y - s->c.y + f->a.y + 1, '^', frb);
-    if (++j >= NUM_COLS_ON_SCREEN + s->c.x - 1)
-     return;
-   }
-  }
-  else if (*(b->bf[y].s + i) < ' ')
-  {
-   e_pr_char(f->a.x - s->c.x + j +1, y - s->c.y + f->a.y + 1, '^', frb);
-   if (++j >= NUM_COLS_ON_SCREEN + s->c.x - 1)
-    return;
-  }
+      else if (!WpeIsXwin () && ((unsigned char) *(b->bf[y].s + i)) > 126)
+	{
+	  e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1, '@',
+		     frb);
+	  if (++j >= NUM_COLS_ON_SCREEN + s->c.x - 1)
+	    return;
+	  if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' '
+	      && j < NUM_COLS_ON_SCREEN + s->c.x - 1)
+	    {
+	      e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+			 '^', frb);
+	      if (++j >= NUM_COLS_ON_SCREEN + s->c.x - 1)
+		return;
+	    }
+	}
+      else if (*(b->bf[y].s + i) < ' ')
+	{
+	  e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1, '^',
+		     frb);
+	  if (++j >= NUM_COLS_ON_SCREEN + s->c.x - 1)
+	    return;
+	}
 #endif
-  if (*(b->bf[y].s + i) == WPE_TAB)
-   e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,                  ' ', frb);
+      if (*(b->bf[y].s + i) == WPE_TAB)
+	e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1, ' ',
+		   frb);
 #ifdef UNIX
-  else if(!WpeIsXwin() && ((unsigned char)*(b->bf[y].s + i)) > 126 &&
-    j < NUM_COLS_ON_SCREEN + s->c.x - 1)
-  {
-   if (((unsigned char)*(b->bf[y].s + i)) < 128 + ' ')
-    e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-      ((unsigned char) *(b->bf[y].s + i)) + 'A' - 129, frb);
-   else
-    e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-      ((unsigned char) *(b->bf[y].s + i)) - 128, frb);
-  }
-  else if (*(b->bf[y].s + i) < ' ' && j < NUM_COLS_ON_SCREEN + s->c.x - 1)
-   e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-     *(b->bf[y].s + i) + 'A' - 1, frb);
+      else if (!WpeIsXwin () && ((unsigned char) *(b->bf[y].s + i)) > 126 &&
+	       j < NUM_COLS_ON_SCREEN + s->c.x - 1)
+	{
+	  if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' ')
+	    e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		       ((unsigned char) *(b->bf[y].s + i)) + 'A' - 129, frb);
+	  else
+	    e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		       ((unsigned char) *(b->bf[y].s + i)) - 128, frb);
+	}
+      else if (*(b->bf[y].s + i) < ' ' && j < NUM_COLS_ON_SCREEN + s->c.x - 1)
+	e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		   *(b->bf[y].s + i) + 'A' - 1, frb);
 #endif
-  else
-   e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-     *(b->bf[y].s + i), frb);
- }
+      else
+	e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		   *(b->bf[y].s + i), frb);
+    }
 
- e_mk_col(b->bf[y].s, b->bf[y].len, i, &frb, f->c_st, n_nd, &n_bg, &mcsw, &bssw, &svmsw, s);
+  e_mk_col (b->bf[y].s, b->bf[y].len, i, &frb, f->c_st, n_nd, &n_bg, &mcsw,
+	    &bssw, &svmsw, s);
 
- if ((i == b->bf[y].len) && (f->ed->edopt & ED_SHOW_ENDMARKS) &&
-   (DTMD_ISMARKABLE(f->dtmd)) && (j < NUM_COLS_ON_SCREEN_SAFE + s->c.x - 1))
- {
-  if ((y < s->mark_end.y && ( y > s->mark_begin.y ||
-    (y == s->mark_begin.y && i >= s->mark_begin.x) ) ) ||
-    (y == s->mark_end.y && i < s->mark_end.x && ( y > s->mark_begin.y ||
-    (y == s->mark_begin.y && i >= s->mark_begin.x) ) ) )
-  {
-   if (*(b->bf[y].s + i) == WPE_WR)
-    e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-      PWR, s->fb->ez.fb);
-   else
-    e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-      PNL, s->fb->ez.fb);
-  }
-  else
-  {
-   if (*(b->bf[y].s + i) == WPE_WR)
-     e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-       PWR, frb);
-   else
-    e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
-      PNL, frb);
-  }
-  j++;
- }
- for (; j < NUM_COLS_ON_SCREEN + s->c.x - 1; j++)
-  e_pr_char(f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1, ' ', frb);
+  if ((i == b->bf[y].len) && (f->ed->edopt & ED_SHOW_ENDMARKS) &&
+      (DTMD_ISMARKABLE (f->dtmd))
+      && (j < NUM_COLS_ON_SCREEN_SAFE + s->c.x - 1))
+    {
+      if ((y < s->mark_end.y && (y > s->mark_begin.y ||
+				 (y == s->mark_begin.y
+				  && i >= s->mark_begin.x)))
+	  || (y == s->mark_end.y && i < s->mark_end.x
+	      && (y > s->mark_begin.y
+		  || (y == s->mark_begin.y && i >= s->mark_begin.x))))
+	{
+	  if (*(b->bf[y].s + i) == WPE_WR)
+	    e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		       PWR, s->fb->ez.fb);
+	  else
+	    e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		       PNL, s->fb->ez.fb);
+	}
+      else
+	{
+	  if (*(b->bf[y].s + i) == WPE_WR)
+	    e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		       PWR, frb);
+	  else
+	    e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1,
+		       PNL, frb);
+	}
+      j++;
+    }
+  for (; j < NUM_COLS_ON_SCREEN + s->c.x - 1; j++)
+    e_pr_char (f->a.x - s->c.x + j + 1, y - s->c.y + f->a.y + 1, ' ', frb);
 }
 
-int e_add_synt_tl(char *filename, FENSTER *f)
+int
+e_add_synt_tl (char *filename, FENSTER * f)
 {
- int i, k;
+  int i, k;
 
- f->c_st = NULL;
- f->c_sw = NULL;
- if (!WpeSyntaxDef || !filename) return 0;
- filename = strrchr(filename, '.');
- if (!filename) return 0;
- for(i = 0; i < WpeExpArrayGetSize(WpeSyntaxDef); i++)
- {
-  for (k = 0; k < WpeExpArrayGetSize(WpeSyntaxDef[i]->extension); k++)
-  {
-   if (!strcmp(filename, WpeSyntaxDef[i]->extension[k]))
-   {
-    f->c_st = WpeSyntaxDef[i]->syntax_rule;
-    if (f->ed->edopt & ED_SYNTAX_HIGHLIGHT)
-     f->c_sw = malloc(f->b->mx.y*sizeof(int));
-   }
-  }
- }
- return(0);
+  f->c_st = NULL;
+  f->c_sw = NULL;
+  if (!WpeSyntaxDef || !filename)
+    return 0;
+  filename = strrchr (filename, '.');
+  if (!filename)
+    return 0;
+  for (i = 0; i < WpeExpArrayGetSize (WpeSyntaxDef); i++)
+    {
+      for (k = 0; k < WpeExpArrayGetSize (WpeSyntaxDef[i]->extension); k++)
+	{
+	  if (!strcmp (filename, WpeSyntaxDef[i]->extension[k]))
+	    {
+	      f->c_st = WpeSyntaxDef[i]->syntax_rule;
+	      if (f->ed->edopt & ED_SYNTAX_HIGHLIGHT)
+		f->c_sw = malloc (f->b->mx.y * sizeof (int));
+	    }
+	}
+    }
+  return (0);
 }
 
 /*  Browser   */
-E_AFILE *e_aopen(char *name, char *path, int mode)
+E_AFILE *
+e_aopen (char *name, char *path, int mode)
 {
- ECNT *cn = WpeEditor;
- E_AFILE *ep = malloc(sizeof(E_AFILE));
- char str[256];
- int i, j;
+  ECNT *cn = WpeEditor;
+  E_AFILE *ep = malloc (sizeof (E_AFILE));
+  char str[256];
+  int i, j;
 
- ep->b = NULL;
- ep->fp = NULL;
- if (mode & 1)
- {
-  for (i = 1; i <= cn->mxedt && strcmp(cn->f[i]->datnam, name); i++)
-   ;
-  if (i <= cn->mxedt)
-  {
-   ep->b = cn->f[i]->b;
-   ep->p.x = ep->p.y = 0;
-  }
- }
- if ((mode & 2) && !ep->b && !access(name, R_OK))
-  ep->fp = fopen(name, "r");
- if ((mode & 4) && !ep->b && !ep->fp)
- {
-  for (i = 0; path[i] && !ep->fp; i++)
-  {
-   for (j = 0; (str[j] = path[i]) && path[i] != ':'; j++, i++)
-    ;
-   if (!path[i]) i--;
-   str[j] = '/';
-   str[j+1] = '\0';
-   strcat(str, name);
-   if (!access(str, R_OK))
-    ep->fp = fopen(str, "r");
-   if (ep->fp)
-    strcpy(name, str);
-  }
- }
- if (!ep->b && !ep->fp)
- {
-  free(ep);
-  return NULL;
- }
- return(ep);
-}
-
-int e_aclose(E_AFILE *ep)
-{
- int ret = 0;
-
- if (ep->fp)
-  ret = fclose(ep->fp);
- free(ep);
- return(ret);
-}
-
-char *e_agets(char *str, int n, E_AFILE *ep)
-{
- int i, j;
-
- if (ep->fp)
-  return(fgets(str, n, ep->fp));
- if (ep->p.y >= ep->b->mxlines ||
-   (ep->p.y == ep->b->mxlines-1 && ep->p.x > ep->b->bf[ep->p.y].len))
-  return(NULL);
- for (i = 0; ep->p.y < ep->b->mxlines; (ep->p.y)++)
- {
-  for (j = ep->p.x; i < n-1 && j <= ep->b->bf[ep->p.y].len; i++, j++)
-   str[i] = ep->b->bf[ep->p.y].s[j];
-
-  if (str[i-1] == '\n')
-  {
-   ep->p.x = 0;
-   (ep->p.y)++;
-   break;
-  }
-  else if (i == n-1)
-  {
-   ep->p.x = j;
-   break;
-  }
-  else
-  {
-   ep->p.x = 0;
-   (ep->p.y)++;
-  }
- }
- str[i] = '\0';
- return(str);
-}
-
-char *e_sh_spl1(char *sp, char *str, E_AFILE *fp, int *n)
-{
- while (1)
- {
-  while (isspace(*++sp))
-   ;
-  if (sp[0] == '\\')
-  {
-   (*n)++;
-   if (!e_agets((sp = str), 256, fp))
-    return(NULL);
-   --sp;
-  }
-  else if (sp[0] == '/' && sp[1] == '*')
-  {
-   while (!(sp = strstr(sp, "*/")))
-   {
-    (*n)++;
-    if (!e_agets((sp = str), 256, fp))
-     return(NULL);
-   }
-   sp++;
-  }
-  else
-   break;
- }
- return(sp);
-}
-
-char *e_sh_spl2(char *sp, char *str, E_AFILE *fp, int *n)
-{
- while (1)
- {
-  while (isspace(*++sp))
-   ;
-  if (!sp[0] || sp[0] == '\n' || sp[0] == '\\')
-  {
-   (*n)++;
-   if (!e_agets((sp = str), 256, fp))
-    return(NULL);
-   --sp;
-  }
-  else if (sp[0] == '/' && sp[1] == '*')
-  {
-   while (!(sp = strstr(sp, "*/")))
-   {
-    (*n)++;
-    if (!e_agets((sp = str), 256, fp))
-     return(NULL);
-   }
-   sp++;
-  }
-  else
-   break;
- }
- return(sp);
-}
-
-char *e_sh_spl3(sp, str, fp, n)
-     char *sp;
-     char *str;
-     E_AFILE *fp;
-     int *n;
-{
-    int brk = 1;
-    while(*++sp != '}' || brk > 1)
-    { if(!sp[0] || sp[0] == '\n')
-      { (*n)++; if(!e_agets((sp = str), 256, fp)) return(NULL);
-	if(isspace(*sp)) while(isspace(*++sp));
-	if(sp[0] == '#' && ispelse(sp))
-	{ do
-	  {  (*n)++; if(!e_agets((sp = str), 256, fp)) return(NULL);
-	     if(isspace(*sp)) while(isspace(*++sp));
-	  } while(sp[0] != '#' || !ispendif(sp));
+  ep->b = NULL;
+  ep->fp = NULL;
+  if (mode & 1)
+    {
+      for (i = 1; i <= cn->mxedt && strcmp (cn->f[i]->datnam, name); i++)
+	;
+      if (i <= cn->mxedt)
+	{
+	  ep->b = cn->f[i]->b;
+	  ep->p.x = ep->p.y = 0;
 	}
-	sp--;
-      }
-      else if(sp[0] == '/' && sp[1] == '*')
-      { while(!(sp = strstr(sp, "*/")))
-        { (*n)++; if(!e_agets((sp = str), 256, fp)) return(NULL);  }
-	sp++;
-      }
-      else if(sp[0] == '{') brk++;
-      else if(sp[0] == '}') brk--;
-      else if(sp[0] == '\'')
-      { int bsl = 0;
-	while(*++sp && (sp[0] != '\'' || bsl))
-	{  bsl = *sp == '\\' ? !bsl : 0;  }
-	if(!*sp) sp--;
-      }
-      else if(sp[0] == '\"')
-      { int bsl = 0;
-	while(*++sp && ( *sp != '\"' || bsl))
-	{  bsl = *sp == '\\' ? !bsl : 0;  }
-	if(!*sp) sp--;
-      }
     }
-    return(sp);
-}
-
-char *e_sh_spl5(sp, str, fp, n)
-     char *sp;
-     char *str;
-     E_AFILE *fp;
-     int *n;
-{
-    int brk = 1;
-    while(*++sp != ')' || brk > 1)
-    { if(!sp[0] || sp[0] == '\n')
-      { (*n)++; if(!e_agets((sp = str), 256, fp)) return(NULL);
-	if(isspace(*sp)) while(isspace(*++sp));
-	if(sp[0] == '#' && ispelse(sp))
-	{ do
-	  {  (*n)++; if(!e_agets((sp = str), 256, fp)) return(NULL);
-	     if(isspace(*sp)) while(isspace(*++sp));
-	  } while(sp[0] != '#' || !ispendif(sp));
+  if ((mode & 2) && !ep->b && !access (name, R_OK))
+    ep->fp = fopen (name, "r");
+  if ((mode & 4) && !ep->b && !ep->fp)
+    {
+      for (i = 0; path[i] && !ep->fp; i++)
+	{
+	  for (j = 0; (str[j] = path[i]) && path[i] != ':'; j++, i++)
+	    ;
+	  if (!path[i])
+	    i--;
+	  str[j] = '/';
+	  str[j + 1] = '\0';
+	  strcat (str, name);
+	  if (!access (str, R_OK))
+	    ep->fp = fopen (str, "r");
+	  if (ep->fp)
+	    strcpy (name, str);
 	}
-	sp--;
-      }
-      else if(sp[0] == '/' && sp[1] == '*')
-      { while(!(sp = strstr(sp, "*/")))
-        { (*n)++; if(!e_agets((sp = str), 256, fp)) return(NULL);  }
-	sp++;
-      }
-      else if(sp[0] == '(') brk++;
-      else if(sp[0] == ')') brk--;
-      else if(sp[0] == '\'')
-      { int bsl = 0;
-	while(*++sp && (sp[0] != '\'' || bsl))
-	{  bsl = *sp == '\\' ? !bsl : 0;  }
-	if(!*sp) sp--;
-      }
-      else if(sp[0] == '\"')
-      { int bsl = 0;
-	while(*++sp && (*sp != '\"' || bsl))
-	{  bsl = *sp == '\\' ? !bsl : 0;  }
-	if(!*sp) sp--;
-      }
     }
-    return(sp);
+  if (!ep->b && !ep->fp)
+    {
+      free (ep);
+      return NULL;
+    }
+  return (ep);
 }
 
-char *e_sh_spl4(sp, str, fp, n)
+int
+e_aclose (E_AFILE * ep)
+{
+  int ret = 0;
+
+  if (ep->fp)
+    ret = fclose (ep->fp);
+  free (ep);
+  return (ret);
+}
+
+char *
+e_agets (char *str, int n, E_AFILE * ep)
+{
+  int i, j;
+
+  if (ep->fp)
+    return (fgets (str, n, ep->fp));
+  if (ep->p.y >= ep->b->mxlines ||
+      (ep->p.y == ep->b->mxlines - 1 && ep->p.x > ep->b->bf[ep->p.y].len))
+    return (NULL);
+  for (i = 0; ep->p.y < ep->b->mxlines; (ep->p.y)++)
+    {
+      for (j = ep->p.x; i < n - 1 && j <= ep->b->bf[ep->p.y].len; i++, j++)
+	str[i] = ep->b->bf[ep->p.y].s[j];
+
+      if (str[i - 1] == '\n')
+	{
+	  ep->p.x = 0;
+	  (ep->p.y)++;
+	  break;
+	}
+      else if (i == n - 1)
+	{
+	  ep->p.x = j;
+	  break;
+	}
+      else
+	{
+	  ep->p.x = 0;
+	  (ep->p.y)++;
+	}
+    }
+  str[i] = '\0';
+  return (str);
+}
+
+char *
+e_sh_spl1 (char *sp, char *str, E_AFILE * fp, int *n)
+{
+  while (1)
+    {
+      while (isspace (*++sp))
+	;
+      if (sp[0] == '\\')
+	{
+	  (*n)++;
+	  if (!e_agets ((sp = str), 256, fp))
+	    return (NULL);
+	  --sp;
+	}
+      else if (sp[0] == '/' && sp[1] == '*')
+	{
+	  while (!(sp = strstr (sp, "*/")))
+	    {
+	      (*n)++;
+	      if (!e_agets ((sp = str), 256, fp))
+		return (NULL);
+	    }
+	  sp++;
+	}
+      else
+	break;
+    }
+  return (sp);
+}
+
+char *
+e_sh_spl2 (char *sp, char *str, E_AFILE * fp, int *n)
+{
+  while (1)
+    {
+      while (isspace (*++sp))
+	;
+      if (!sp[0] || sp[0] == '\n' || sp[0] == '\\')
+	{
+	  (*n)++;
+	  if (!e_agets ((sp = str), 256, fp))
+	    return (NULL);
+	  --sp;
+	}
+      else if (sp[0] == '/' && sp[1] == '*')
+	{
+	  while (!(sp = strstr (sp, "*/")))
+	    {
+	      (*n)++;
+	      if (!e_agets ((sp = str), 256, fp))
+		return (NULL);
+	    }
+	  sp++;
+	}
+      else
+	break;
+    }
+  return (sp);
+}
+
+char *
+e_sh_spl3 (sp, str, fp, n)
      char *sp;
      char *str;
      E_AFILE *fp;
      int *n;
 {
-    int brk = 0;
-    while((*++sp != ',' && *sp != ';' && *sp != '(') || brk)
-    { if(!sp[0] || sp[0] == '\n')
-      {  (*n)++;  if(!e_agets((sp = str), 256, fp)) return(NULL);
-	 --sp;
-      }
-      else if(sp[0] == '/' && sp[1] == '*')
-      { while(!(sp = strstr(sp, "*/")))
-        { (*n)++; if(!e_agets((sp = str), 256, fp)) return(NULL);  }
-	sp++;
-      }
-      else if(sp[0] == '\"')
-      { int bsl = 0;
-	while(*++sp && (sp[0] != '\"' || bsl))
-	{  bsl = *sp == '\\' ? !bsl : 0;  }
-	if(!*sp) sp--;
-      }
-      else if(sp[0] == '\'')
-      { int bsl = 0;
-	while(*++sp && (sp[0] != '\'' || bsl))
-	{  bsl = *sp == '\\' ? !bsl : 0;  }
-	if(!*sp) sp--;
-      }
-      else if(sp[0] == '{') brk++;
-      else if(sp[0] == '}') brk--;
+  int brk = 1;
+  while (*++sp != '}' || brk > 1)
+    {
+      if (!sp[0] || sp[0] == '\n')
+	{
+	  (*n)++;
+	  if (!e_agets ((sp = str), 256, fp))
+	    return (NULL);
+	  if (isspace (*sp))
+	    while (isspace (*++sp));
+	  if (sp[0] == '#' && ispelse (sp))
+	    {
+	      do
+		{
+		  (*n)++;
+		  if (!e_agets ((sp = str), 256, fp))
+		    return (NULL);
+		  if (isspace (*sp))
+		    while (isspace (*++sp));
+		}
+	      while (sp[0] != '#' || !ispendif (sp));
+	    }
+	  sp--;
+	}
+      else if (sp[0] == '/' && sp[1] == '*')
+	{
+	  while (!(sp = strstr (sp, "*/")))
+	    {
+	      (*n)++;
+	      if (!e_agets ((sp = str), 256, fp))
+		return (NULL);
+	    }
+	  sp++;
+	}
+      else if (sp[0] == '{')
+	brk++;
+      else if (sp[0] == '}')
+	brk--;
+      else if (sp[0] == '\'')
+	{
+	  int bsl = 0;
+	  while (*++sp && (sp[0] != '\'' || bsl))
+	    {
+	      bsl = *sp == '\\' ? !bsl : 0;
+	    }
+	  if (!*sp)
+	    sp--;
+	}
+      else if (sp[0] == '\"')
+	{
+	  int bsl = 0;
+	  while (*++sp && (*sp != '\"' || bsl))
+	    {
+	      bsl = *sp == '\\' ? !bsl : 0;
+	    }
+	  if (!*sp)
+	    sp--;
+	}
     }
-    return(sp);
+  return (sp);
 }
 
-struct dirfile *e_c_add_df(char *str, struct dirfile *df)
+char *
+e_sh_spl5 (sp, str, fp, n)
+     char *sp;
+     char *str;
+     E_AFILE *fp;
+     int *n;
 {
- if (df == NULL)
- {
-  df = malloc(sizeof(struct dirfile));
-  df->anz = 0;
-  df->name = malloc(sizeof(char*));
- }
- df->anz++;
- df->name = realloc(df->name, df->anz * sizeof(char*));
- df->name[df->anz-1] = malloc((strlen(str)+1) * sizeof(char));
- strcpy(df->name[df->anz-1], str);
- return(df);
+  int brk = 1;
+  while (*++sp != ')' || brk > 1)
+    {
+      if (!sp[0] || sp[0] == '\n')
+	{
+	  (*n)++;
+	  if (!e_agets ((sp = str), 256, fp))
+	    return (NULL);
+	  if (isspace (*sp))
+	    while (isspace (*++sp));
+	  if (sp[0] == '#' && ispelse (sp))
+	    {
+	      do
+		{
+		  (*n)++;
+		  if (!e_agets ((sp = str), 256, fp))
+		    return (NULL);
+		  if (isspace (*sp))
+		    while (isspace (*++sp));
+		}
+	      while (sp[0] != '#' || !ispendif (sp));
+	    }
+	  sp--;
+	}
+      else if (sp[0] == '/' && sp[1] == '*')
+	{
+	  while (!(sp = strstr (sp, "*/")))
+	    {
+	      (*n)++;
+	      if (!e_agets ((sp = str), 256, fp))
+		return (NULL);
+	    }
+	  sp++;
+	}
+      else if (sp[0] == '(')
+	brk++;
+      else if (sp[0] == ')')
+	brk--;
+      else if (sp[0] == '\'')
+	{
+	  int bsl = 0;
+	  while (*++sp && (sp[0] != '\'' || bsl))
+	    {
+	      bsl = *sp == '\\' ? !bsl : 0;
+	    }
+	  if (!*sp)
+	    sp--;
+	}
+      else if (sp[0] == '\"')
+	{
+	  int bsl = 0;
+	  while (*++sp && (*sp != '\"' || bsl))
+	    {
+	      bsl = *sp == '\\' ? !bsl : 0;
+	    }
+	  if (!*sp)
+	    sp--;
+	}
+    }
+  return (sp);
 }
 
-int e_find_def(name, startfile, mode, file, num, xn, nold, oldfile, df, first)
+char *
+e_sh_spl4 (sp, str, fp, n)
+     char *sp;
+     char *str;
+     E_AFILE *fp;
+     int *n;
+{
+  int brk = 0;
+  while ((*++sp != ',' && *sp != ';' && *sp != '(') || brk)
+    {
+      if (!sp[0] || sp[0] == '\n')
+	{
+	  (*n)++;
+	  if (!e_agets ((sp = str), 256, fp))
+	    return (NULL);
+	  --sp;
+	}
+      else if (sp[0] == '/' && sp[1] == '*')
+	{
+	  while (!(sp = strstr (sp, "*/")))
+	    {
+	      (*n)++;
+	      if (!e_agets ((sp = str), 256, fp))
+		return (NULL);
+	    }
+	  sp++;
+	}
+      else if (sp[0] == '\"')
+	{
+	  int bsl = 0;
+	  while (*++sp && (sp[0] != '\"' || bsl))
+	    {
+	      bsl = *sp == '\\' ? !bsl : 0;
+	    }
+	  if (!*sp)
+	    sp--;
+	}
+      else if (sp[0] == '\'')
+	{
+	  int bsl = 0;
+	  while (*++sp && (sp[0] != '\'' || bsl))
+	    {
+	      bsl = *sp == '\\' ? !bsl : 0;
+	    }
+	  if (!*sp)
+	    sp--;
+	}
+      else if (sp[0] == '{')
+	brk++;
+      else if (sp[0] == '}')
+	brk--;
+    }
+  return (sp);
+}
+
+struct dirfile *
+e_c_add_df (char *str, struct dirfile *df)
+{
+  if (df == NULL)
+    {
+      df = malloc (sizeof (struct dirfile));
+      df->anz = 0;
+      df->name = malloc (sizeof (char *));
+    }
+  df->anz++;
+  df->name = realloc (df->name, df->anz * sizeof (char *));
+  df->name[df->anz - 1] = malloc ((strlen (str) + 1) * sizeof (char));
+  strcpy (df->name[df->anz - 1], str);
+  return (df);
+}
+
+int
+e_find_def (name, startfile, mode, file, num, xn, nold, oldfile, df, first)
      char *name;
      char *startfile;
      int mode;
@@ -952,1034 +1179,1455 @@ int e_find_def(name, startfile, mode, file, num, xn, nold, oldfile, df, first)
      struct dirfile **df;
      int *first;
 {
-   E_AFILE *fp = NULL;
-   char *sp = NULL, str[256], *w, word[256];
-   int i, n, com = 0, ret = 1;
-   int len = strlen(name);
-   if(*df)
-   {  for(i = 0; i < (*df)->anz; i++)
-      if(!strcmp((*df)->name[i], startfile)) return(-2);
-   }
-   *df = e_c_add_df(startfile, *df);
-   if(!fp) fp = e_aopen(startfile, e_prog.sys_include, mode);
-   if(!fp) return(-1);
-   for(n = 0; com == 2 || e_agets((sp = str), 256, fp); n++)
-   {  if(com)
-      {  if(com == 1 && !(sp = strstr(sp, "*/"))) continue;
-	 else com = 0;
-      }
-      if(isspace(*sp) && !(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-      if(sp[0] == '/' && sp[1] == '*')
-      {  if(!(sp = strstr(sp, "*/"))) com = 1;
-	 else {  n--;  com = 2;  sp += 2;  }
-	 continue;
-      }
-      else if(*sp == '#')
-      {  if(!(sp = e_sh_spl1(sp, str, fp, &n))) goto b_end;
-	 if(!strncmp(sp, "define", 6))
-	 {  while(isalpha(*++sp)) {
-		;
+  E_AFILE *fp = NULL;
+  char *sp = NULL, str[256], *w, word[256];
+  int i, n, com = 0, ret = 1;
+  int len = strlen (name);
+  if (*df)
+    {
+      for (i = 0; i < (*df)->anz; i++)
+	if (!strcmp ((*df)->name[i], startfile))
+	  return (-2);
+    }
+  *df = e_c_add_df (startfile, *df);
+  if (!fp)
+    fp = e_aopen (startfile, e_prog.sys_include, mode);
+  if (!fp)
+    return (-1);
+  for (n = 0; com == 2 || e_agets ((sp = str), 256, fp); n++)
+    {
+      if (com)
+	{
+	  if (com == 1 && !(sp = strstr (sp, "*/")))
+	    continue;
+	  else
+	    com = 0;
+	}
+      if (isspace (*sp) && !(sp = e_sh_spl2 (sp, str, fp, &n)))
+	goto b_end;
+      if (sp[0] == '/' && sp[1] == '*')
+	{
+	  if (!(sp = strstr (sp, "*/")))
+	    com = 1;
+	  else
+	    {
+	      n--;
+	      com = 2;
+	      sp += 2;
 	    }
-	    if(isspace(*sp) && !(sp = e_sh_spl1(sp, str, fp, &n))) goto b_end;
-	    if(!strncmp(sp, name, len) && !isalnum1(sp[len]))
-	    {  if(*first)
-	       {  e_aclose(fp);  strcpy(file, startfile);
-		  *num = n;  *xn = ((int)(sp - str)) + len;  return(0);
-	       }
-	       else if(n == nold && !strcmp(startfile, oldfile)) *first = 1;
+	  continue;
+	}
+      else if (*sp == '#')
+	{
+	  if (!(sp = e_sh_spl1 (sp, str, fp, &n)))
+	    goto b_end;
+	  if (!strncmp (sp, "define", 6))
+	    {
+	      while (isalpha (*++sp))
+		{
+		  ;
+		}
+	      if (isspace (*sp) && !(sp = e_sh_spl1 (sp, str, fp, &n)))
+		goto b_end;
+	      if (!strncmp (sp, name, len) && !isalnum1 (sp[len]))
+		{
+		  if (*first)
+		    {
+		      e_aclose (fp);
+		      strcpy (file, startfile);
+		      *num = n;
+		      *xn = ((int) (sp - str)) + len;
+		      return (0);
+		    }
+		  else if (n == nold && !strcmp (startfile, oldfile))
+		    *first = 1;
+		}
 	    }
-	 }
 #ifndef TESTSDEF
-	 else if(!strncmp(sp, "include", 7))
-	 {  while(isalpha(*++sp)) {
-		;
+	  else if (!strncmp (sp, "include", 7))
+	    {
+	      while (isalpha (*++sp))
+		{
+		  ;
+		}
+	      if (isspace (*sp) && !(sp = e_sh_spl1 (sp, str, fp, &n)))
+		goto b_end;
+	      for (i = 1; (word[i - 1] = sp[i])
+		   && sp[i] != '\"' && sp[i] != '>'; i++);
+	      word[i - 1] = '\0';
+	      if (!e_find_def (name, word, sp[i] == '>' ? 4 : 7,
+			       file, num, xn, nold, oldfile, df, first))
+		{
+		  e_aclose (fp);
+		  return (0);
+		}
 	    }
-	    if(isspace(*sp) && !(sp = e_sh_spl1(sp, str, fp, &n))) goto b_end;
-	    for(i = 1; (word[i-1] = sp[i])
-			&& sp[i] != '\"' && sp[i] != '>'; i++);
-	    word[i-1] = '\0';
-	    if(!e_find_def(name, word, sp[i] == '>' ? 4 : 7,
-				file, num, xn, nold, oldfile, df, first))
-	    {  e_aclose(fp);  return(0);  }
-	 }
 #endif
-	 while(sp[i = (strlen(sp) - 1)] != '\n' || sp[i-1] == '\\')
-	 {  n++; if(!e_agets((sp = str), 256, fp)) goto b_end;  }
-      }
-      else if(*sp == '{')
-      {  if(!(sp = e_sh_spl3(sp, str, fp, &n))) goto b_end;
-	 sp++;  com = 2;  n--;
-      }
-      else if(!strncmp(sp, "extern", 6)) continue;
-      else if(!strncmp(sp, "typedef", 7))
-      {  while(!isspace(*++sp)) {
-		;
-	 }
-	 if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	 if(!strncmp(sp, "struct", 6) || !strncmp(sp, "class", 5) ||
-		!strncmp(sp, "union", 5))
-	 {  while(!isspace(*++sp)) {
-		;
+	  while (sp[i = (strlen (sp) - 1)] != '\n' || sp[i - 1] == '\\')
+	    {
+	      n++;
+	      if (!e_agets ((sp = str), 256, fp))
+		goto b_end;
 	    }
-	    if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	    if(*sp == ';') {  sp++;  com = 2;  n--;  continue;  }
-	    if(!strncmp(sp, name, len) && !isalnum1(sp[len]))
-	    {  while(!isspace(*++sp)) {
-		;
-	       }
-	       if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	       if(*sp == '{')
-	       {  if(*first)
-		  {  e_aclose(fp);  strcpy(file, startfile);
-		     *num = n;  *xn = (int)(sp - str);  return(0);
-		  }
-		  else if(n == nold && !strcmp(startfile, oldfile)) *first = 1;
-	       }
+	}
+      else if (*sp == '{')
+	{
+	  if (!(sp = e_sh_spl3 (sp, str, fp, &n)))
+	    goto b_end;
+	  sp++;
+	  com = 2;
+	  n--;
+	}
+      else if (!strncmp (sp, "extern", 6))
+	continue;
+      else if (!strncmp (sp, "typedef", 7))
+	{
+	  while (!isspace (*++sp))
+	    {
+	      ;
 	    }
-	 }
-	 while(1)
-	 {  if(isalpha1(*sp))
-	    {  for(w = word; isalnum1(*w = *sp); w++, sp++) {
-		;
-	       }
-	       *w = '\0';
-	       if(isspace(*sp) && !(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	       if(*sp == ';')
-	       {  if(!strncmp(word, name, len))
-		  {  if(*first)
-		     {  e_aclose(fp);  strcpy(file, startfile);
-			*num = n;  *xn = (int)(sp - str);  return(0);
-		     }
-		     else if(n == nold && !strcmp(startfile, oldfile)) *first = 1;
-		  }
-		  sp++;  com = 2;  n--;  break;
-	       }
+	  if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+	    goto b_end;
+	  if (!strncmp (sp, "struct", 6) || !strncmp (sp, "class", 5) ||
+	      !strncmp (sp, "union", 5))
+	    {
+	      while (!isspace (*++sp))
+		{
+		  ;
+		}
+	      if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		goto b_end;
+	      if (*sp == ';')
+		{
+		  sp++;
+		  com = 2;
+		  n--;
+		  continue;
+		}
+	      if (!strncmp (sp, name, len) && !isalnum1 (sp[len]))
+		{
+		  while (!isspace (*++sp))
+		    {
+		      ;
+		    }
+		  if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		    goto b_end;
+		  if (*sp == '{')
+		    {
+		      if (*first)
+			{
+			  e_aclose (fp);
+			  strcpy (file, startfile);
+			  *num = n;
+			  *xn = (int) (sp - str);
+			  return (0);
+			}
+		      else if (n == nold && !strcmp (startfile, oldfile))
+			*first = 1;
+		    }
+		}
 	    }
-	    else if(*sp == '{')
-	    {  if(!(sp = e_sh_spl3(sp, str, fp, &n))) goto b_end;
-	       if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	       if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
+	  while (1)
+	    {
+	      if (isalpha1 (*sp))
+		{
+		  for (w = word; isalnum1 (*w = *sp); w++, sp++)
+		    {
+		      ;
+		    }
+		  *w = '\0';
+		  if (isspace (*sp) && !(sp = e_sh_spl2 (sp, str, fp, &n)))
+		    goto b_end;
+		  if (*sp == ';')
+		    {
+		      if (!strncmp (word, name, len))
+			{
+			  if (*first)
+			    {
+			      e_aclose (fp);
+			      strcpy (file, startfile);
+			      *num = n;
+			      *xn = (int) (sp - str);
+			      return (0);
+			    }
+			  else if (n == nold && !strcmp (startfile, oldfile))
+			    *first = 1;
+			}
+		      sp++;
+		      com = 2;
+		      n--;
+		      break;
+		    }
+		}
+	      else if (*sp == '{')
+		{
+		  if (!(sp = e_sh_spl3 (sp, str, fp, &n)))
+		    goto b_end;
+		  if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		    goto b_end;
+		  if (*sp == ';')
+		    {
+		      sp++;
+		      com = 2;
+		      n--;
+		      break;
+		    }
+		}
+	      else if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		goto b_end;
 	    }
-	    else if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	 }
-      }
-      else if(!strncmp(sp, "struct", 6) || !strncmp(sp, "class", 5) ||
-		!strncmp(sp, "union", 5))
-      {  while(!isspace(*++sp)) {
-		;
-	 }
-	 if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	 if(*sp == ';') {  sp++;  com = 2;  n--;  continue;  }
-	 if(!strncmp(sp, name, len) && !isalnum1(sp[len]))
-	 {  while(!isspace(*++sp)) {
-		;
+	}
+      else if (!strncmp (sp, "struct", 6) || !strncmp (sp, "class", 5) ||
+	       !strncmp (sp, "union", 5))
+	{
+	  while (!isspace (*++sp))
+	    {
+	      ;
 	    }
-	    if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	    if(*sp == '{')
-	    {  if(*first)
-	       {  e_aclose(fp);  strcpy(file, startfile);
-		  *num = n;  *xn = (int)(sp - str);  return(0);
-	       }
-	       else if(n == nold && !strcmp(startfile, oldfile)) *first = 1;
+	  if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+	    goto b_end;
+	  if (*sp == ';')
+	    {
+	      sp++;
+	      com = 2;
+	      n--;
+	      continue;
 	    }
-	 }
-	 else if(*sp != '{')
-	 {  while(!isspace(*++sp)) {
-		;
+	  if (!strncmp (sp, name, len) && !isalnum1 (sp[len]))
+	    {
+	      while (!isspace (*++sp))
+		{
+		  ;
+		}
+	      if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		goto b_end;
+	      if (*sp == '{')
+		{
+		  if (*first)
+		    {
+		      e_aclose (fp);
+		      strcpy (file, startfile);
+		      *num = n;
+		      *xn = (int) (sp - str);
+		      return (0);
+		    }
+		  else if (n == nold && !strcmp (startfile, oldfile))
+		    *first = 1;
+		}
 	    }
-	    if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	 }
-	 if(*sp == ';') {  sp++;  com = 2;  n--;  continue;  }
-	 if(*sp == '{')
-	 {  if(!(sp = e_sh_spl3(sp, str, fp, &n))) goto b_end;
-	    if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	    if(*sp == ';') {  sp++;  com = 2;  n--;  continue;  }
-	 }
-	 while(1)
-	 {  while (*sp == '*') sp++;
-	    if(isspace(*sp) && !(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	    if(!strncmp(sp, name, len) && !isalnum1(sp[len]))
-	    {  while(isalnum1(*sp)) sp++;
-	       if(isspace(*sp) && !(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	       if((*sp == ';' || *sp == ',' || *sp == '='
-					 || *sp == '[' || *sp == ')'))
-	       {  if(*first)
-		  {  e_aclose(fp);  strcpy(file, startfile);
-		     *num = n;  *xn = (int)(sp - str);  return(0);
-		  }
-		  else if(n == nold && !strcmp(startfile, oldfile))
-		  {  *first = 1;
-		     if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
-		  }
-	       }
-	       else if(*sp == '(')
-	       {  if(!(sp = e_sh_spl5(sp, str, fp, &n))) goto b_end;
-		  if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-		  if(*sp == '{')
-		  {  if(*first)
-		     {  e_aclose(fp);  strcpy(file, startfile);
-			*num = n;  *xn = (int)(sp - str);  return(0);
-		     }
-		     else if(n == nold && !strcmp(startfile, oldfile))
-		     {  *first = 1;  break;  }
-		  }
-		  else break;
-	       }
+	  else if (*sp != '{')
+	    {
+	      while (!isspace (*++sp))
+		{
+		  ;
+		}
+	      if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		goto b_end;
 	    }
-	    else if(*sp == '(') sp++;
-	    else if(*sp == '*') {  while (*sp == '*') sp++;  continue;  }
-	    else if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
-	    else if(*sp == '{')
-	    {  if(!(sp = e_sh_spl3(sp, str, fp, &n))) goto b_end;
-	       sp++;  com = 2;  n--;
-	       break;
+	  if (*sp == ';')
+	    {
+	      sp++;
+	      com = 2;
+	      n--;
+	      continue;
 	    }
-	    else
-	    {  if(!(sp = e_sh_spl4(sp, str, fp, &n))) goto b_end;
-	       if(*sp == '(') break;
-	       else if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
-	       if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
+	  if (*sp == '{')
+	    {
+	      if (!(sp = e_sh_spl3 (sp, str, fp, &n)))
+		goto b_end;
+	      if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		goto b_end;
+	      if (*sp == ';')
+		{
+		  sp++;
+		  com = 2;
+		  n--;
+		  continue;
+		}
 	    }
-	    if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
-	 }
-      }
-      else if(isalnum1(*sp))
-      {  while(isalnum1(*sp)) sp++;
-	 while(1)
-	 {  while (*sp == '*') sp++;
-	    if(isspace(*sp) && !(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	    if(!strncmp(sp, name, len) && !isalnum1(sp[len]))
-	    {  while(isalnum1(*sp)) sp++;
-	       if(isspace(*sp) && !(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	       if(*sp == ';' || *sp == ',' || *sp == '='
-					 || *sp == '[' || *sp == ')')
-	       {  if(*first)
-		  {  e_aclose(fp);  strcpy(file, startfile);
-		     *num = n;  *xn = (int)(sp - str);  return(0);
-		  }
-		  else if(n == nold && !strcmp(startfile, oldfile))
-		  {  *first = 1;  break;  }
-	       }
-	       else if(*sp == '(')
-	       {  if(!(sp = e_sh_spl5(sp, str, fp, &n))) goto b_end;
-		  if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-		  if(*sp == '{')
-		  {  if(*first)
-		     {  e_aclose(fp);  strcpy(file, startfile);
-			*num = n;  *xn = (int)(sp - str);  return(0);
-		     }
-		     else if(n == nold && !strcmp(startfile, oldfile))
-		     {  *first = 1;  break;  }
-		  }
-		  else break;
-	       }
+	  while (1)
+	    {
+	      while (*sp == '*')
+		sp++;
+	      if (isspace (*sp) && !(sp = e_sh_spl2 (sp, str, fp, &n)))
+		goto b_end;
+	      if (!strncmp (sp, name, len) && !isalnum1 (sp[len]))
+		{
+		  while (isalnum1 (*sp))
+		    sp++;
+		  if (isspace (*sp) && !(sp = e_sh_spl2 (sp, str, fp, &n)))
+		    goto b_end;
+		  if ((*sp == ';' || *sp == ',' || *sp == '='
+		       || *sp == '[' || *sp == ')'))
+		    {
+		      if (*first)
+			{
+			  e_aclose (fp);
+			  strcpy (file, startfile);
+			  *num = n;
+			  *xn = (int) (sp - str);
+			  return (0);
+			}
+		      else if (n == nold && !strcmp (startfile, oldfile))
+			{
+			  *first = 1;
+			  if (*sp == ';')
+			    {
+			      sp++;
+			      com = 2;
+			      n--;
+			      break;
+			    }
+			}
+		    }
+		  else if (*sp == '(')
+		    {
+		      if (!(sp = e_sh_spl5 (sp, str, fp, &n)))
+			goto b_end;
+		      if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+			goto b_end;
+		      if (*sp == '{')
+			{
+			  if (*first)
+			    {
+			      e_aclose (fp);
+			      strcpy (file, startfile);
+			      *num = n;
+			      *xn = (int) (sp - str);
+			      return (0);
+			    }
+			  else if (n == nold && !strcmp (startfile, oldfile))
+			    {
+			      *first = 1;
+			      break;
+			    }
+			}
+		      else
+			break;
+		    }
+		}
+	      else if (*sp == '(')
+		sp++;
+	      else if (*sp == '*')
+		{
+		  while (*sp == '*')
+		    sp++;
+		  continue;
+		}
+	      else if (*sp == ';')
+		{
+		  sp++;
+		  com = 2;
+		  n--;
+		  break;
+		}
+	      else if (*sp == '{')
+		{
+		  if (!(sp = e_sh_spl3 (sp, str, fp, &n)))
+		    goto b_end;
+		  sp++;
+		  com = 2;
+		  n--;
+		  break;
+		}
+	      else
+		{
+		  if (!(sp = e_sh_spl4 (sp, str, fp, &n)))
+		    goto b_end;
+		  if (*sp == '(')
+		    break;
+		  else if (*sp == ';')
+		    {
+		      sp++;
+		      com = 2;
+		      n--;
+		      break;
+		    }
+		  if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		    goto b_end;
+		}
+	      if (*sp == ';')
+		{
+		  sp++;
+		  com = 2;
+		  n--;
+		  break;
+		}
 	    }
-	    else if(*sp == '(') sp++;
-	    else if(*sp == '*')
-            {  while (*sp == '*') sp++;  continue;  }
-	    else if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
-	    else if(*sp == '{')
-	    {  if(!(sp = e_sh_spl3(sp, str, fp, &n))) goto b_end;
-	       sp++;  com = 2;  n--;
-	       break;
+	}
+      else if (isalnum1 (*sp))
+	{
+	  while (isalnum1 (*sp))
+	    sp++;
+	  while (1)
+	    {
+	      while (*sp == '*')
+		sp++;
+	      if (isspace (*sp) && !(sp = e_sh_spl2 (sp, str, fp, &n)))
+		goto b_end;
+	      if (!strncmp (sp, name, len) && !isalnum1 (sp[len]))
+		{
+		  while (isalnum1 (*sp))
+		    sp++;
+		  if (isspace (*sp) && !(sp = e_sh_spl2 (sp, str, fp, &n)))
+		    goto b_end;
+		  if (*sp == ';' || *sp == ',' || *sp == '='
+		      || *sp == '[' || *sp == ')')
+		    {
+		      if (*first)
+			{
+			  e_aclose (fp);
+			  strcpy (file, startfile);
+			  *num = n;
+			  *xn = (int) (sp - str);
+			  return (0);
+			}
+		      else if (n == nold && !strcmp (startfile, oldfile))
+			{
+			  *first = 1;
+			  break;
+			}
+		    }
+		  else if (*sp == '(')
+		    {
+		      if (!(sp = e_sh_spl5 (sp, str, fp, &n)))
+			goto b_end;
+		      if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+			goto b_end;
+		      if (*sp == '{')
+			{
+			  if (*first)
+			    {
+			      e_aclose (fp);
+			      strcpy (file, startfile);
+			      *num = n;
+			      *xn = (int) (sp - str);
+			      return (0);
+			    }
+			  else if (n == nold && !strcmp (startfile, oldfile))
+			    {
+			      *first = 1;
+			      break;
+			    }
+			}
+		      else
+			break;
+		    }
+		}
+	      else if (*sp == '(')
+		sp++;
+	      else if (*sp == '*')
+		{
+		  while (*sp == '*')
+		    sp++;
+		  continue;
+		}
+	      else if (*sp == ';')
+		{
+		  sp++;
+		  com = 2;
+		  n--;
+		  break;
+		}
+	      else if (*sp == '{')
+		{
+		  if (!(sp = e_sh_spl3 (sp, str, fp, &n)))
+		    goto b_end;
+		  sp++;
+		  com = 2;
+		  n--;
+		  break;
+		}
+	      else
+		{
+		  if (!(sp = e_sh_spl4 (sp, str, fp, &n)))
+		    goto b_end;
+		  if (*sp == '(')
+		    {
+		      if (!(sp = e_sh_spl5 (sp, str, fp, &n)))
+			goto b_end;
+		      if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+			goto b_end;
+		      if (*sp == '{' && !(sp = e_sh_spl3 (sp, str, fp, &n)))
+			goto b_end;
+		      sp++;
+		      com = 2;
+		      n--;
+		      break;
+		    }
+		  else if (*sp == ';')
+		    {
+		      sp++;
+		      com = 2;
+		      n--;
+		      break;
+		    }
+		  if (!(sp = e_sh_spl2 (sp, str, fp, &n)))
+		    goto b_end;
+		}
+	      if (*sp == ';')
+		{
+		  sp++;
+		  com = 2;
+		  n--;
+		  break;
+		}
 	    }
-	    else
-	    {  if(!(sp = e_sh_spl4(sp, str, fp, &n))) goto b_end;
-	       if(*sp == '(')
-	       {  if(!(sp = e_sh_spl5(sp, str, fp, &n))) goto b_end;
-		  if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-		  if(*sp == '{' && !(sp = e_sh_spl3(sp, str, fp, &n))) goto b_end;
-		  sp++;  com = 2;  n--;  break;
-	       }
-	       else if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
-	       if(!(sp = e_sh_spl2(sp, str, fp, &n))) goto b_end;
-	    }
-	    if(*sp == ';') {  sp++;  com = 2;  n--;  break;  }
-	 }
-      }
-   }
-   b_end:
-    e_aclose(fp);
-   return(ret);
+	}
+    }
+b_end:
+  e_aclose (fp);
+  return (ret);
 }
 
-int e_show_nm_f(char *name, FENSTER *f, int oldn, char **oldname)
+int
+e_show_nm_f (char *name, FENSTER * f, int oldn, char **oldname)
 {
- int i, j, len, ret, num, x, first = oldn < 0 ? 1 : 0;
- char str[128], file[128], *filename;
- struct dirfile *df, *fdf = NULL;
+  int i, j, len, ret, num, x, first = oldn < 0 ? 1 : 0;
+  char str[128], file[128], *filename;
+  struct dirfile *df, *fdf = NULL;
 
 #ifndef TESTSDEF
- if (!access(e_prog.project, F_OK))
- {
-  WpeMouseChangeShape(WpeWorkingShape);
-  if (e_read_var(f)) ret = -1;
+  if (!access (e_prog.project, F_OK))
+    {
+      WpeMouseChangeShape (WpeWorkingShape);
+      if (e_read_var (f))
+	ret = -1;
+      else
+	{
+	  df = e_p_get_var ("FILES");
+	  if (!df)
+	    {
+	      e_error (e_p_msg[ERR_NOTHING], 0, f->fb);
+	      WpeMouseRestoreShape ();
+	      return (-1);
+	    }
+	  for (i = 0, ret = 1; i < df->anz && ret; i++)
+	    {
+	      strcpy (str, df->name[i]);
+	      ret = e_find_def (name, str, 7, file, &num, &x, oldn,
+				*oldname, &fdf, &first);
+	    }
+	  freedf (df);
+	}
+    }
   else
-  {
-   df = e_p_get_var("FILES");
-   if (!df)
-   {
-    e_error(e_p_msg[ERR_NOTHING], 0, f->fb);
-    WpeMouseRestoreShape();
-    return(-1);
-   }
-   for (i = 0, ret = 1; i < df->anz && ret; i++)
-   {
-    strcpy(str, df->name[i]);
-    ret = e_find_def(name, str, 7, file, &num, &x, oldn,
-      *oldname, &fdf, &first);
-   }
-   freedf(df);
-  }
- }
- else
 #endif
- {
-  if (!DTMD_ISTEXT(f->dtmd)) return(-1);
-  WpeMouseChangeShape(WpeWorkingShape);
-  strcpy(str, f->datnam);
-  ret = e_find_def(name, str, 7, file, &num, &x, oldn,
-    *oldname, &fdf, &first);
- }
- freedf(fdf);
- if (ret)
- {
-  sprintf(str, "%s not found!", name);
-  e_error(str, 0, f->fb);
-  WpeMouseRestoreShape();
-  return(-1);
- }
- if (*oldname) free(*oldname);
- *oldname = malloc((strlen(file)+1) * sizeof(char));
- strcpy(*oldname, file);
- for (i = strlen(file)-1; i >= 0 && file[i] != '/'; i--)
-  ;
- for (j = f->ed->mxedt; j > 0; j--)
- {
-  if (i < 0) filename = f->ed->f[j]->datnam;
-  else filename = e_mkfilename(f->ed->f[j]->dirct, f->ed->f[j]->datnam);
-  if (!strcmp(filename, file)) break;
- }
- if (j > 0) e_switch_window(f->ed->edt[j], f->ed->f[f->ed->mxedt]);
- else e_edit(f->ed, file);
- f = f->ed->f[f->ed->mxedt];
- for (i = num, j = x+1-(len = strlen(name)); i >= 0; )
- {
-  for (len = strlen(name); j >= 0 && strncmp(name, (const char *)f->b->bf[i].s+j, len);
-    j--)
-   ;
-  if (j < 0 && i >= 0)
-  {  i--;  j = f->b->bf[i].len-len+1;  }
-  else break;
- }
- if (i >= 0)
- {  num = i;  x = j;  }
- else len = 0;
- f->s->fa.y = f->s->fe.y = f->b->b.y = num;
- f->s->fe.x = f->b->b.x = x + len;
- f->s->fa.x = x;
- e_cursor(f, 1);
- f->s->fa.y = num;
- e_schirm(f, 1);
- WpeMouseRestoreShape();
- return(num);
-}
-
-struct {
- int num;
- char *str, *file;
-}  sh_df = {  -1, NULL, NULL  };
-
-int e_sh_def(FENSTER *f)
-{
- char str[80];
-
- if (f->ed->shdf && f->ed->shdf->anz > 0)
-  strcpy(str, f->ed->shdf->name[0]);
- else
-  str[0] = '\0';
- if (e_add_arguments(str, "Show Definition", f, 0 , AltB, &f->ed->shdf))
- {
-  if (sh_df.str)
-   free(sh_df.str);
-  sh_df.str = malloc((strlen(str)+1)*sizeof(char));
-  strcpy(sh_df.str, str);
-  if (sh_df.file)
-  {
-   free(sh_df.file);
-   sh_df.file = NULL;
-  }
-  f->ed->shdf = e_add_df(str, f->ed->shdf);
-  sh_df.num = e_show_nm_f(str, f, -1, &sh_df.file);
- }
- return(0);
-}
-
-int e_sh_nxt_def(FENSTER *f)
-{
- if (sh_df.num >= 0 && sh_df.str && sh_df.file)
- {
-  sh_df.num = e_show_nm_f(sh_df.str, f, sh_df.num, &sh_df.file);
- }
- return(0);
-}
-
-int e_nxt_brk(FENSTER *f)
-{
- int c = f->b->bf[f->b->b.y].s[f->b->b.x];
- int i, j, ob, cb, bsp, brk, nif;
-
- if (c == '{' || c == '(' || c == '[')
- {
-  if (c == '{')
-  {
-   ob = '{';  cb = '}';
-  }
-  else if (c == '(')
-  {
-   ob = '(';  cb = ')';
-  }
-  else
-  {
-   ob = '[';  cb = ']';
-  }
-  for (brk = 1, i = f->b->b.y; i < f->b->mxlines; i++)
-   for (j = i == f->b->b.y ? f->b->b.x+1 : 0; j < f->b->bf[i].len; j++)
-   {
-    if (f->b->bf[i].s[j] == '\"')
     {
-     for (bsp = 0, j++;
-       j < f->b->bf[i].len && (f->b->bf[i].s[j] != '\"' || bsp); j++)
-     {
-      if (f->b->bf[i].s[j] == '\\')
-       bsp = !bsp;
-      else
-       bsp = 0;
-      if (j == f->b->bf[i].len - 1 && bsp && i < f->b->mxlines-1)
-      {
-       i++;
-       j = -1;
-       bsp = 0;
-      }
-     }
+      if (!DTMD_ISTEXT (f->dtmd))
+	return (-1);
+      WpeMouseChangeShape (WpeWorkingShape);
+      strcpy (str, f->datnam);
+      ret = e_find_def (name, str, 7, file, &num, &x, oldn,
+			*oldname, &fdf, &first);
     }
-    else if (f->b->bf[i].s[j] == '\'')
+  freedf (fdf);
+  if (ret)
     {
-     for (bsp = 0, j++;
-       j < f->b->bf[i].len && (f->b->bf[i].s[j] != '\'' || bsp); j++)
-     {
-      if (f->b->bf[i].s[j] == '\\')
-       bsp = !bsp;
-      else
-       bsp = 0;
-      if (j == f->b->bf[i].len - 1 && bsp && i < f->b->mxlines-1)
-      {
-       i++;
-       j = -1;
-       bsp = 0;
-      }
-     }
+      sprintf (str, "%s not found!", name);
+      e_error (str, 0, f->fb);
+      WpeMouseRestoreShape ();
+      return (-1);
     }
-    else if (f->b->bf[i].s[j] == '/' && f->b->bf[i].s[j+1] == '*')
-    {
-     for (j += 2; f->b->bf[i].s[j] != '*' || f->b->bf[i].s[j+1] != '/'; j++)
-     {
-      if (j >= f->b->bf[i].len - 1)
-      {
-       if (i < f->b->mxlines-1)
-       {
-        i++;
-        j = -1;
-       }
-       else
-        break;
-      }
-     }
-    }
-    else if (f->b->bf[i].s[j] == '/' && f->b->bf[i].s[j+1] == '/')
-     break;
-    else if (f->b->bf[i].s[j] == '#'
-		&& ( !strncmp((const char *)f->b->bf[i].s, "#else", 5) 
-			|| !strncmp((const char *)f->b->bf[i].s, "#elif", 5)  ) )
-    {
-     for (nif = 1, i++; i < f->b->mxlines-1; i++)
-     {
-      for (j = 0; isspace(f->b->bf[i].s[j]); j++)
-       ;
-      if ( !strncmp((const char *)f->b->bf[i].s+j, "#endif", 6) )
-       nif--;
-      else if ( !strncmp((const char *)f->b->bf[i].s+j, "#if", 3) )
-       nif++;
-      if (!nif)
-       break;
-     }
-     continue;
-    }
-    else if (f->b->bf[i].s[j] == ob)
-     brk++;
-    else if (f->b->bf[i].s[j] == cb)
-    {
-     brk--;
-     if (!brk)
-     {
-      f->b->b.y = i;  f->b->b.x = j;  return(0);
-     }
-    }
-   }
- }
- else
- {
-  if (c == '}')
-  {
-   ob = '{';  cb = '}';
-  }
-  else if (c == ')')
-  {
-   ob = '(';  cb = ')';
-  }
-  else if (c == ']')
-  {
-   ob = '[';  cb = ']';
-  }
-  else
-  {
-   ob = 0;  cb = 0;
-  }
-  for (brk = -1, i = f->b->b.y; i >= 0; i--)
-  {
-   if (i == f->b->b.y)
-    for (j = 0;
-      j < f->b->b.x && (f->b->bf[i].s[j] != '/' || f->b->bf[i].s[j+1] != '/');
-      j++)
-     ;
-   else
-    for (j = 0;
-      j < f->b->bf[i].len && (f->b->bf[i].s[j] != '/' || f->b->bf[i].s[j+1] != '/');
-      j++)
-     ;
-   for (j--; j >= 0; j--)
-   {
-    if (f->b->bf[i].s[j] == '\"')
-    {
-     for (j--; j >= 0; j--)
-     {
-      if (f->b->bf[i].s[j] == '\"')
-      {
-       for (bsp = 0, j--; j >= 0 && f->b->bf[i].s[j] == '\\'; j--)
-        bsp = !bsp;
-       j++;
-       if (!bsp)
-        break;
-      }
-      if (j == 0 && i > 0 && f->b->bf[i-1].s[f->b->bf[i-1].len] == '\\')
-      {
-       i--;
-       j = f->b->bf[i].len;
-      }
-     }
-    }
-    else if (f->b->bf[i].s[j] == '\'')
-    {
-     for (j--; j >= 0; j--)
-     {
-      if (f->b->bf[i].s[j] == '\'')
-      {
-       for (bsp = 0, j--; j >= 0 && f->b->bf[i].s[j] == '\\'; j--)
-        bsp = !bsp;
-       j++;
-       if (!bsp)
-        break;
-      }
-      if (j == 0 && i > 0 && f->b->bf[i-1].s[f->b->bf[i-1].len] == '\\')
-      {
-       i--;
-       j = f->b->bf[i].len;
-      }
-     }
-    }
-    else if (f->b->bf[i].s[j] == '/' && f->b->bf[i].s[j-1] == '*')
-    {
-     for (j -= 2; f->b->bf[i].s[j] != '*' || f->b->bf[i].s[j-1] != '/'; j--)
-     {
-      if (j <= 0)
-      {
-       if (i > 0)
-       {
-        i--;
-        j = f->b->bf[i].len;
-       }
-       else
-        break;
-      }
-     }
-    }
-     else if (f->b->bf[i].s[j] == '#'
-		&& ( !strncmp((const char *)f->b->bf[i].s, "#else", 5) 
-			|| !strncmp((const char *)f->b->bf[i].s, "#elif", 5)  ) )
-    {
-     for (nif = 1, i--; i > 0; i--)
-     {
-      for (j = 0; isspace(f->b->bf[i].s[j]); j++)
-       ;
-      if ( !strncmp((const char *)f->b->bf[i].s+j, "#endif", 6) )
-       nif++;
-      else if ( !strncmp((const char *)f->b->bf[i].s+j, "#if", 3) )
-       nif--;
-      if (!nif)
-       break;
-     }
-     continue;
-    }
-    else if (!ob)
-    {
-     if (f->b->bf[i].s[j] == '{' || f->b->bf[i].s[j] == '(' || f->b->bf[i].s[j] == '[')
-     {
-      brk++;
-      if (!brk)
-      {
-       f->b->b.y = i;
-       f->b->b.x = j;
-       return(0);
-      }
-     }
-     else if (f->b->bf[i].s[j] == '}' || f->b->bf[i].s[j] == ')' || f->b->bf[i].s[j] == ']')
-      brk--;
-     else if (i == 0 && j == 0)
-     {
-      f->b->b.y = i;
-      f->b->b.x = j;
-      return(0);
-     }
-    }
-    else
-    {
-     if (f->b->bf[i].s[j] == ob)
-     {
-      brk++;
-      if (!brk)
-      {
-       f->b->b.y = i;
-       f->b->b.x = j;
-       return(0);
-      }
-     }
-     else if (f->b->bf[i].s[j] == cb)
-      brk--;
-    }
-   }
-  }
- }
- return(e_error("No Matching Bracket!", 0, f->ed->fb));
-}
-
-char *e_mbt_mk_sp(char *str, int n, int sw, int *m)
-{
- int k;
-
- if (!sw) *m = n;
- else *m = n / sw + n % sw;
- str = realloc(str, (*m+1)*sizeof(char));
- if (!sw) k = 0;
- else for (k = 0; k < n / sw; k++) str[k] = '\t';
- for (; k < *m; k++) str[k] = ' ';
- str[*m] = '\0';
- return(str);
-}
-
-int e_mbt_str(BUFFER *b, int *ii, int *jj, unsigned char c, int n, int sw,
-  int *cmnd)
-{
- int i = *ii, j = *jj + 1, bsp;
-
- if (*cmnd != 2)
-  *cmnd = 0;
- for (bsp = 0; j < b->bf[i].len && (b->bf[i].s[j] != c || bsp); j++)
- {
-  if (b->bf[i].s[j] == '\\')
-   bsp = !bsp;
-  else
-   bsp = 0;
-  if (j == b->bf[i].len - 1 && bsp && i < b->mxlines-1)
-  {
-   char *str = malloc(1);
-   int m;
-
-   i++;
-   bsp = 0;
-   for (j = 0, m = b->bf[i].len; j < m && isspace(b->bf[i].s[j]); j++)
+  if (*oldname)
+    free (*oldname);
+  *oldname = malloc ((strlen (file) + 1) * sizeof (char));
+  strcpy (*oldname, file);
+  for (i = strlen (file) - 1; i >= 0 && file[i] != '/'; i--)
     ;
-   if (j > 0)
-    e_del_nchar(b, b->f->s, 0, i, j);
-   if (j < m)
-   {
-    str = e_mbt_mk_sp(str, n+b->cn->autoindent, sw, &m);
-    e_ins_nchar(b, b->f->s, (unsigned char *)str, 0, i, m);
-   }
-   j = -1;
-   free(str);
-  }
- }
- *ii = i;
- *jj = j;
- return(0);
+  for (j = f->ed->mxedt; j > 0; j--)
+    {
+      if (i < 0)
+	filename = f->ed->f[j]->datnam;
+      else
+	filename = e_mkfilename (f->ed->f[j]->dirct, f->ed->f[j]->datnam);
+      if (!strcmp (filename, file))
+	break;
+    }
+  if (j > 0)
+    e_switch_window (f->ed->edt[j], f->ed->f[f->ed->mxedt]);
+  else
+    e_edit (f->ed, file);
+  f = f->ed->f[f->ed->mxedt];
+  for (i = num, j = x + 1 - (len = strlen (name)); i >= 0;)
+    {
+      for (len = strlen (name);
+	   j >= 0 && strncmp (name, (const char *) f->b->bf[i].s + j, len);
+	   j--)
+	;
+      if (j < 0 && i >= 0)
+	{
+	  i--;
+	  j = f->b->bf[i].len - len + 1;
+	}
+      else
+	break;
+    }
+  if (i >= 0)
+    {
+      num = i;
+      x = j;
+    }
+  else
+    len = 0;
+  f->s->fa.y = f->s->fe.y = f->b->b.y = num;
+  f->s->fe.x = f->b->b.x = x + len;
+  f->s->fa.x = x;
+  e_cursor (f, 1);
+  f->s->fa.y = num;
+  e_schirm (f, 1);
+  WpeMouseRestoreShape ();
+  return (num);
 }
 
-int e_mbt_cnd(BUFFER *b, int *ii, int *jj, int n, int sw, int *cmnd)
+struct
 {
- int i = *ii, j = *jj + 2;
+  int num;
+  char *str, *file;
+} sh_df =
+{
+-1, NULL, NULL};
 
- for (; b->bf[i].s[j] != '*' || b->bf[i].s[j+1] != '/'; j++)
- {
-  if (j >= b->bf[i].len - 1)
-  {
-   if (i < b->mxlines-1)
-   {
-    char *str = malloc(1);
-    int m;
+int
+e_sh_def (FENSTER * f)
+{
+  char str[80];
 
-    i++;
-    for (j = 0, m = b->bf[i].len; j < m && isspace(b->bf[i].s[j]); j++)
-     ;
-    if (j > 0)
-     e_del_nchar(b, b->f->s, 0, i, j);
-    if (j < m && (b->bf[i].s[0] != '*' || b->bf[i].s[1] != '/'))
+  if (f->ed->shdf && f->ed->shdf->anz > 0)
+    strcpy (str, f->ed->shdf->name[0]);
+  else
+    str[0] = '\0';
+  if (e_add_arguments (str, "Show Definition", f, 0, AltB, &f->ed->shdf))
     {
-     str = e_mbt_mk_sp(str, n+b->cn->autoindent, sw, &m);
-     e_ins_nchar(b, b->f->s, (unsigned char *)str, 0, i, m);
+      if (sh_df.str)
+	free (sh_df.str);
+      sh_df.str = malloc ((strlen (str) + 1) * sizeof (char));
+      strcpy (sh_df.str, str);
+      if (sh_df.file)
+	{
+	  free (sh_df.file);
+	  sh_df.file = NULL;
+	}
+      f->ed->shdf = e_add_df (str, f->ed->shdf);
+      sh_df.num = e_show_nm_f (str, f, -1, &sh_df.file);
     }
-    j = -1;
-    free(str);
-    if (*cmnd == 2)
-     *cmnd = 1;
-   }
-   else
-    break;
-  }
- }
- *ii = i;
- *jj = j+1;
- return(0);
+  return (0);
 }
 
-int e_mk_beauty(int sw, int ndif, FENSTER *f)
+int
+e_sh_nxt_def (FENSTER * f)
 {
- BUFFER *b;
- SCHIRM *s;
- int bg, nd, m, n, i, j, k, brk, cbrk = 0, nif = 0, nic = 0;
- int nstrct = 0, cmnd, cm_sv;
- char *tstr = malloc(sizeof(char));
- char *bstr = malloc((ndif+1)*sizeof(char));
- int *nvek = malloc(sizeof(int));
- int *ifvekb = malloc(sizeof(int));
- int *ifvekr = malloc(sizeof(int));
- int *vkcs = malloc(sizeof(int));
- int *vkcb = malloc(sizeof(int));
- POINT sa, se, sb;
-
- for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT(f->ed->f[i]->dtmd); i--)
-  ;
- if (i <= 0)
- {
-  free(tstr);  free(bstr);  free(nvek);  free(ifvekb);
-  free(ifvekr);  free(vkcs);  free(vkcb);
-  return(0);
- }
- *ifvekb = 0;
- *ifvekr = 0;
- *vkcs = 0;
- *vkcb = 0;
- e_switch_window(f->ed->edt[i], f);
- WpeMouseChangeShape(WpeWorkingShape);
- f = f->ed->f[f->ed->mxedt];
- b = f->b;
- s = f->s;
- sa = s->mark_begin;  se = s->mark_end;  sb = b->b;
- if (sw & 1)
- {
-  if (sw & 2)  bg = i = b->b.x == 0 ? b->b.y : b->b.y + 1;
-  else  bg = i = s->mark_begin.x == 0 ? s->mark_begin.y : s->mark_begin.y + 1;
-  nd = s->mark_end.x == 0 ? s->mark_end.y : s->mark_end.y + 1;
-  if (nd > b->mxlines) nd = b->mxlines;
- }
- else
- {
-  if (sw & 2)  bg = i = b->b.x == 0 ? b->b.y : b->b.y + 1;
-  else  bg = i = 0;
-  nd = b->mxlines;
- }
- if (s->mark_begin.y < 0 || (s->mark_begin.y == 0 && s->mark_begin.x <= 0))
-  n = 0;
- else
- {
-  for (n = j = 0; j < b->bf[i].len && isspace(b->bf[i].s[j]); j++)
-  {
-   if (b->bf[i].s[j] == ' ') n++;
-   else if (b->bf[i].s[j] == '\t')
-    n += f->ed->tabn - (n % f->ed->tabn);
-  }
- }
- tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
- for (k = 0; k < ndif; k++)
-  bstr[k] = ' ';
- bstr[ndif] = '\0';
- nvek[0] = n;
- for (cm_sv = 1, cmnd = 1, brk = 0; i < nd; i++)
- {
-  for (j = 0; j < b->bf[i].len && isspace(b->bf[i].s[j]); j++)
-   ;
-  if (i > bg)
-  {
-   for (k = b->bf[i-1].len-1; k >= 0 && isspace(b->bf[i-1].s[k]); k--);
-   if (k >= 0) e_del_nchar(b, s, k + 1, i-1, b->bf[i-1].len-1-k);
-   e_del_nchar(b, s, 0, i, j);
-   if (b->bf[i].len > 0 && b->bf[i].s[0] != '#' &&
-     (b->bf[i].s[0] != '/' || b->bf[i].s[1] != '*'))
-   {
-    if ((cmnd == 0 && (!cm_sv || b->bf[i].s[0] != '{')) ||
-      (cmnd == 2 && b->bf[i-1].s[k] == '\\'))
+  if (sh_df.num >= 0 && sh_df.str && sh_df.file)
     {
-     tstr = e_mbt_mk_sp(tstr, !cmnd ? n+b->cn->autoindent : b->cn->autoindent,
-       (sw & 4) ? 0 : f->ed->tabn, &m);
-     e_ins_nchar(b, s, (unsigned char *)tstr, 0, i, m);
-     j = m;
-     tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+      sh_df.num = e_show_nm_f (sh_df.str, f, sh_df.num, &sh_df.file);
     }
-    else
-    {
-     e_ins_nchar(b, s, (unsigned char *)tstr, 0, i, m);
-     j = m;
-     if (cmnd == 0) cmnd = 1;
-    }
-   }
-  }
-  if (cmnd == 0) cm_sv = cbrk ? 1 : 0;
-  else cm_sv = cmnd;
-  for (cmnd = 1; j < b->bf[i].len; j++)
-  {
-   if (b->bf[i].s[j] == '\"')
-    e_mbt_str(b, &i, &j, '\"', n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
-   else if (f->b->bf[i].s[j] == '\'')
-    e_mbt_str(b, &i, &j, '\'', n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
-   else if (b->bf[i].s[j] == '/' && b->bf[i].s[j+1] == '*')
-    e_mbt_cnd(b, &i, &j, n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
-   else if (b->bf[i].s[j] == '/' && b->bf[i].s[j+1] == '/') break;
-   else if (b->bf[i].s[j] == ';') {  cmnd = cbrk ? 0 : 1;  nstrct = 0;  }
-   else if (b->bf[i].s[j] == '#' && 
-			( !strncmp((const char *)b->bf[i].s, "#if", 3) 
-				|| !strncmp((const char *)b->bf[i].s, "#ifdef", 6) ))
-   {
-    nif++;
-    ifvekb = realloc(ifvekb, (nif+1)*sizeof(int));
-    ifvekr = realloc(ifvekr, (nif+1)*sizeof(int));
-    ifvekb[nif] = brk;
-    ifvekr[nif] = cbrk;
-    cmnd = 2;
-   }
-   else if (b->bf[i].s[j] == '#' && nif > 0 
-				&& ( !strncmp((const char *)b->bf[i].s, "#else", 5) 
-					|| !strncmp((const char *)b->bf[i].s, "#elif", 5)  ) )
-   {
-    brk = ifvekb[nif];
-    cbrk = ifvekr[nif];
-    n = nvek[brk];
-    tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-    cmnd = 2;
-   }
-   else if (b->bf[i].s[j] == '#' 
-		&& ( !strncmp((const char *)b->bf[i].s, "#endif", 6)  ) )
-   {  nif--;  cmnd = 2;  }
-   else if (b->bf[i].s[j] == '#')
-   {
-    cmnd = 2;
-    for (j++; j < b->bf[i].len; j++)
-    {
-     if (j == b->bf[i].len - 1 && i < b->mxlines-1 && b->bf[i].s[j] == '\\')
-     {  i++;  j = 0;  }
-     else if (b->bf[i].s[j] == '\"')
-      e_mbt_str(b, &i, &j, '\"', n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
-     else if (f->b->bf[i].s[j] == '\'')
-      e_mbt_str(b, &i, &j, '\'', n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
-     else if (b->bf[i].s[j] == '/' && b->bf[i].s[j+1] == '*')
-      e_mbt_cnd(b, &i, &j, n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
-     else if (b->bf[i].s[j] == '/' && b->bf[i].s[j+1] == '/') break;
-    }
-    if (b->bf[i].s[j] == '/' && b->bf[i].s[j+1] == '/') break;
-   }
-   else if (b->bf[i].s[j] == '(') {  nstrct = 0;  cmnd = 0;  cbrk++;  }
-   else if (b->bf[i].s[j] == ')') {  nstrct = 0;  cmnd = 0;  cbrk--;  }
-   else if (b->bf[i].s[j] == '{')
-   {
-    brk++;
-    cmnd = 1;
-    for (k = j + 1; k < b->bf[i].len && isspace(b->bf[i].s[k]); k++);
-    if (k < b->bf[i].len && (b->bf[i].s[k] != '/' ||
-      (b->bf[i].s[k+1] != '*' && b->bf[i].s[k+1] != '/')))
-    {
-     e_del_nchar(b, s, j+1, i, k-j-1);
-     e_ins_nchar(b, s, (unsigned char *)bstr, j+1, i, ndif-1);
-    }
-    if (nstrct == 1)
-    {
-     if (k >= b->bf[i].len) n = nvek[brk-1];
-     else
-     {
-      for (k = j - 1; k >= 0 && isspace(b->bf[i].s[k]); k--);
-      if (k >= 0) nstrct++;
-     }
-     nstrct++;
-     nic++;
-     vkcb = realloc(vkcb, (nic+1)*sizeof(int));
-     vkcs = realloc(vkcs, (nic+1)*sizeof(int));
-     vkcs[nic] = 0;
-     vkcb[nic] = brk-1;
-    }
-    else
-    {
-     for(n = k = 0; k < j; k++)
-     {
-      if (b->bf[i].s[k] == '\t')
-       n += f->ed->tabn - (n % f->ed->tabn);
-      else n++;
-     }
-    }
-    n += ndif;
-    tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-    nvek = realloc(nvek, (brk+1)*sizeof(int));
-    nvek[brk] = n;
-   }
-   else if (f->b->bf[i].s[j] == '}')
-   {
-    brk--;
-    cmnd = 1;
-    nstrct = 0;
-    if (nic > 0 && vkcb[nic] == brk - 1)
-    {  n = nvek[brk];  nic--;  brk--;  }
-    if (brk < 0)
-    {
-     free(tstr);  free(bstr);  free(nvek);
-     free(ifvekb);  free(ifvekr);
-     free(vkcs);  free(vkcb);
-     b->b = sb;  s->mark_begin = sa;  s->mark_end = se;
-     e_schirm(f, 1);
-     WpeMouseRestoreShape();
-     return(0);
-    }
-    n -= ndif;
-    tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-    for (k = j - 1; k >= 0 && isspace(b->bf[i].s[k]); k--);
-    e_del_nchar(b, s, k+1, i, j-1-k);
-    if (k > 0)
-    {  e_ins_nchar(b, s, (unsigned char *)bstr, k+1, i, ndif-1);  j = k+ndif+1;  }
-    else
-    {  e_ins_nchar(b, s, (unsigned char *)tstr, k+1, i, m);  j = k+m+2;  }
-    n = nvek[brk];
-    tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-   }
-   else if (((j == 0 || !isalnum1(b->bf[i].s[j-1])) &&
-     (iscase((const char *)b->bf[i].s+j) || isstatus((const char *)b->bf[i].s+j))) ||
-     (nstrct > 1 && isalnum1(b->bf[i].s[j])))
-   {
-    if (vkcs[nic])
-    {
-     n = nvek[vkcb[nic]+1];
-     tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-     for (k = j - 1; k >= 0 && isspace(b->bf[i].s[k]); k--);
-     e_del_nchar(b, s, k+1, i, j-1-k);
-     if (k > 0)
-     {  e_ins_nchar(b, s, (unsigned char *)bstr, k+1, i, ndif-1);  j = k+ndif+1;  }
-     else
-     {  e_ins_nchar(b, s, (unsigned char *)tstr, k+1, i, m);  j = k+m+2;  }
-    }
-    else
-    {  brk++;  vkcs[nic] = 1;  }
-    if (nstrct < 2 || isstatus((const char *)b->bf[i].s+j))
-    {
-     for (j++; j < b->bf[i].len && b->bf[i].s[j] != ':'; j++);
-     for (k = j + 1; k < b->bf[i].len && isspace(b->bf[i].s[k]); k++);
-     if (k < b->bf[i].len && (b->bf[i].s[k] != '/' ||
-       (b->bf[i].s[k+1] != '*' && b->bf[i].s[k+1] != '/')))
-     {
-      e_del_nchar(b, s, j+1, i, k-j-1);
-      e_ins_nchar(b, s, (unsigned char *)bstr, j+1, i, ndif-1);
-      for (n = k = 0; k < j; k++)
-      {
-       if (b->bf[i].s[k] == '\t')
-        n += f->ed->tabn - (n % f->ed->tabn);
-       else
-        n++;
-      }
-     }
-    }
-    else if (nstrct == 2)
-     e_ins_nchar(b, s, (unsigned char *)bstr, j, i, ndif);
-    else
-     j--;
-    n += ndif;
-    tstr = e_mbt_mk_sp(tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
-    nvek = realloc(nvek, (brk+1)*sizeof(int));
-    nvek[brk] = n;
-    cmnd = 3;
-    nstrct = 0;
-   }
-   else if ((j == 0 || !isalnum1(b->bf[i].s[j-1])) &&
-     (!strncmp((const char *)b->bf[i].s+j, "switch", 6) && !isalnum1(b->bf[i].s[j+6])))
-   {
-    nic++;
-    vkcb = realloc(vkcb, (nic+1)*sizeof(int));
-    vkcs = realloc(vkcs, (nic+1)*sizeof(int));
-    vkcs[nic] = 0;
-    vkcb[nic] = brk;
-   }
-   else if ((j == 0 || !isalnum1(b->bf[i].s[j-1])) &&
-     ((!strncmp((const char *)b->bf[i].s+j, "class", 5) && !isalnum1(b->bf[i].s[j+5])) ||
-     (!strncmp((const char *)b->bf[i].s+j, "struct", 6) && !isalnum1(b->bf[i].s[j+6]))))
-    nstrct = 1;
-   else if (cmnd == 1 && !isspace(f->b->bf[i].s[j]))
-    cmnd = 0;
-   else if (cmnd == 3 && f->b->bf[i].s[j] == ':') cmnd = 1;
-  }
- }
- free(nvek);  free(tstr);  free(bstr);
- free(ifvekb);  free(ifvekr);
- free(vkcs);  free(vkcb);
- s->mark_begin = sa;  s->mark_end = se;
- b->b = sb;
- e_schirm(f, 1);
- WpeMouseRestoreShape();
- return(0);
+  return (0);
 }
 
-int e_p_beautify(FENSTER *f)
+int
+e_nxt_brk (FENSTER * f)
 {
- static int b_sw = 0;
- int ret;
- W_OPTSTR *o = e_init_opt_kst(f);
+  int c = f->b->bf[f->b->b.y].s[f->b->b.x];
+  int i, j, ob, cb, bsp, brk, nif;
 
- if (!o) return(-1);
- o->xa = 21;  o->ya = 3;  o->xe = 52;  o->ye = 19;
- o->bgsw = AltO;
- o->name = "Beautify";
- o->crsw = AltO;
- e_add_txtstr(4, 2, "Begin:", o);
- e_add_txtstr(4, 6, "Scope:", o);
- e_add_numstr(4, 12, 26, 12, 2, 100, 0, AltN, "Number of Columns:", f->ed->autoindent, o);
- e_add_sswstr(5, 10, 3, AltT, (b_sw & 4) ? 1 : 0, "No Tabulators     ", o);
- e_add_pswstr(0, 5, 3, 0, AltG, 0, "Global            ", o);
- e_add_pswstr(0, 5, 4, 0, AltS, b_sw & 1, "Selected Text     ", o);
- e_add_pswstr(1, 5, 7, 0, AltE, 0, "Entire Scope      ", o);
- e_add_pswstr(1, 5, 8, 0, AltF, (b_sw & 2) ? 1 : 0, "From Cursor       ", o);
- e_add_bttstr(7, 14, 1, AltO, " Ok ", NULL, o);
- e_add_bttstr(18, 14, -1, WPE_ESC, "Cancel", NULL, o);
- ret = e_opt_kst(o);
- if (ret != WPE_ESC)
- {
-  b_sw = o->pstr[0]->num + (o->pstr[1]->num << 1) + (o->sstr[0]->num << 2);
-  f->ed->autoindent = o->nstr[0]->num;
-  e_mk_beauty(b_sw, f->ed->autoindent, f);
- }
- freeostr(o);
- return(0);
+  if (c == '{' || c == '(' || c == '[')
+    {
+      if (c == '{')
+	{
+	  ob = '{';
+	  cb = '}';
+	}
+      else if (c == '(')
+	{
+	  ob = '(';
+	  cb = ')';
+	}
+      else
+	{
+	  ob = '[';
+	  cb = ']';
+	}
+      for (brk = 1, i = f->b->b.y; i < f->b->mxlines; i++)
+	for (j = i == f->b->b.y ? f->b->b.x + 1 : 0; j < f->b->bf[i].len; j++)
+	  {
+	    if (f->b->bf[i].s[j] == '\"')
+	      {
+		for (bsp = 0, j++;
+		     j < f->b->bf[i].len && (f->b->bf[i].s[j] != '\"' || bsp);
+		     j++)
+		  {
+		    if (f->b->bf[i].s[j] == '\\')
+		      bsp = !bsp;
+		    else
+		      bsp = 0;
+		    if (j == f->b->bf[i].len - 1 && bsp
+			&& i < f->b->mxlines - 1)
+		      {
+			i++;
+			j = -1;
+			bsp = 0;
+		      }
+		  }
+	      }
+	    else if (f->b->bf[i].s[j] == '\'')
+	      {
+		for (bsp = 0, j++;
+		     j < f->b->bf[i].len && (f->b->bf[i].s[j] != '\'' || bsp);
+		     j++)
+		  {
+		    if (f->b->bf[i].s[j] == '\\')
+		      bsp = !bsp;
+		    else
+		      bsp = 0;
+		    if (j == f->b->bf[i].len - 1 && bsp
+			&& i < f->b->mxlines - 1)
+		      {
+			i++;
+			j = -1;
+			bsp = 0;
+		      }
+		  }
+	      }
+	    else if (f->b->bf[i].s[j] == '/' && f->b->bf[i].s[j + 1] == '*')
+	      {
+		for (j += 2;
+		     f->b->bf[i].s[j] != '*' || f->b->bf[i].s[j + 1] != '/';
+		     j++)
+		  {
+		    if (j >= f->b->bf[i].len - 1)
+		      {
+			if (i < f->b->mxlines - 1)
+			  {
+			    i++;
+			    j = -1;
+			  }
+			else
+			  break;
+		      }
+		  }
+	      }
+	    else if (f->b->bf[i].s[j] == '/' && f->b->bf[i].s[j + 1] == '/')
+	      break;
+	    else if (f->b->bf[i].s[j] == '#'
+		     && (!strncmp ((const char *) f->b->bf[i].s, "#else", 5)
+			 || !strncmp ((const char *) f->b->bf[i].s, "#elif",
+				      5)))
+	      {
+		for (nif = 1, i++; i < f->b->mxlines - 1; i++)
+		  {
+		    for (j = 0; isspace (f->b->bf[i].s[j]); j++)
+		      ;
+		    if (!strncmp
+			((const char *) f->b->bf[i].s + j, "#endif", 6))
+		      nif--;
+		    else
+		      if (!strncmp
+			  ((const char *) f->b->bf[i].s + j, "#if", 3))
+		      nif++;
+		    if (!nif)
+		      break;
+		  }
+		continue;
+	      }
+	    else if (f->b->bf[i].s[j] == ob)
+	      brk++;
+	    else if (f->b->bf[i].s[j] == cb)
+	      {
+		brk--;
+		if (!brk)
+		  {
+		    f->b->b.y = i;
+		    f->b->b.x = j;
+		    return (0);
+		  }
+	      }
+	  }
+    }
+  else
+    {
+      if (c == '}')
+	{
+	  ob = '{';
+	  cb = '}';
+	}
+      else if (c == ')')
+	{
+	  ob = '(';
+	  cb = ')';
+	}
+      else if (c == ']')
+	{
+	  ob = '[';
+	  cb = ']';
+	}
+      else
+	{
+	  ob = 0;
+	  cb = 0;
+	}
+      for (brk = -1, i = f->b->b.y; i >= 0; i--)
+	{
+	  if (i == f->b->b.y)
+	    for (j = 0;
+		 j < f->b->b.x && (f->b->bf[i].s[j] != '/'
+				   || f->b->bf[i].s[j + 1] != '/'); j++)
+	      ;
+	  else
+	    for (j = 0;
+		 j < f->b->bf[i].len && (f->b->bf[i].s[j] != '/'
+					 || f->b->bf[i].s[j + 1] != '/'); j++)
+	      ;
+	  for (j--; j >= 0; j--)
+	    {
+	      if (f->b->bf[i].s[j] == '\"')
+		{
+		  for (j--; j >= 0; j--)
+		    {
+		      if (f->b->bf[i].s[j] == '\"')
+			{
+			  for (bsp = 0, j--;
+			       j >= 0 && f->b->bf[i].s[j] == '\\'; j--)
+			    bsp = !bsp;
+			  j++;
+			  if (!bsp)
+			    break;
+			}
+		      if (j == 0 && i > 0
+			  && f->b->bf[i - 1].s[f->b->bf[i - 1].len] == '\\')
+			{
+			  i--;
+			  j = f->b->bf[i].len;
+			}
+		    }
+		}
+	      else if (f->b->bf[i].s[j] == '\'')
+		{
+		  for (j--; j >= 0; j--)
+		    {
+		      if (f->b->bf[i].s[j] == '\'')
+			{
+			  for (bsp = 0, j--;
+			       j >= 0 && f->b->bf[i].s[j] == '\\'; j--)
+			    bsp = !bsp;
+			  j++;
+			  if (!bsp)
+			    break;
+			}
+		      if (j == 0 && i > 0
+			  && f->b->bf[i - 1].s[f->b->bf[i - 1].len] == '\\')
+			{
+			  i--;
+			  j = f->b->bf[i].len;
+			}
+		    }
+		}
+	      else if (f->b->bf[i].s[j] == '/' && f->b->bf[i].s[j - 1] == '*')
+		{
+		  for (j -= 2;
+		       f->b->bf[i].s[j] != '*' || f->b->bf[i].s[j - 1] != '/';
+		       j--)
+		    {
+		      if (j <= 0)
+			{
+			  if (i > 0)
+			    {
+			      i--;
+			      j = f->b->bf[i].len;
+			    }
+			  else
+			    break;
+			}
+		    }
+		}
+	      else if (f->b->bf[i].s[j] == '#'
+		       && (!strncmp ((const char *) f->b->bf[i].s, "#else", 5)
+			   || !strncmp ((const char *) f->b->bf[i].s, "#elif",
+					5)))
+		{
+		  for (nif = 1, i--; i > 0; i--)
+		    {
+		      for (j = 0; isspace (f->b->bf[i].s[j]); j++)
+			;
+		      if (!strncmp
+			  ((const char *) f->b->bf[i].s + j, "#endif", 6))
+			nif++;
+		      else
+			if (!strncmp
+			    ((const char *) f->b->bf[i].s + j, "#if", 3))
+			nif--;
+		      if (!nif)
+			break;
+		    }
+		  continue;
+		}
+	      else if (!ob)
+		{
+		  if (f->b->bf[i].s[j] == '{' || f->b->bf[i].s[j] == '('
+		      || f->b->bf[i].s[j] == '[')
+		    {
+		      brk++;
+		      if (!brk)
+			{
+			  f->b->b.y = i;
+			  f->b->b.x = j;
+			  return (0);
+			}
+		    }
+		  else if (f->b->bf[i].s[j] == '}' || f->b->bf[i].s[j] == ')'
+			   || f->b->bf[i].s[j] == ']')
+		    brk--;
+		  else if (i == 0 && j == 0)
+		    {
+		      f->b->b.y = i;
+		      f->b->b.x = j;
+		      return (0);
+		    }
+		}
+	      else
+		{
+		  if (f->b->bf[i].s[j] == ob)
+		    {
+		      brk++;
+		      if (!brk)
+			{
+			  f->b->b.y = i;
+			  f->b->b.x = j;
+			  return (0);
+			}
+		    }
+		  else if (f->b->bf[i].s[j] == cb)
+		    brk--;
+		}
+	    }
+	}
+    }
+  return (e_error ("No Matching Bracket!", 0, f->ed->fb));
+}
+
+char *
+e_mbt_mk_sp (char *str, int n, int sw, int *m)
+{
+  int k;
+
+  if (!sw)
+    *m = n;
+  else
+    *m = n / sw + n % sw;
+  str = realloc (str, (*m + 1) * sizeof (char));
+  if (!sw)
+    k = 0;
+  else
+    for (k = 0; k < n / sw; k++)
+      str[k] = '\t';
+  for (; k < *m; k++)
+    str[k] = ' ';
+  str[*m] = '\0';
+  return (str);
+}
+
+int
+e_mbt_str (BUFFER * b, int *ii, int *jj, unsigned char c, int n, int sw,
+	   int *cmnd)
+{
+  int i = *ii, j = *jj + 1, bsp;
+
+  if (*cmnd != 2)
+    *cmnd = 0;
+  for (bsp = 0; j < b->bf[i].len && (b->bf[i].s[j] != c || bsp); j++)
+    {
+      if (b->bf[i].s[j] == '\\')
+	bsp = !bsp;
+      else
+	bsp = 0;
+      if (j == b->bf[i].len - 1 && bsp && i < b->mxlines - 1)
+	{
+	  char *str = malloc (1);
+	  int m;
+
+	  i++;
+	  bsp = 0;
+	  for (j = 0, m = b->bf[i].len; j < m && isspace (b->bf[i].s[j]); j++)
+	    ;
+	  if (j > 0)
+	    e_del_nchar (b, b->f->s, 0, i, j);
+	  if (j < m)
+	    {
+	      str = e_mbt_mk_sp (str, n + b->cn->autoindent, sw, &m);
+	      e_ins_nchar (b, b->f->s, (unsigned char *) str, 0, i, m);
+	    }
+	  j = -1;
+	  free (str);
+	}
+    }
+  *ii = i;
+  *jj = j;
+  return (0);
+}
+
+int
+e_mbt_cnd (BUFFER * b, int *ii, int *jj, int n, int sw, int *cmnd)
+{
+  int i = *ii, j = *jj + 2;
+
+  for (; b->bf[i].s[j] != '*' || b->bf[i].s[j + 1] != '/'; j++)
+    {
+      if (j >= b->bf[i].len - 1)
+	{
+	  if (i < b->mxlines - 1)
+	    {
+	      char *str = malloc (1);
+	      int m;
+
+	      i++;
+	      for (j = 0, m = b->bf[i].len; j < m && isspace (b->bf[i].s[j]);
+		   j++)
+		;
+	      if (j > 0)
+		e_del_nchar (b, b->f->s, 0, i, j);
+	      if (j < m && (b->bf[i].s[0] != '*' || b->bf[i].s[1] != '/'))
+		{
+		  str = e_mbt_mk_sp (str, n + b->cn->autoindent, sw, &m);
+		  e_ins_nchar (b, b->f->s, (unsigned char *) str, 0, i, m);
+		}
+	      j = -1;
+	      free (str);
+	      if (*cmnd == 2)
+		*cmnd = 1;
+	    }
+	  else
+	    break;
+	}
+    }
+  *ii = i;
+  *jj = j + 1;
+  return (0);
+}
+
+int
+e_mk_beauty (int sw, int ndif, FENSTER * f)
+{
+  BUFFER *b;
+  SCHIRM *s;
+  int bg, nd, m, n, i, j, k, brk, cbrk = 0, nif = 0, nic = 0;
+  int nstrct = 0, cmnd, cm_sv;
+  char *tstr = malloc (sizeof (char));
+  char *bstr = malloc ((ndif + 1) * sizeof (char));
+  int *nvek = malloc (sizeof (int));
+  int *ifvekb = malloc (sizeof (int));
+  int *ifvekr = malloc (sizeof (int));
+  int *vkcs = malloc (sizeof (int));
+  int *vkcb = malloc (sizeof (int));
+  POINT sa, se, sb;
+
+  for (i = f->ed->mxedt; i > 0 && !DTMD_ISTEXT (f->ed->f[i]->dtmd); i--)
+    ;
+  if (i <= 0)
+    {
+      free (tstr);
+      free (bstr);
+      free (nvek);
+      free (ifvekb);
+      free (ifvekr);
+      free (vkcs);
+      free (vkcb);
+      return (0);
+    }
+  *ifvekb = 0;
+  *ifvekr = 0;
+  *vkcs = 0;
+  *vkcb = 0;
+  e_switch_window (f->ed->edt[i], f);
+  WpeMouseChangeShape (WpeWorkingShape);
+  f = f->ed->f[f->ed->mxedt];
+  b = f->b;
+  s = f->s;
+  sa = s->mark_begin;
+  se = s->mark_end;
+  sb = b->b;
+  if (sw & 1)
+    {
+      if (sw & 2)
+	bg = i = b->b.x == 0 ? b->b.y : b->b.y + 1;
+      else
+	bg = i = s->mark_begin.x == 0 ? s->mark_begin.y : s->mark_begin.y + 1;
+      nd = s->mark_end.x == 0 ? s->mark_end.y : s->mark_end.y + 1;
+      if (nd > b->mxlines)
+	nd = b->mxlines;
+    }
+  else
+    {
+      if (sw & 2)
+	bg = i = b->b.x == 0 ? b->b.y : b->b.y + 1;
+      else
+	bg = i = 0;
+      nd = b->mxlines;
+    }
+  if (s->mark_begin.y < 0 || (s->mark_begin.y == 0 && s->mark_begin.x <= 0))
+    n = 0;
+  else
+    {
+      for (n = j = 0; j < b->bf[i].len && isspace (b->bf[i].s[j]); j++)
+	{
+	  if (b->bf[i].s[j] == ' ')
+	    n++;
+	  else if (b->bf[i].s[j] == '\t')
+	    n += f->ed->tabn - (n % f->ed->tabn);
+	}
+    }
+  tstr = e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+  for (k = 0; k < ndif; k++)
+    bstr[k] = ' ';
+  bstr[ndif] = '\0';
+  nvek[0] = n;
+  for (cm_sv = 1, cmnd = 1, brk = 0; i < nd; i++)
+    {
+      for (j = 0; j < b->bf[i].len && isspace (b->bf[i].s[j]); j++)
+	;
+      if (i > bg)
+	{
+	  for (k = b->bf[i - 1].len - 1;
+	       k >= 0 && isspace (b->bf[i - 1].s[k]); k--);
+	  if (k >= 0)
+	    e_del_nchar (b, s, k + 1, i - 1, b->bf[i - 1].len - 1 - k);
+	  e_del_nchar (b, s, 0, i, j);
+	  if (b->bf[i].len > 0 && b->bf[i].s[0] != '#' &&
+	      (b->bf[i].s[0] != '/' || b->bf[i].s[1] != '*'))
+	    {
+	      if ((cmnd == 0 && (!cm_sv || b->bf[i].s[0] != '{')) ||
+		  (cmnd == 2 && b->bf[i - 1].s[k] == '\\'))
+		{
+		  tstr =
+		    e_mbt_mk_sp (tstr,
+				 !cmnd ? n +
+				 b->cn->autoindent : b->cn->autoindent,
+				 (sw & 4) ? 0 : f->ed->tabn, &m);
+		  e_ins_nchar (b, s, (unsigned char *) tstr, 0, i, m);
+		  j = m;
+		  tstr =
+		    e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+		}
+	      else
+		{
+		  e_ins_nchar (b, s, (unsigned char *) tstr, 0, i, m);
+		  j = m;
+		  if (cmnd == 0)
+		    cmnd = 1;
+		}
+	    }
+	}
+      if (cmnd == 0)
+	cm_sv = cbrk ? 1 : 0;
+      else
+	cm_sv = cmnd;
+      for (cmnd = 1; j < b->bf[i].len; j++)
+	{
+	  if (b->bf[i].s[j] == '\"')
+	    e_mbt_str (b, &i, &j, '\"', n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
+	  else if (f->b->bf[i].s[j] == '\'')
+	    e_mbt_str (b, &i, &j, '\'', n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
+	  else if (b->bf[i].s[j] == '/' && b->bf[i].s[j + 1] == '*')
+	    e_mbt_cnd (b, &i, &j, n, (sw & 4) ? 0 : f->ed->tabn, &cmnd);
+	  else if (b->bf[i].s[j] == '/' && b->bf[i].s[j + 1] == '/')
+	    break;
+	  else if (b->bf[i].s[j] == ';')
+	    {
+	      cmnd = cbrk ? 0 : 1;
+	      nstrct = 0;
+	    }
+	  else if (b->bf[i].s[j] == '#' &&
+		   (!strncmp ((const char *) b->bf[i].s, "#if", 3)
+		    || !strncmp ((const char *) b->bf[i].s, "#ifdef", 6)))
+	    {
+	      nif++;
+	      ifvekb = realloc (ifvekb, (nif + 1) * sizeof (int));
+	      ifvekr = realloc (ifvekr, (nif + 1) * sizeof (int));
+	      ifvekb[nif] = brk;
+	      ifvekr[nif] = cbrk;
+	      cmnd = 2;
+	    }
+	  else if (b->bf[i].s[j] == '#' && nif > 0
+		   && (!strncmp ((const char *) b->bf[i].s, "#else", 5)
+		       || !strncmp ((const char *) b->bf[i].s, "#elif", 5)))
+	    {
+	      brk = ifvekb[nif];
+	      cbrk = ifvekr[nif];
+	      n = nvek[brk];
+	      tstr = e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+	      cmnd = 2;
+	    }
+	  else if (b->bf[i].s[j] == '#'
+		   && (!strncmp ((const char *) b->bf[i].s, "#endif", 6)))
+	    {
+	      nif--;
+	      cmnd = 2;
+	    }
+	  else if (b->bf[i].s[j] == '#')
+	    {
+	      cmnd = 2;
+	      for (j++; j < b->bf[i].len; j++)
+		{
+		  if (j == b->bf[i].len - 1 && i < b->mxlines - 1
+		      && b->bf[i].s[j] == '\\')
+		    {
+		      i++;
+		      j = 0;
+		    }
+		  else if (b->bf[i].s[j] == '\"')
+		    e_mbt_str (b, &i, &j, '\"', n, (sw & 4) ? 0 : f->ed->tabn,
+			       &cmnd);
+		  else if (f->b->bf[i].s[j] == '\'')
+		    e_mbt_str (b, &i, &j, '\'', n, (sw & 4) ? 0 : f->ed->tabn,
+			       &cmnd);
+		  else if (b->bf[i].s[j] == '/' && b->bf[i].s[j + 1] == '*')
+		    e_mbt_cnd (b, &i, &j, n, (sw & 4) ? 0 : f->ed->tabn,
+			       &cmnd);
+		  else if (b->bf[i].s[j] == '/' && b->bf[i].s[j + 1] == '/')
+		    break;
+		}
+	      if (b->bf[i].s[j] == '/' && b->bf[i].s[j + 1] == '/')
+		break;
+	    }
+	  else if (b->bf[i].s[j] == '(')
+	    {
+	      nstrct = 0;
+	      cmnd = 0;
+	      cbrk++;
+	    }
+	  else if (b->bf[i].s[j] == ')')
+	    {
+	      nstrct = 0;
+	      cmnd = 0;
+	      cbrk--;
+	    }
+	  else if (b->bf[i].s[j] == '{')
+	    {
+	      brk++;
+	      cmnd = 1;
+	      for (k = j + 1; k < b->bf[i].len && isspace (b->bf[i].s[k]);
+		   k++);
+	      if (k < b->bf[i].len
+		  && (b->bf[i].s[k] != '/'
+		      || (b->bf[i].s[k + 1] != '*'
+			  && b->bf[i].s[k + 1] != '/')))
+		{
+		  e_del_nchar (b, s, j + 1, i, k - j - 1);
+		  e_ins_nchar (b, s, (unsigned char *) bstr, j + 1, i,
+			       ndif - 1);
+		}
+	      if (nstrct == 1)
+		{
+		  if (k >= b->bf[i].len)
+		    n = nvek[brk - 1];
+		  else
+		    {
+		      for (k = j - 1; k >= 0 && isspace (b->bf[i].s[k]); k--);
+		      if (k >= 0)
+			nstrct++;
+		    }
+		  nstrct++;
+		  nic++;
+		  vkcb = realloc (vkcb, (nic + 1) * sizeof (int));
+		  vkcs = realloc (vkcs, (nic + 1) * sizeof (int));
+		  vkcs[nic] = 0;
+		  vkcb[nic] = brk - 1;
+		}
+	      else
+		{
+		  for (n = k = 0; k < j; k++)
+		    {
+		      if (b->bf[i].s[k] == '\t')
+			n += f->ed->tabn - (n % f->ed->tabn);
+		      else
+			n++;
+		    }
+		}
+	      n += ndif;
+	      tstr = e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+	      nvek = realloc (nvek, (brk + 1) * sizeof (int));
+	      nvek[brk] = n;
+	    }
+	  else if (f->b->bf[i].s[j] == '}')
+	    {
+	      brk--;
+	      cmnd = 1;
+	      nstrct = 0;
+	      if (nic > 0 && vkcb[nic] == brk - 1)
+		{
+		  n = nvek[brk];
+		  nic--;
+		  brk--;
+		}
+	      if (brk < 0)
+		{
+		  free (tstr);
+		  free (bstr);
+		  free (nvek);
+		  free (ifvekb);
+		  free (ifvekr);
+		  free (vkcs);
+		  free (vkcb);
+		  b->b = sb;
+		  s->mark_begin = sa;
+		  s->mark_end = se;
+		  e_schirm (f, 1);
+		  WpeMouseRestoreShape ();
+		  return (0);
+		}
+	      n -= ndif;
+	      tstr = e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+	      for (k = j - 1; k >= 0 && isspace (b->bf[i].s[k]); k--);
+	      e_del_nchar (b, s, k + 1, i, j - 1 - k);
+	      if (k > 0)
+		{
+		  e_ins_nchar (b, s, (unsigned char *) bstr, k + 1, i,
+			       ndif - 1);
+		  j = k + ndif + 1;
+		}
+	      else
+		{
+		  e_ins_nchar (b, s, (unsigned char *) tstr, k + 1, i, m);
+		  j = k + m + 2;
+		}
+	      n = nvek[brk];
+	      tstr = e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+	    }
+	  else if (((j == 0 || !isalnum1 (b->bf[i].s[j - 1])) &&
+		    (iscase ((const char *) b->bf[i].s + j)
+		     || isstatus ((const char *) b->bf[i].s + j)))
+		   || (nstrct > 1 && isalnum1 (b->bf[i].s[j])))
+	    {
+	      if (vkcs[nic])
+		{
+		  n = nvek[vkcb[nic] + 1];
+		  tstr =
+		    e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+		  for (k = j - 1; k >= 0 && isspace (b->bf[i].s[k]); k--);
+		  e_del_nchar (b, s, k + 1, i, j - 1 - k);
+		  if (k > 0)
+		    {
+		      e_ins_nchar (b, s, (unsigned char *) bstr, k + 1, i,
+				   ndif - 1);
+		      j = k + ndif + 1;
+		    }
+		  else
+		    {
+		      e_ins_nchar (b, s, (unsigned char *) tstr, k + 1, i, m);
+		      j = k + m + 2;
+		    }
+		}
+	      else
+		{
+		  brk++;
+		  vkcs[nic] = 1;
+		}
+	      if (nstrct < 2 || isstatus ((const char *) b->bf[i].s + j))
+		{
+		  for (j++; j < b->bf[i].len && b->bf[i].s[j] != ':'; j++);
+		  for (k = j + 1; k < b->bf[i].len && isspace (b->bf[i].s[k]);
+		       k++);
+		  if (k < b->bf[i].len
+		      && (b->bf[i].s[k] != '/'
+			  || (b->bf[i].s[k + 1] != '*'
+			      && b->bf[i].s[k + 1] != '/')))
+		    {
+		      e_del_nchar (b, s, j + 1, i, k - j - 1);
+		      e_ins_nchar (b, s, (unsigned char *) bstr, j + 1, i,
+				   ndif - 1);
+		      for (n = k = 0; k < j; k++)
+			{
+			  if (b->bf[i].s[k] == '\t')
+			    n += f->ed->tabn - (n % f->ed->tabn);
+			  else
+			    n++;
+			}
+		    }
+		}
+	      else if (nstrct == 2)
+		e_ins_nchar (b, s, (unsigned char *) bstr, j, i, ndif);
+	      else
+		j--;
+	      n += ndif;
+	      tstr = e_mbt_mk_sp (tstr, n, (sw & 4) ? 0 : f->ed->tabn, &m);
+	      nvek = realloc (nvek, (brk + 1) * sizeof (int));
+	      nvek[brk] = n;
+	      cmnd = 3;
+	      nstrct = 0;
+	    }
+	  else if ((j == 0 || !isalnum1 (b->bf[i].s[j - 1])) &&
+		   (!strncmp ((const char *) b->bf[i].s + j, "switch", 6)
+		    && !isalnum1 (b->bf[i].s[j + 6])))
+	    {
+	      nic++;
+	      vkcb = realloc (vkcb, (nic + 1) * sizeof (int));
+	      vkcs = realloc (vkcs, (nic + 1) * sizeof (int));
+	      vkcs[nic] = 0;
+	      vkcb[nic] = brk;
+	    }
+	  else if ((j == 0 || !isalnum1 (b->bf[i].s[j - 1])) &&
+		   ((!strncmp ((const char *) b->bf[i].s + j, "class", 5)
+		     && !isalnum1 (b->bf[i].s[j + 5]))
+		    || (!strncmp ((const char *) b->bf[i].s + j, "struct", 6)
+			&& !isalnum1 (b->bf[i].s[j + 6]))))
+	    nstrct = 1;
+	  else if (cmnd == 1 && !isspace (f->b->bf[i].s[j]))
+	    cmnd = 0;
+	  else if (cmnd == 3 && f->b->bf[i].s[j] == ':')
+	    cmnd = 1;
+	}
+    }
+  free (nvek);
+  free (tstr);
+  free (bstr);
+  free (ifvekb);
+  free (ifvekr);
+  free (vkcs);
+  free (vkcb);
+  s->mark_begin = sa;
+  s->mark_end = se;
+  b->b = sb;
+  e_schirm (f, 1);
+  WpeMouseRestoreShape ();
+  return (0);
+}
+
+int
+e_p_beautify (FENSTER * f)
+{
+  static int b_sw = 0;
+  int ret;
+  W_OPTSTR *o = e_init_opt_kst (f);
+
+  if (!o)
+    return (-1);
+  o->xa = 21;
+  o->ya = 3;
+  o->xe = 52;
+  o->ye = 19;
+  o->bgsw = AltO;
+  o->name = "Beautify";
+  o->crsw = AltO;
+  e_add_txtstr (4, 2, "Begin:", o);
+  e_add_txtstr (4, 6, "Scope:", o);
+  e_add_numstr (4, 12, 26, 12, 2, 100, 0, AltN, "Number of Columns:",
+		f->ed->autoindent, o);
+  e_add_sswstr (5, 10, 3, AltT, (b_sw & 4) ? 1 : 0, "No Tabulators     ", o);
+  e_add_pswstr (0, 5, 3, 0, AltG, 0, "Global            ", o);
+  e_add_pswstr (0, 5, 4, 0, AltS, b_sw & 1, "Selected Text     ", o);
+  e_add_pswstr (1, 5, 7, 0, AltE, 0, "Entire Scope      ", o);
+  e_add_pswstr (1, 5, 8, 0, AltF, (b_sw & 2) ? 1 : 0, "From Cursor       ",
+		o);
+  e_add_bttstr (7, 14, 1, AltO, " Ok ", NULL, o);
+  e_add_bttstr (18, 14, -1, WPE_ESC, "Cancel", NULL, o);
+  ret = e_opt_kst (o);
+  if (ret != WPE_ESC)
+    {
+      b_sw =
+	o->pstr[0]->num + (o->pstr[1]->num << 1) + (o->sstr[0]->num << 2);
+      f->ed->autoindent = o->nstr[0]->num;
+      e_mk_beauty (b_sw, f->ed->autoindent, f);
+    }
+  freeostr (o);
+  return (0);
 }
 
 #endif
-

--- a/src/we_progn.h
+++ b/src/we_progn.h
@@ -4,35 +4,40 @@
 #include "globals.h"
 #include "we_wind.h"
 
-typedef struct {  FILE *fp;  BUFFER *b;  POINT p;  }  E_AFILE;
+typedef struct
+{
+  FILE *fp;
+  BUFFER *b;
+  POINT p;
+} E_AFILE;
 
-int *e_sc_txt(int *c_sw, BUFFER *b);
-int e_sc_nw_txt(int y, BUFFER *b, int sw);
-int e_add_synt_tl(char *filename, FENSTER *f);
-int e_mk_beauty(int sw, int ndif, FENSTER *f);
-int e_sh_def(FENSTER *f);
-int e_sh_nxt_def(FENSTER *f);
-int e_nxt_brk(FENSTER *f);
-int e_p_beautify(FENSTER *f);
+int *e_sc_txt (int *c_sw, BUFFER * b);
+int e_sc_nw_txt (int y, BUFFER * b, int sw);
+int e_add_synt_tl (char *filename, FENSTER * f);
+int e_mk_beauty (int sw, int ndif, FENSTER * f);
+int e_sh_def (FENSTER * f);
+int e_sh_nxt_def (FENSTER * f);
+int e_nxt_brk (FENSTER * f);
+int e_p_beautify (FENSTER * f);
 
 /*   we_progn.c  */
 
-int e_scfbol(int n, int mcsw, unsigned char *str, struct wpeSyntaxRule *cs);
-int e_sc_all(FENSTER *f, int sw);
-int e_program_opt(FENSTER *f);
-void e_pr_c_line(int y, FENSTER *f);
-E_AFILE *e_aopen(char *name, char *path, int mode);
-int e_aclose(E_AFILE *ep);
-char *e_agets(char *str, int n, E_AFILE *ep);
-char *e_sh_spl1(char *sp, char *str, E_AFILE *fp, int *n);
-char *e_sh_spl2(char *sp, char *str, E_AFILE *fp, int *n);
-char *e_sh_spl3(char *sp, char *str, E_AFILE *fp, int *n);
-char *e_sh_spl4(char *sp, char *str, E_AFILE *fp, int *n);
-char *e_sh_spl5(char *sp, char *str, E_AFILE *fp, int *n);
-struct dirfile *e_c_add_df(char *str, struct dirfile *df);
-int e_find_def(char *name, char *startfile, int mode, char *file,
-  int *num, int *xn, int nold, char *oldfile, struct dirfile **df,
-  int *first);
-int e_show_nm_f(char *name, FENSTER *f, int oldn, char **oldname);
+int e_scfbol (int n, int mcsw, unsigned char *str, struct wpeSyntaxRule *cs);
+int e_sc_all (FENSTER * f, int sw);
+int e_program_opt (FENSTER * f);
+void e_pr_c_line (int y, FENSTER * f);
+E_AFILE *e_aopen (char *name, char *path, int mode);
+int e_aclose (E_AFILE * ep);
+char *e_agets (char *str, int n, E_AFILE * ep);
+char *e_sh_spl1 (char *sp, char *str, E_AFILE * fp, int *n);
+char *e_sh_spl2 (char *sp, char *str, E_AFILE * fp, int *n);
+char *e_sh_spl3 (char *sp, char *str, E_AFILE * fp, int *n);
+char *e_sh_spl4 (char *sp, char *str, E_AFILE * fp, int *n);
+char *e_sh_spl5 (char *sp, char *str, E_AFILE * fp, int *n);
+struct dirfile *e_c_add_df (char *str, struct dirfile *df);
+int e_find_def (char *name, char *startfile, int mode, char *file,
+		int *num, int *xn, int nold, char *oldfile,
+		struct dirfile **df, int *first);
+int e_show_nm_f (char *name, FENSTER * f, int oldn, char **oldname);
 
 #endif

--- a/src/we_term.c
+++ b/src/we_term.c
@@ -21,7 +21,7 @@
 #include <fcntl.h>
 
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
-# include <curses.h>
+#include <curses.h>
 #endif
 
 #include<signal.h>
@@ -33,29 +33,29 @@
 #endif
 
 /*    we_term.c    */
-char *init_key(char *key);
-char *init_kkey(char *key);
-int init_cursor(void);
-int e_begscr(void);
-void e_endwin(void);
-int fk_t_cursor(int x);
-int fk_t_putchar(int c);
-int fk_attrset(int a);
-int e_t_refresh(void);
-int e_t_sys_ini(void);
-int e_t_sys_end(void);
-int e_t_getch(void);
-int e_find_key(int c, int j, int sw);
-void e_exitm(char *s, int n);
-int fk_t_locate(int x, int y);
-int fk_t_mouse(int *g);
-int e_t_initscr(void);
-int e_t_kbhit(void);
-int e_t_d_switch_out(int sw);
-int e_t_switch_screen(int sw);
-int e_t_deb_out(FENSTER *f);
-int e_s_sys_end();
-int e_s_sys_ini();
+char *init_key (char *key);
+char *init_kkey (char *key);
+int init_cursor (void);
+int e_begscr (void);
+void e_endwin (void);
+int fk_t_cursor (int x);
+int fk_t_putchar (int c);
+int fk_attrset (int a);
+int e_t_refresh (void);
+int e_t_sys_ini (void);
+int e_t_sys_end (void);
+int e_t_getch (void);
+int e_find_key (int c, int j, int sw);
+void e_exitm (char *s, int n);
+int fk_t_locate (int x, int y);
+int fk_t_mouse (int *g);
+int e_t_initscr (void);
+int e_t_kbhit (void);
+int e_t_d_switch_out (int sw);
+int e_t_switch_screen (int sw);
+int e_t_deb_out (FENSTER * f);
+int e_s_sys_end ();
+int e_s_sys_ini ();
 
 extern int MAXSLNS;
 extern int MAXSCOL;
@@ -89,9 +89,9 @@ char area[315];
 char *ap = area;
 char tcbuf[1024];
 char *tc_screen;
-char *tgetstr();
-int tgetnum();
-char *tgoto();
+char *tgetstr ();
+int tgetnum ();
+char *tgoto ();
 #define tigetstr(k) tgetstr(k, &ap)
 
 #define term_move(x,y) e_putp(tgoto(cur_rc, x, y))
@@ -114,1037 +114,1374 @@ char *tgoto();
 #endif
 #endif // (#else) #if !defined HAVE_LIBNCURSES && !defined HAVE_LIBCURSES
 
-int WpeDllInit(int *argc, char **argv)
+int
+WpeDllInit (int *argc, char **argv)
 {
- UNUSED(argc);
- UNUSED(argv);
- fk_u_cursor = fk_t_cursor;
- fk_u_locate = fk_t_locate;
- e_u_d_switch_out = e_t_d_switch_out;
- e_u_switch_screen = e_t_switch_screen;
- e_u_deb_out = e_t_deb_out;
- e_u_kbhit = e_t_kbhit;
- e_u_s_sys_end = e_s_sys_end;
- e_u_s_sys_ini = e_s_sys_ini;
- e_u_refresh = e_t_refresh;
- e_u_getch = e_t_getch;
- e_u_sys_ini = e_t_sys_ini;
- e_u_sys_end = e_t_sys_end;
- e_u_system = system;
- fk_u_putchar = fk_t_putchar;
+  UNUSED (argc);
+  UNUSED (argv);
+  fk_u_cursor = fk_t_cursor;
+  fk_u_locate = fk_t_locate;
+  e_u_d_switch_out = e_t_d_switch_out;
+  e_u_switch_screen = e_t_switch_screen;
+  e_u_deb_out = e_t_deb_out;
+  e_u_kbhit = e_t_kbhit;
+  e_u_s_sys_end = e_s_sys_end;
+  e_u_s_sys_ini = e_s_sys_ini;
+  e_u_refresh = e_t_refresh;
+  e_u_getch = e_t_getch;
+  e_u_sys_ini = e_t_sys_ini;
+  e_u_sys_end = e_t_sys_end;
+  e_u_system = system;
+  fk_u_putchar = fk_t_putchar;
 #ifdef HAVE_LIBGPM
- if (WpeGpmMouseInit() == 0)
- {
-  fk_mouse = WpeGpmMouse;
- }
- else
+  if (WpeGpmMouseInit () == 0)
+    {
+      fk_mouse = WpeGpmMouse;
+    }
+  else
 #endif
-  fk_mouse = fk_t_mouse;
- WpeMouseChangeShape = (void (*)(WpeMouseShape))WpeNullFunction;
- WpeMouseRestoreShape = WpeNullFunction;
- WpeDisplayEnd = e_endwin;
+    fk_mouse = fk_t_mouse;
+  WpeMouseChangeShape = (void (*)(WpeMouseShape)) WpeNullFunction;
+  WpeMouseRestoreShape = WpeNullFunction;
+  WpeDisplayEnd = e_endwin;
 #ifdef __linux__
- u_bioskey = WpeLinuxBioskey;
+  u_bioskey = WpeLinuxBioskey;
 #else
- u_bioskey = WpeZeroFunction;
+  u_bioskey = WpeZeroFunction;
 #endif
- e_t_initscr();
- if (col_num > 0)
- {
-  e_pr_u_col_kasten = e_pr_x_col_kasten;
-  e_frb_u_menue = e_frb_x_menue;
-  e_s_u_clr = e_s_x_clr;
-  e_n_u_clr = e_n_x_clr;
- }
- else
- {
-  e_pr_u_col_kasten = e_pr_t_col_kasten;
-  e_frb_u_menue = e_frb_t_menue;
-  e_s_u_clr = e_s_t_clr;
-  e_n_u_clr = e_n_t_clr;
- }
- MCI = '+';
- MCA = '0';
- RD1 = '\01';
- RD2 = '\02';
- RD3 = '\03';
- RD4 = '\04';
- RD5 = '\05';
- RD6 = '\06';
- RE1 = '\01';
- RE2 = '\02';
- RE3 = '\03';
- RE4 = '\04';
- RE5 = '\05';
- RE6 = '\06';
- WBT = '\13';
- ctree[0] = "\11\12\07";   /*  07 -> 30  */
- ctree[1] = "\11\12\12";	/*  11 -> 16  */
- ctree[2] = "\11\07\12";   /*  12 -> 22  */
- ctree[3] = "\10\12\12";   /*  10 -> 25  */
- ctree[4] = "\11\12\12";
+  e_t_initscr ();
+  if (col_num > 0)
+    {
+      e_pr_u_col_kasten = e_pr_x_col_kasten;
+      e_frb_u_menue = e_frb_x_menue;
+      e_s_u_clr = e_s_x_clr;
+      e_n_u_clr = e_n_x_clr;
+    }
+  else
+    {
+      e_pr_u_col_kasten = e_pr_t_col_kasten;
+      e_frb_u_menue = e_frb_t_menue;
+      e_s_u_clr = e_s_t_clr;
+      e_n_u_clr = e_n_t_clr;
+    }
+  MCI = '+';
+  MCA = '0';
+  RD1 = '\01';
+  RD2 = '\02';
+  RD3 = '\03';
+  RD4 = '\04';
+  RD5 = '\05';
+  RD6 = '\06';
+  RE1 = '\01';
+  RE2 = '\02';
+  RE3 = '\03';
+  RE4 = '\04';
+  RE5 = '\05';
+  RE6 = '\06';
+  WBT = '\13';
+  ctree[0] = "\11\12\07";	/*  07 -> 30  */
+  ctree[1] = "\11\12\12";	/*  11 -> 16  */
+  ctree[2] = "\11\07\12";	/*  12 -> 22  */
+  ctree[3] = "\10\12\12";	/*  10 -> 25  */
+  ctree[4] = "\11\12\12";
 /*
  RD1 = '+';
  RD2 = '+';
  RD3 = '+';
  RD4 = '+';
  RD5 = '-';
- RD6 = '|';
+   RD6 = '|';
 *//*
- RE1 = '.';
- RE2 = '.';
- RE3 = '.';
- RE4 = '.';
- RE5 = '.';
- RE6 = ':';
- WBT = '#';
- ctree[0] = "|__";
- ctree[1] = "|__";
- ctree[2] = "|__";
- ctree[3] = "|__";
- ctree[4] = "|__";
-*/
- return 0;
+     RE1 = '.';
+     RE2 = '.';
+     RE3 = '.';
+     RE4 = '.';
+     RE5 = '.';
+     RE6 = ':';
+     WBT = '#';
+     ctree[0] = "|__";
+     ctree[1] = "|__";
+     ctree[2] = "|__";
+     ctree[3] = "|__";
+     ctree[4] = "|__";
+   */
+  return 0;
 }
 
-char *init_key(char *key)
+char *
+init_key (char *key)
 {
- char *tmp, *keystr;
+  char *tmp, *keystr;
 
- tmp = (char *) tigetstr(key);
- if (tmp == NULL || tmp == ((char *) -1))
-  return(NULL);
- else
- {
-  keystr = malloc(strlen(tmp)+1);
-  strcpy(keystr, tmp);
- }
- return(keystr);
+  tmp = (char *) tigetstr (key);
+  if (tmp == NULL || tmp == ((char *) -1))
+    return (NULL);
+  else
+    {
+      keystr = malloc (strlen (tmp) + 1);
+      strcpy (keystr, tmp);
+    }
+  return (keystr);
 }
 
 //#ifndef NCURSES
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
-char *init_kkey(char *key)
+char *
+init_kkey (char *key)
 {
- char *tmp;
- int i;
+  char *tmp;
+  int i;
 
- tmp = init_key(key);
- if (tmp == NULL)
-  return(NULL);
- if (!key_key)
- {
-  key_key = malloc(2);
-  key_key[0] = tmp[1];
-  key_key[1] = '\0';
-  return(tmp);
- }
- else
- {
-  for (i = 0; key_key[i] != '\0'; i++)
-   if (key_key[i] == tmp[1])
-    return(tmp);
-  key_key = realloc(key_key, i + 2);
-  key_key[i] = tmp[1];
-  key_key[i + 1] = '\0';
- }
- return(tmp);
+  tmp = init_key (key);
+  if (tmp == NULL)
+    return (NULL);
+  if (!key_key)
+    {
+      key_key = malloc (2);
+      key_key[0] = tmp[1];
+      key_key[1] = '\0';
+      return (tmp);
+    }
+  else
+    {
+      for (i = 0; key_key[i] != '\0'; i++)
+	if (key_key[i] == tmp[1])
+	  return (tmp);
+      key_key = realloc (key_key, i + 2);
+      key_key[i] = tmp[1];
+      key_key[i + 1] = '\0';
+    }
+  return (tmp);
 }
 #endif
 
-char *init_spchr(char c)
+char *
+init_spchr (char c)
 {
- int i;
- char *pt = NULL;
+  int i;
+  char *pt = NULL;
 
- if (!spc_st || !spc_bg || !spc_nd)
-  return(NULL);
- for (i = 0; spc_st[i] && spc_st[i+1] && spc_st[i] != c; i+=2)
-  ;
- if (spc_st[i] && spc_st[i+1])
- {
-  pt = malloc((strlen(spc_bg)+strlen(spc_nd)+2)*sizeof(char));
-  if(pt)
-   sprintf(pt, "%s%c%s", spc_bg, spc_st[i+1], spc_nd);
- }
- return(pt);
+  if (!spc_st || !spc_bg || !spc_nd)
+    return (NULL);
+  for (i = 0; spc_st[i] && spc_st[i + 1] && spc_st[i] != c; i += 2)
+    ;
+  if (spc_st[i] && spc_st[i + 1])
+    {
+      pt = malloc ((strlen (spc_bg) + strlen (spc_nd) + 2) * sizeof (char));
+      if (pt)
+	sprintf (pt, "%s%c%s", spc_bg, spc_st[i + 1], spc_nd);
+    }
+  return (pt);
 }
 
-int init_cursor()
+int
+init_cursor ()
 {
 //#ifndef TERMCAP
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
-   if (!(cur_rc = init_key("cup")))
-    return(-1);
-   if ((col_fg = init_key("setaf")) && (col_bg = init_key("setab")))
-   { /* terminfo 10.2.x color code */
-    if ((col_num = tigetnum("colors")) < 0) col_num = 8;
-   }
-   else if ((col_fg = init_key("setf")) && (col_bg = init_key("setb")))
-   { /* Older terminfo color code */
-    if((col_num = tigetnum("colors")) < 0) col_num = 8;
-   }
-   else
-   { /* No colors */
-    if(col_fg) {  free(col_fg);  col_fg = NULL;   }
-    if(col_bg) {  free(col_bg);  col_bg = NULL;   }
-   }
+  if (!(cur_rc = init_key ("cup")))
+    return (-1);
+  if ((col_fg = init_key ("setaf")) && (col_bg = init_key ("setab")))
+    {				/* terminfo 10.2.x color code */
+      if ((col_num = tigetnum ("colors")) < 0)
+	col_num = 8;
+    }
+  else if ((col_fg = init_key ("setf")) && (col_bg = init_key ("setb")))
+    {				/* Older terminfo color code */
+      if ((col_num = tigetnum ("colors")) < 0)
+	col_num = 8;
+    }
+  else
+    {				/* No colors */
+      if (col_fg)
+	{
+	  free (col_fg);
+	  col_fg = NULL;
+	}
+      if (col_bg)
+	{
+	  free (col_bg);
+	  col_bg = NULL;
+	}
+    }
 
-   spc_st = init_key("acsc");
-   spc_in = init_key("enacs");
-   spc_bg = init_key("smacs");
-   spc_nd = init_key("rmacs");
-   att_no = init_key("sgr0");
-   att_so = init_key("smso");
-   att_ul = init_key("smul");
-   att_rv = init_key("rev");
-   att_bl = init_key("blink");
-   att_dm = init_key("dim");
-   att_bo = init_key("bold");
-   ratt_no = init_key("sgr0");
-   ratt_so = init_key("rmso");
-   ratt_ul = init_key("rmul");
-   ratt_rv = init_key("sgr0");
-   ratt_bl = init_key("sgr0");
-   ratt_dm = init_key("sgr0");
-   ratt_bo = init_key("sgr0");
-   beg_scr = init_key("smcup");
-   swt_scr = init_key("rmcup");
-   sav_cur = init_key("sc");
-   res_cur = init_key("rc");
+  spc_st = init_key ("acsc");
+  spc_in = init_key ("enacs");
+  spc_bg = init_key ("smacs");
+  spc_nd = init_key ("rmacs");
+  att_no = init_key ("sgr0");
+  att_so = init_key ("smso");
+  att_ul = init_key ("smul");
+  att_rv = init_key ("rev");
+  att_bl = init_key ("blink");
+  att_dm = init_key ("dim");
+  att_bo = init_key ("bold");
+  ratt_no = init_key ("sgr0");
+  ratt_so = init_key ("rmso");
+  ratt_ul = init_key ("rmul");
+  ratt_rv = init_key ("sgr0");
+  ratt_bl = init_key ("sgr0");
+  ratt_dm = init_key ("sgr0");
+  ratt_bo = init_key ("sgr0");
+  beg_scr = init_key ("smcup");
+  swt_scr = init_key ("rmcup");
+  sav_cur = init_key ("sc");
+  res_cur = init_key ("rc");
 
 //#ifndef NCURSES
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
-   key_f[0] = init_kkey("kf1");
-   key_f[1] = init_kkey("kf2");
-   key_f[2] = init_kkey("kf3");
-   key_f[3] = init_kkey("kf4");
-   key_f[4] = init_kkey("kf5");
-   key_f[5] = init_kkey("kf6");
-   key_f[6] = init_kkey("kf7");
-   key_f[7] = init_kkey("kf8");
-   key_f[8] = init_kkey("kf9");
-   key_f[9] = init_kkey("kf10");
-   key_f[10] = init_kkey("kcuu1");
-   key_f[11] = init_kkey("kcud1");
-   key_f[12] = init_kkey("kcub1");
-   key_f[13] = init_kkey("kcuf1");
-   key_f[14] = init_kkey("kich1");
-   key_f[15] = init_kkey("khome");
-   key_f[16] = init_kkey("kpp");
-   if(!(key_f[17] = init_kkey("kdch1"))) key_f[17] = "\177";
-   key_f[18] = init_kkey("kend");
-   key_f[19] = init_kkey("knp");
-   key_f[20] = init_kkey("kbs");
-   key_f[21] = init_kkey("khlp");
-   key_f[22] = init_kkey("kll");
-   key_f[23] = init_kkey("kf17");
-   key_f[24] = init_kkey("kf18");
-   key_f[25] = init_kkey("kf19");
-   key_f[26] = init_kkey("kf20");
-   key_f[27] = init_kkey("kf21");
-   key_f[28] = init_kkey("kf22");
-   key_f[29] = init_kkey("kf23");
-   key_f[30] = init_kkey("kf24");
-   key_f[31] = init_kkey("kf25");
-   key_f[32] = init_kkey("kf26");
-   key_f[33] = init_kkey("kPRV");
-   key_f[34] = init_kkey("kNXT");
-   key_f[35] = init_kkey("kLFT");
-   key_f[36] = init_kkey("kRIT");
-   key_f[37] = init_kkey("kHOM");
-   key_f[38] = init_kkey("kri");
-   key_f[39] = init_kkey("kEND");
-   key_f[40] = init_kkey("kind");
-   key_f[41] = init_kkey("kext");
+  key_f[0] = init_kkey ("kf1");
+  key_f[1] = init_kkey ("kf2");
+  key_f[2] = init_kkey ("kf3");
+  key_f[3] = init_kkey ("kf4");
+  key_f[4] = init_kkey ("kf5");
+  key_f[5] = init_kkey ("kf6");
+  key_f[6] = init_kkey ("kf7");
+  key_f[7] = init_kkey ("kf8");
+  key_f[8] = init_kkey ("kf9");
+  key_f[9] = init_kkey ("kf10");
+  key_f[10] = init_kkey ("kcuu1");
+  key_f[11] = init_kkey ("kcud1");
+  key_f[12] = init_kkey ("kcub1");
+  key_f[13] = init_kkey ("kcuf1");
+  key_f[14] = init_kkey ("kich1");
+  key_f[15] = init_kkey ("khome");
+  key_f[16] = init_kkey ("kpp");
+  if (!(key_f[17] = init_kkey ("kdch1")))
+    key_f[17] = "\177";
+  key_f[18] = init_kkey ("kend");
+  key_f[19] = init_kkey ("knp");
+  key_f[20] = init_kkey ("kbs");
+  key_f[21] = init_kkey ("khlp");
+  key_f[22] = init_kkey ("kll");
+  key_f[23] = init_kkey ("kf17");
+  key_f[24] = init_kkey ("kf18");
+  key_f[25] = init_kkey ("kf19");
+  key_f[26] = init_kkey ("kf20");
+  key_f[27] = init_kkey ("kf21");
+  key_f[28] = init_kkey ("kf22");
+  key_f[29] = init_kkey ("kf23");
+  key_f[30] = init_kkey ("kf24");
+  key_f[31] = init_kkey ("kf25");
+  key_f[32] = init_kkey ("kf26");
+  key_f[33] = init_kkey ("kPRV");
+  key_f[34] = init_kkey ("kNXT");
+  key_f[35] = init_kkey ("kLFT");
+  key_f[36] = init_kkey ("kRIT");
+  key_f[37] = init_kkey ("kHOM");
+  key_f[38] = init_kkey ("kri");
+  key_f[39] = init_kkey ("kEND");
+  key_f[40] = init_kkey ("kind");
+  key_f[41] = init_kkey ("kext");
 #endif
 
 #else // #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
 
-   if(!(cur_rc = init_key("cm"))) return(-1);
-   if((col_fg = init_key("Sf")) && (col_bg = init_key("Sb")))
-   {  if((col_num = tgetnum("Co")) < 0) col_num = 8;  }
-   else
-   {  if(col_fg) {  free(col_fg);  col_fg = NULL;   }
-      if(col_bg) {  free(col_bg);  col_bg = NULL;   }
-   }
-   spc_st = init_key("ac");
-   spc_in = init_key("eA");
-   spc_bg = init_key("as");
-   spc_nd = init_key("ae");
-   att_no = init_key("me");
-   att_so = init_key("so");
-   att_ul = init_key("us");
-   att_rv = init_key("mr");
-   att_bl = init_key("mb");
-   att_dm = init_key("mh");
-   att_bo = init_key("md");
-   ratt_no = init_key("me");
-   ratt_so = init_key("se");
-   ratt_ul = init_key("ue");
-   ratt_rv = init_key("me");
-   ratt_bl = init_key("me");
-   ratt_dm = init_key("me");
-   ratt_bo = init_key("me");
-   beg_scr = init_key("ti");
-   swt_scr = init_key("te");
-   sav_cur = init_key("sc");
-   res_cur = init_key("rc");
+  if (!(cur_rc = init_key ("cm")))
+    return (-1);
+  if ((col_fg = init_key ("Sf")) && (col_bg = init_key ("Sb")))
+    {
+      if ((col_num = tgetnum ("Co")) < 0)
+	col_num = 8;
+    }
+  else
+    {
+      if (col_fg)
+	{
+	  free (col_fg);
+	  col_fg = NULL;
+	}
+      if (col_bg)
+	{
+	  free (col_bg);
+	  col_bg = NULL;
+	}
+    }
+  spc_st = init_key ("ac");
+  spc_in = init_key ("eA");
+  spc_bg = init_key ("as");
+  spc_nd = init_key ("ae");
+  att_no = init_key ("me");
+  att_so = init_key ("so");
+  att_ul = init_key ("us");
+  att_rv = init_key ("mr");
+  att_bl = init_key ("mb");
+  att_dm = init_key ("mh");
+  att_bo = init_key ("md");
+  ratt_no = init_key ("me");
+  ratt_so = init_key ("se");
+  ratt_ul = init_key ("ue");
+  ratt_rv = init_key ("me");
+  ratt_bl = init_key ("me");
+  ratt_dm = init_key ("me");
+  ratt_bo = init_key ("me");
+  beg_scr = init_key ("ti");
+  swt_scr = init_key ("te");
+  sav_cur = init_key ("sc");
+  res_cur = init_key ("rc");
 
-   key_f[0] = init_kkey("k1");
-   key_f[1] = init_kkey("k2");
-   key_f[2] = init_kkey("k3");
-   key_f[3] = init_kkey("k4");
-   key_f[4] = init_kkey("k5");
-   key_f[5] = init_kkey("k6");
-   key_f[6] = init_kkey("k7");
-   key_f[7] = init_kkey("k8");
-   key_f[8] = init_kkey("k9");
-   key_f[9] = init_kkey("k;");
-   key_f[10] = init_kkey("ku");
-   key_f[11] = init_kkey("kd");
-   key_f[12] = init_kkey("kl");
-   key_f[13] = init_kkey("kr");
-   key_f[14] = init_kkey("kI");
-   key_f[15] = init_kkey("kh");
-   key_f[16] = init_kkey("kP");
-   key_f[17] = init_kkey("kD");
-   key_f[18] = init_kkey("@7");
-   key_f[19] = init_kkey("kN");
-   key_f[20] = init_kkey("kb");
-   key_f[21] = init_kkey("%1");
-   key_f[22] = init_kkey("kH");
-   key_f[23] = init_kkey("F7");
-   key_f[24] = init_kkey("F8");
-   key_f[25] = init_kkey("F9");
-   key_f[26] = init_kkey("FA");
-   key_f[27] = init_kkey("FB");
-   key_f[28] = init_kkey("FC");
-   key_f[29] = init_kkey("FD");
-   key_f[30] = init_kkey("FE");
-   key_f[31] = init_kkey("FF");
-   key_f[32] = init_kkey("FG");
-   key_f[33] = init_kkey("%e");
-   key_f[34] = init_kkey("%c");
-   key_f[35] = init_kkey("#4");
-   key_f[36] = init_kkey("%i");
-   key_f[37] = init_kkey("#2");
-   key_f[38] = init_kkey("kR");
-   key_f[39] = init_kkey("*7");
-   key_f[40] = init_kkey("kF");
-   key_f[41] = init_kkey("@1");
+  key_f[0] = init_kkey ("k1");
+  key_f[1] = init_kkey ("k2");
+  key_f[2] = init_kkey ("k3");
+  key_f[3] = init_kkey ("k4");
+  key_f[4] = init_kkey ("k5");
+  key_f[5] = init_kkey ("k6");
+  key_f[6] = init_kkey ("k7");
+  key_f[7] = init_kkey ("k8");
+  key_f[8] = init_kkey ("k9");
+  key_f[9] = init_kkey ("k;");
+  key_f[10] = init_kkey ("ku");
+  key_f[11] = init_kkey ("kd");
+  key_f[12] = init_kkey ("kl");
+  key_f[13] = init_kkey ("kr");
+  key_f[14] = init_kkey ("kI");
+  key_f[15] = init_kkey ("kh");
+  key_f[16] = init_kkey ("kP");
+  key_f[17] = init_kkey ("kD");
+  key_f[18] = init_kkey ("@7");
+  key_f[19] = init_kkey ("kN");
+  key_f[20] = init_kkey ("kb");
+  key_f[21] = init_kkey ("%1");
+  key_f[22] = init_kkey ("kH");
+  key_f[23] = init_kkey ("F7");
+  key_f[24] = init_kkey ("F8");
+  key_f[25] = init_kkey ("F9");
+  key_f[26] = init_kkey ("FA");
+  key_f[27] = init_kkey ("FB");
+  key_f[28] = init_kkey ("FC");
+  key_f[29] = init_kkey ("FD");
+  key_f[30] = init_kkey ("FE");
+  key_f[31] = init_kkey ("FF");
+  key_f[32] = init_kkey ("FG");
+  key_f[33] = init_kkey ("%e");
+  key_f[34] = init_kkey ("%c");
+  key_f[35] = init_kkey ("#4");
+  key_f[36] = init_kkey ("%i");
+  key_f[37] = init_kkey ("#2");
+  key_f[38] = init_kkey ("kR");
+  key_f[39] = init_kkey ("*7");
+  key_f[40] = init_kkey ("kF");
+  key_f[41] = init_kkey ("@1");
 #endif
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
-   sp_chr[0] = 0;
-   sp_chr[1] = ACS_ULCORNER;
-   sp_chr[2] = ACS_URCORNER;
-   sp_chr[3] = ACS_LLCORNER;
-   sp_chr[4] = ACS_LRCORNER;
-   sp_chr[5] = ACS_HLINE;
-   sp_chr[6] = ACS_VLINE;
-   sp_chr[7] = ACS_S9;
-   sp_chr[8] = ACS_VLINE;
-   sp_chr[9] = ACS_VLINE;
-   sp_chr[10] = ACS_S9;
-   sp_chr[11] = ACS_DIAMOND;
-   sp_chr[12] = ' ';
+  sp_chr[0] = 0;
+  sp_chr[1] = ACS_ULCORNER;
+  sp_chr[2] = ACS_URCORNER;
+  sp_chr[3] = ACS_LLCORNER;
+  sp_chr[4] = ACS_LRCORNER;
+  sp_chr[5] = ACS_HLINE;
+  sp_chr[6] = ACS_VLINE;
+  sp_chr[7] = ACS_S9;
+  sp_chr[8] = ACS_VLINE;
+  sp_chr[9] = ACS_VLINE;
+  sp_chr[10] = ACS_S9;
+  sp_chr[11] = ACS_DIAMOND;
+  sp_chr[12] = ' ';
 #else // #else #ifdef NCURSES (i.e. FALSE)
-   sp_chr[0] = "";
-   if(!(sp_chr[1] = init_spchr('l'))) sp_chr[1] = "+";
-   if(!(sp_chr[2] = init_spchr('k'))) sp_chr[2] = "+";
-   if(!(sp_chr[3] = init_spchr('m'))) sp_chr[3] = "+";
-   if(!(sp_chr[4] = init_spchr('j'))) sp_chr[4] = "+";
-   if(!(sp_chr[5] = init_spchr('q'))) sp_chr[5] = "-";
-   if(!(sp_chr[6] = init_spchr('x'))) sp_chr[6] = "|";
-   if(!(sp_chr[7] = init_spchr('w'))) sp_chr[7] = "_";
-   if(!(sp_chr[8] = init_spchr('t'))) sp_chr[8] = "|";
-   if(!(sp_chr[9] = init_spchr('m'))) sp_chr[9] = "|";
-   if(!(sp_chr[10] = init_spchr('q'))) sp_chr[10] = "_";
-   if(!(sp_chr[11] = init_spchr('`'))) sp_chr[11] = "#";
-   if(!(sp_chr[12] = init_spchr('a'))) sp_chr[12] = " ";
+  sp_chr[0] = "";
+  if (!(sp_chr[1] = init_spchr ('l')))
+    sp_chr[1] = "+";
+  if (!(sp_chr[2] = init_spchr ('k')))
+    sp_chr[2] = "+";
+  if (!(sp_chr[3] = init_spchr ('m')))
+    sp_chr[3] = "+";
+  if (!(sp_chr[4] = init_spchr ('j')))
+    sp_chr[4] = "+";
+  if (!(sp_chr[5] = init_spchr ('q')))
+    sp_chr[5] = "-";
+  if (!(sp_chr[6] = init_spchr ('x')))
+    sp_chr[6] = "|";
+  if (!(sp_chr[7] = init_spchr ('w')))
+    sp_chr[7] = "_";
+  if (!(sp_chr[8] = init_spchr ('t')))
+    sp_chr[8] = "|";
+  if (!(sp_chr[9] = init_spchr ('m')))
+    sp_chr[9] = "|";
+  if (!(sp_chr[10] = init_spchr ('q')))
+    sp_chr[10] = "_";
+  if (!(sp_chr[11] = init_spchr ('`')))
+    sp_chr[11] = "#";
+  if (!(sp_chr[12] = init_spchr ('a')))
+    sp_chr[12] = " ";
 #endif
-   return(0);
+  return (0);
 }
 
-int e_t_initscr()
+int
+e_t_initscr ()
 {
- int ret, i, k;
+  int ret, i, k;
 //#ifndef TERMCAP
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
- WINDOW * stdscr;
+  WINDOW *stdscr;
 #endif
 
- ret = tcgetattr(1, &otermio); /* save old settings */
- if(ret)
- {
-  int errno_save = errno;	// save errno before it is overwritten
-  const int max_desc = 1024;
-  char err_desc[max_desc];
-  strerror_r(errno_save, err_desc, max_desc);
-  printf("Error in Terminal Initialisation Code nr %d with description: %s\n",
-	errno_save, err_desc);
-  printf("c_iflag = %o, c_oflag = %o, c_cflag = %o,\n",
-    otermio.c_iflag, otermio.c_oflag, otermio.c_cflag);
-  printf("c_lflag = %o, c_line = %o, c_cc = {\"\\%o\\%o\\%o\\%o\\%o\\%o\\%o\\%o\"}\n",
-    otermio.c_lflag, otermio.c_line, otermio.c_cc[0], otermio.c_cc[1],
-    otermio.c_cc[2], otermio.c_cc[3], otermio.c_cc[4], otermio.c_cc[5],
-    otermio.c_cc[6], otermio.c_cc[7]);
-  WpeExit(1);
- }
+  ret = tcgetattr (1, &otermio);	/* save old settings */
+  if (ret)
+    {
+      int errno_save = errno;	// save errno before it is overwritten
+      const int max_desc = 1024;
+      char err_desc[max_desc];
+      strerror_r (errno_save, err_desc, max_desc);
+      printf
+	("Error in Terminal Initialisation Code nr %d with description: %s\n",
+	 errno_save, err_desc);
+      printf ("c_iflag = %o, c_oflag = %o, c_cflag = %o,\n", otermio.c_iflag,
+	      otermio.c_oflag, otermio.c_cflag);
+      printf
+	("c_lflag = %o, c_line = %o, c_cc = {\"\\%o\\%o\\%o\\%o\\%o\\%o\\%o\\%o\"}\n",
+	 otermio.c_lflag, otermio.c_line, otermio.c_cc[0], otermio.c_cc[1],
+	 otermio.c_cc[2], otermio.c_cc[3], otermio.c_cc[4], otermio.c_cc[5],
+	 otermio.c_cc[6], otermio.c_cc[7]);
+      WpeExit (1);
+    }
 //#ifndef TERMCAP
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
- if ((stdscr=initscr())==(WINDOW *)ERR) exit(27);
+  if ((stdscr = initscr ()) == (WINDOW *) ERR)
+    exit (27);
 //#ifdef NCURSES
 //#if FALSE
- cbreak();
- noecho();
- nonl();
- intrflush(stdscr,FALSE);
- keypad(stdscr,TRUE);
+  cbreak ();
+  noecho ();
+  nonl ();
+  intrflush (stdscr, FALSE);
+  keypad (stdscr, TRUE);
 //#endif // #if NCURSES i.e. FALSE
- if (has_colors())
- {
-  start_color();
-  for (i = 0; i < COLORS; i++)
-  {
-   for (k = 0; k < COLORS; k++)
-   {
-    if (i != 0 || k != 0)
+  if (has_colors ())
     {
-     init_pair(i * 8 + k, k, i);
+      start_color ();
+      for (i = 0; i < COLORS; i++)
+	{
+	  for (k = 0; k < COLORS; k++)
+	    {
+	      if (i != 0 || k != 0)
+		{
+		  init_pair (i * 8 + k, k, i);
+		}
+	    }
+	}
     }
-   }
-  }
- }
 #endif // #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
- e_begscr();
- schirm = malloc(2 * MAXSCOL * MAXSLNS);
- altschirm = malloc(2 * MAXSCOL * MAXSLNS);
+  e_begscr ();
+  schirm = malloc (2 * MAXSCOL * MAXSLNS);
+  altschirm = malloc (2 * MAXSCOL * MAXSLNS);
 #if !defined(NO_XWINDOWS) && defined(NEWSTYLE)
- extbyte = malloc(MAXSCOL * MAXSLNS);
+  extbyte = malloc (MAXSCOL * MAXSLNS);
 #endif
- e_abs_refr();
- if(init_cursor())
- {
-  printf("Terminal Not in the right mode\n");
-  e_exit(1);
- }
- tcgetattr(0, &ntermio);
- ntermio.c_iflag = 0;            /* setup new settings */
- ntermio.c_oflag = 0;
- ntermio.c_lflag = 0;
- ntermio.c_cc[VMIN] = 1;
- ntermio.c_cc[VTIME] = 0;
+  e_abs_refr ();
+  if (init_cursor ())
+    {
+      printf ("Terminal Not in the right mode\n");
+      e_exit (1);
+    }
+  tcgetattr (0, &ntermio);
+  ntermio.c_iflag = 0;		/* setup new settings */
+  ntermio.c_oflag = 0;
+  ntermio.c_lflag = 0;
+  ntermio.c_cc[VMIN] = 1;
+  ntermio.c_cc[VTIME] = 0;
 #ifdef VSWTCH
- ntermio.c_cc[VSWTCH] = 0;
+  ntermio.c_cc[VSWTCH] = 0;
 #endif
- tcsetattr(0, TCSADRAIN, &ntermio);
+  tcsetattr (0, TCSADRAIN, &ntermio);
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
- if (spc_in) e_putp(spc_in);
+  if (spc_in)
+    e_putp (spc_in);
 #endif
- return(0);
+  return (0);
 }
 
 int svflgs, kbdflgs;
 
-int e_begscr()
+int
+e_begscr ()
 {
- int cols, lns;
+  int cols, lns;
 
- kbdflgs = fcntl( 0, F_GETFL, 0 );
+  kbdflgs = fcntl (0, F_GETFL, 0);
 //#ifndef TERMCAP
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
 //#ifndef NCURSES
 //#if TRUE
 // setupterm((char *)0, 1, (int *)0);
 //#endif
- if ((lns = tigetnum("lines")) > 0)
-  MAXSLNS = lns;
- if ((cols = tigetnum("cols")) > 0)
-  MAXSCOL = cols;
+  if ((lns = tigetnum ("lines")) > 0)
+    MAXSLNS = lns;
+  if ((cols = tigetnum ("cols")) > 0)
+    MAXSCOL = cols;
 #else // #if defined HAVE_LIBNCURSES || define HAVE_LIBCURSES
- if ((tc_screen = getenv("TERM")) == NULL)
-  e_exitm("Environment variable TERM not defined!", 1);
- if ((tgetent(tcbuf, tc_screen)) != 1)
-  e_exitm("Unknown terminal type!", 1);
- if ((lns = tgetnum("li")) > 0)
-  MAXSLNS = lns;
- if ((cols = tgetnum("co")) > 0)
-  MAXSCOL = cols;
+  if ((tc_screen = getenv ("TERM")) == NULL)
+    e_exitm ("Environment variable TERM not defined!", 1);
+  if ((tgetent (tcbuf, tc_screen)) != 1)
+    e_exitm ("Unknown terminal type!", 1);
+  if ((lns = tgetnum ("li")) > 0)
+    MAXSLNS = lns;
+  if ((cols = tgetnum ("co")) > 0)
+    MAXSCOL = cols;
 #endif
- return(0);
+  return (0);
 }
 
 #define fk_putp(p) ( p ? e_putp(p) : e_putp(att_no) )
 
-void e_endwin()
+void
+e_endwin ()
 {
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
- endwin();
+  endwin ();
 #else
- fk_putp(ratt_bo);
+  fk_putp (ratt_bo);
 #endif
- tcsetattr(0, TCSADRAIN, &otermio);
+  tcsetattr (0, TCSADRAIN, &otermio);
 }
 
-int fk_t_cursor(int x)
+int
+fk_t_cursor (int x)
 {
- return(x);
+  return (x);
 }
 
-int fk_t_putchar(int c)
+int
+fk_t_putchar (int c)
 {
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
- addch(c);
- return c;
+  addch (c);
+  return c;
 #else
- return(fputc(c, stdout));
+  return (fputc (c, stdout));
 #endif
 }
 
-int fk_attrset(int a)
+int
+fk_attrset (int a)
 {
- if(cur_attr == a) return(0);
+  if (cur_attr == a)
+    return (0);
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
- switch(a)
- {  case 0:  attrset(A_NORMAL);  break;
-    case 1:  attrset(A_STANDOUT);  break;
-    case 2:  attrset(A_UNDERLINE);  break;
-    case 4:  attrset(A_REVERSE);  break;
-    case 8:  attrset(A_BLINK);  break;
-    case 16:  attrset(A_DIM);  break;
-    case 32:  attrset(A_BOLD);  break;
- }
+  switch (a)
+    {
+    case 0:
+      attrset (A_NORMAL);
+      break;
+    case 1:
+      attrset (A_STANDOUT);
+      break;
+    case 2:
+      attrset (A_UNDERLINE);
+      break;
+    case 4:
+      attrset (A_REVERSE);
+      break;
+    case 8:
+      attrset (A_BLINK);
+      break;
+    case 16:
+      attrset (A_DIM);
+      break;
+    case 32:
+      attrset (A_BOLD);
+      break;
+    }
 #else
- switch(cur_attr)
- {  case 0:  fk_putp(ratt_no);  break;
-    case 1:  fk_putp(ratt_so);  break;
-    case 2:  fk_putp(ratt_ul);  break;
-    case 4:  fk_putp(ratt_rv);  break;
-    case 8:  fk_putp(ratt_bl);  break;
-    case 16:  fk_putp(ratt_dm);  break;
-    case 32:  fk_putp(ratt_bo);  break;
- }
- switch(a)
- {  case 0:  fk_putp(att_no);  break;
-    case 1:  fk_putp(att_so);  break;
-    case 2:  fk_putp(att_ul);  break;
-    case 4:  fk_putp(att_rv);  break;
-    case 8:  fk_putp(att_bl);  break;
-    case 16:  fk_putp(att_dm);  break;
-    case 32:  fk_putp(att_bo);  break;
- }
+  switch (cur_attr)
+    {
+    case 0:
+      fk_putp (ratt_no);
+      break;
+    case 1:
+      fk_putp (ratt_so);
+      break;
+    case 2:
+      fk_putp (ratt_ul);
+      break;
+    case 4:
+      fk_putp (ratt_rv);
+      break;
+    case 8:
+      fk_putp (ratt_bl);
+      break;
+    case 16:
+      fk_putp (ratt_dm);
+      break;
+    case 32:
+      fk_putp (ratt_bo);
+      break;
+    }
+  switch (a)
+    {
+    case 0:
+      fk_putp (att_no);
+      break;
+    case 1:
+      fk_putp (att_so);
+      break;
+    case 2:
+      fk_putp (att_ul);
+      break;
+    case 4:
+      fk_putp (att_rv);
+      break;
+    case 8:
+      fk_putp (att_bl);
+      break;
+    case 16:
+      fk_putp (att_dm);
+      break;
+    case 32:
+      fk_putp (att_bo);
+      break;
+    }
 #endif
- return(cur_attr = a);
+  return (cur_attr = a);
 }
 
-void fk_colset(int c)
+void
+fk_colset (int c)
 {
- int bg;
- if (cur_attr == c) return;
- cur_attr = c;
- bg = c / 16;
+  int bg;
+  if (cur_attr == c)
+    return;
+  cur_attr = c;
+  bg = c / 16;
 //#ifdef TERMCAP
 #if !defined HAVE_LIBNCURSES && !defined HAVE_LIBCURSES
- if ((c %= 16) >= col_num)
- {
-  fk_putp(att_bo);
-  e_putp(tgoto(col_fg, 0, c % col_num));
-  e_putp(tgoto(col_bg, 0, bg));
- }
- else
- {
-  fk_putp(ratt_bo);
-  e_putp(tgoto(col_fg, 0, c));
-  e_putp(tgoto(col_bg, 0, bg));
- }
+  if ((c %= 16) >= col_num)
+    {
+      fk_putp (att_bo);
+      e_putp (tgoto (col_fg, 0, c % col_num));
+      e_putp (tgoto (col_bg, 0, bg));
+    }
+  else
+    {
+      fk_putp (ratt_bo);
+      e_putp (tgoto (col_fg, 0, c));
+      e_putp (tgoto (col_bg, 0, bg));
+    }
 #else // #if !defined HAVE_LIBNCURSES && !defined HAVE_LIBCURSES
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
- if (c & 8)
-  attrset(A_BOLD);
- else
-  attrset(A_NORMAL);
- color_set((bg * 8) + c % 8, NULL);
+  if (c & 8)
+    attrset (A_BOLD);
+  else
+    attrset (A_NORMAL);
+  color_set ((bg * 8) + c % 8, NULL);
 #else // #ifdef NCURSES i.e. FALSE
- if ((c %= 16) >= col_num)
- {
-  fk_putp(att_bo);
-  e_putp(tparm1(col_fg, c % col_num));
-  e_putp(tparm1(col_bg, bg));
- }
- else
- {
-  fk_putp(ratt_bo);
-  e_putp(tparm1(col_fg, c));
-  e_putp(tparm1(col_bg, bg));
- }
+  if ((c %= 16) >= col_num)
+    {
+      fk_putp (att_bo);
+      e_putp (tparm1 (col_fg, c % col_num));
+      e_putp (tparm1 (col_bg, bg));
+    }
+  else
+    {
+      fk_putp (ratt_bo);
+      e_putp (tparm1 (col_fg, c));
+      e_putp (tparm1 (col_bg, bg));
+    }
 #endif // #ifdef NCURSES i.e. FALSE
 #endif // #ifdef TERMCAP : !defined HAVE_LIBNCURSES && !defined HAVE_LIBCURSES
 }
 
-int e_t_refresh()
+int
+e_t_refresh ()
 {
- int x = cur_x, y = cur_y, i, j, c;
- fk_cursor(0);
- for(i = 0; i < MAXSLNS; i++)
-  for(j = 0; j < MAXSCOL; j++)
-  {
-   if (i == MAXSLNS-1 && j == MAXSCOL-1) break;
-   if (*(schirm + 2*MAXSCOL * i + 2 * j) != *(altschirm + 2*MAXSCOL * i + 2 * j) ||
-     *(schirm + 2*MAXSCOL * i + 2 * j + 1) != *(altschirm + 2*MAXSCOL * i + 2 * j + 1) )
-   {
-    if (cur_x != j || cur_y != i)
-     term_move(j, i);
-    if (cur_x < MAXSCOL)
-    {  cur_x = j + 1;  cur_y = i;  }
-    else
-    {  cur_x = 0;  cur_y = i+1;  }
-    if (col_num <= 0)
-     fk_attrset(e_gt_col(j, i));
-    else
-     fk_colset(e_gt_col(j, i));
-    c = e_gt_char(j, i);
+  int x = cur_x, y = cur_y, i, j, c;
+  fk_cursor (0);
+  for (i = 0; i < MAXSLNS; i++)
+    for (j = 0; j < MAXSCOL; j++)
+      {
+	if (i == MAXSLNS - 1 && j == MAXSCOL - 1)
+	  break;
+	if (*(schirm + 2 * MAXSCOL * i + 2 * j) !=
+	    *(altschirm + 2 * MAXSCOL * i + 2 * j)
+	    || *(schirm + 2 * MAXSCOL * i + 2 * j + 1) !=
+	    *(altschirm + 2 * MAXSCOL * i + 2 * j + 1))
+	  {
+	    if (cur_x != j || cur_y != i)
+	      term_move (j, i);
+	    if (cur_x < MAXSCOL)
+	      {
+		cur_x = j + 1;
+		cur_y = i;
+	      }
+	    else
+	      {
+		cur_x = 0;
+		cur_y = i + 1;
+	      }
+	    if (col_num <= 0)
+	      fk_attrset (e_gt_col (j, i));
+	    else
+	      fk_colset (e_gt_col (j, i));
+	    c = e_gt_char (j, i);
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
-    if (c < NSPCHR)
-     addch(sp_chr[c]);
-    else
-     addch(c);
+	    if (c < NSPCHR)
+	      addch (sp_chr[c]);
+	    else
+	      addch (c);
 #else // #ifdef NCURSES : i.e. false
-    if (c < NSPCHR)
-     e_putp(sp_chr[c]);
-    else
-     fputc(c, stdout);
+	    if (c < NSPCHR)
+	      e_putp (sp_chr[c]);
+	    else
+	      fputc (c, stdout);
 #endif
-    *(altschirm + 2*MAXSCOL * i + 2 * j) = *(schirm + 2*MAXSCOL * i + 2 * j);
-    *(altschirm + 2*MAXSCOL * i + 2 * j + 1) = *(schirm + 2*MAXSCOL * i + 2 * j + 1);
-   }
-  }
- fk_cursor(1);
- fk_locate(x, y);
- term_refresh();
- return(0);
+	    *(altschirm + 2 * MAXSCOL * i + 2 * j) =
+	      *(schirm + 2 * MAXSCOL * i + 2 * j);
+	    *(altschirm + 2 * MAXSCOL * i + 2 * j + 1) =
+	      *(schirm + 2 * MAXSCOL * i + 2 * j + 1);
+	  }
+      }
+  fk_cursor (1);
+  fk_locate (x, y);
+  term_refresh ();
+  return (0);
 }
 
-int e_t_sys_ini()
+int
+e_t_sys_ini ()
 {
- e_refresh();
- tcgetattr(0, &ttermio);
- svflgs = fcntl( 0, F_GETFL, 0 );
- e_endwin();
- return(0);
+  e_refresh ();
+  tcgetattr (0, &ttermio);
+  svflgs = fcntl (0, F_GETFL, 0);
+  e_endwin ();
+  return (0);
 }
 
-int e_t_sys_end()
+int
+e_t_sys_end ()
 {
- tcsetattr(0, TCSADRAIN, &ttermio);
- fcntl( 0, F_SETFL, svflgs );
- e_abs_refr();
- fk_locate(0, 0);
- return(0);
+  tcsetattr (0, TCSADRAIN, &ttermio);
+  fcntl (0, F_SETFL, svflgs);
+  e_abs_refr ();
+  fk_locate (0, 0);
+  return (0);
 }
 
-int e_t_kbhit()
+int
+e_t_kbhit ()
 {
- int ret;
- char kbdflgs, c;
+  int ret;
+  char kbdflgs, c;
 
- e_refresh();
- kbdflgs = fcntl(0, F_GETFL, 0 );
- fcntl(0, F_SETFL, kbdflgs | O_NONBLOCK);
- ret = read(0, &c, 1);
- fcntl(0, F_SETFL, kbdflgs & ~O_NONBLOCK);
- return (ret == 1 ? c : 0);
+  e_refresh ();
+  kbdflgs = fcntl (0, F_GETFL, 0);
+  fcntl (0, F_SETFL, kbdflgs | O_NONBLOCK);
+  ret = read (0, &c, 1);
+  fcntl (0, F_SETFL, kbdflgs & ~O_NONBLOCK);
+  return (ret == 1 ? c : 0);
 }
 
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
-int e_t_getch()
+int
+e_t_getch ()
 {
- int c, bk;
+  int c, bk;
 
- e_refresh();
- c = fk_getch();
- if (c > KEY_CODE_YES)
- {
-  switch (c)
-  {
-   case KEY_F(1):  c = F1; break;
-   case KEY_F(2):  c = F2; break;
-   case KEY_F(3):  c = F3; break;
-   case KEY_F(4):  c = F4; break;
-   case KEY_F(5):  c = F5; break;
-   case KEY_F(6):  c = F6; break;
-   case KEY_F(7):  c = F7; break;
-   case KEY_F(8):  c = F8; break;
-   case KEY_F(9):  c = F9; break;
-   case KEY_F(10):  c = F10; break;
-   case KEY_UP:  c = CUP; break;
-   case KEY_DOWN:  c = CDO; break;
-   case KEY_LEFT:  c = CLE; break;
-   case KEY_RIGHT:  c = CRI; break;
-   case KEY_SFIND:  c = EINFG; break;
-   case KEY_IC:  c = POS1; break;
-   case KEY_DC:  c = BUP; break;
-   case KEY_PPAGE:  c = ENDE; break;
-   case KEY_NPAGE:  c = BDO; break;
-   case KEY_BACKSPACE:  c = WPE_DC; break;
-   case KEY_HELP:  c = HELP; break;
-   case KEY_LL:  c = ENDE; break;
-   case KEY_F(17):  c = SF1; break;
-   case KEY_F(18):  c = SF2; break;
-   case KEY_F(19):  c = SF3; break;
-   case KEY_F(20):  c = SF4; break;
-   case KEY_F(21):  c = SF5; break;
-   case KEY_F(22):  c = SF6; break;
-   case KEY_F(23):  c = SF7; break;
-   case KEY_F(24):  c = SF8; break;
-   case KEY_F(25):  c = SF9; break;
-   case KEY_F(26):  c = SF10; break;
-   case KEY_PREVIOUS:  c = CUP+512; break;
-   case KEY_NEXT:  c = CDO+512; break;
-   case KEY_HOME:  c = POS1+512; break;
-   case KEY_END:  c = ENDE+512; break;
-   default:  c = 0; break;
-  }
-  bk = bioskey();
-  if (bk & 3)
-   c += 512;
-  else if (bk & 4)
-   c += 514;
- }
- else if ( c == WPE_TAB )
- {
-  bk = bioskey();
-  if ( bk & 3)
-   c = WPE_BTAB;
-  else
-   c = WPE_TAB;
- }
- else if (c == WPE_ESC)
- {
-  c = fk_getch();
+  e_refresh ();
+  c = fk_getch ();
   if (c > KEY_CODE_YES)
-  {
-   switch (c)
-   {
-    case KEY_F(1):  c = AF1; break;
-    case KEY_F(2):  c = AF2; break;
-    case KEY_F(3):  c = AF3; break;
-    case KEY_F(4):  c = AF4; break;
-    case KEY_F(5):  c = AF5; break;
-    case KEY_F(6):  c = AF6; break;
-    case KEY_F(7):  c = AF7; break;
-    case KEY_F(8):  c = AF8; break;
-    case KEY_F(9):  c = AF9; break;
-    case KEY_F(10):  c = AF10; break;
-    case KEY_UP:  c = BUP; break;
-    case KEY_DOWN:  c = BDO; break;
-    case KEY_LEFT:  c = CCLE; break;
-    case KEY_RIGHT:  c = CCRI; break;
-    case KEY_SFIND:  c = EINFG; break;
-    case KEY_IC:  c = CPS1; break;
-    case KEY_DC:  c = CBUP; break;
-    case KEY_PPAGE:  c = CEND; break;
-    case KEY_NPAGE:  c = CBDO; break;
-    case KEY_BACKSPACE:  c = AltBS; break;
-    case KEY_HELP:  c = AF1; break;
-    case KEY_LL:  c = CEND; break;
-    case KEY_PREVIOUS:  c = BUP+512; break;
-    case KEY_NEXT:  c = BDO+512; break;
-    case KEY_HOME:  c = CPS1+512; break;
-    case KEY_END:  c = CEND+512; break;
-    default:  c = 0; break;
-   }
-   bk = bioskey();
-   if (bk & 3)
-    c += 512;
-   else if (bk & 4)
-    c += 514;
-  }
-  else if (c != WPE_ESC)
-   c = e_tast_sim(c);
- }
- return(c);
+    {
+      switch (c)
+	{
+	case KEY_F (1):
+	  c = F1;
+	  break;
+	case KEY_F (2):
+	  c = F2;
+	  break;
+	case KEY_F (3):
+	  c = F3;
+	  break;
+	case KEY_F (4):
+	  c = F4;
+	  break;
+	case KEY_F (5):
+	  c = F5;
+	  break;
+	case KEY_F (6):
+	  c = F6;
+	  break;
+	case KEY_F (7):
+	  c = F7;
+	  break;
+	case KEY_F (8):
+	  c = F8;
+	  break;
+	case KEY_F (9):
+	  c = F9;
+	  break;
+	case KEY_F (10):
+	  c = F10;
+	  break;
+	case KEY_UP:
+	  c = CUP;
+	  break;
+	case KEY_DOWN:
+	  c = CDO;
+	  break;
+	case KEY_LEFT:
+	  c = CLE;
+	  break;
+	case KEY_RIGHT:
+	  c = CRI;
+	  break;
+	case KEY_SFIND:
+	  c = EINFG;
+	  break;
+	case KEY_IC:
+	  c = POS1;
+	  break;
+	case KEY_DC:
+	  c = BUP;
+	  break;
+	case KEY_PPAGE:
+	  c = ENDE;
+	  break;
+	case KEY_NPAGE:
+	  c = BDO;
+	  break;
+	case KEY_BACKSPACE:
+	  c = WPE_DC;
+	  break;
+	case KEY_HELP:
+	  c = HELP;
+	  break;
+	case KEY_LL:
+	  c = ENDE;
+	  break;
+	case KEY_F (17):
+	  c = SF1;
+	  break;
+	case KEY_F (18):
+	  c = SF2;
+	  break;
+	case KEY_F (19):
+	  c = SF3;
+	  break;
+	case KEY_F (20):
+	  c = SF4;
+	  break;
+	case KEY_F (21):
+	  c = SF5;
+	  break;
+	case KEY_F (22):
+	  c = SF6;
+	  break;
+	case KEY_F (23):
+	  c = SF7;
+	  break;
+	case KEY_F (24):
+	  c = SF8;
+	  break;
+	case KEY_F (25):
+	  c = SF9;
+	  break;
+	case KEY_F (26):
+	  c = SF10;
+	  break;
+	case KEY_PREVIOUS:
+	  c = CUP + 512;
+	  break;
+	case KEY_NEXT:
+	  c = CDO + 512;
+	  break;
+	case KEY_HOME:
+	  c = POS1 + 512;
+	  break;
+	case KEY_END:
+	  c = ENDE + 512;
+	  break;
+	default:
+	  c = 0;
+	  break;
+	}
+      bk = bioskey ();
+      if (bk & 3)
+	c += 512;
+      else if (bk & 4)
+	c += 514;
+    }
+  else if (c == WPE_TAB)
+    {
+      bk = bioskey ();
+      if (bk & 3)
+	c = WPE_BTAB;
+      else
+	c = WPE_TAB;
+    }
+  else if (c == WPE_ESC)
+    {
+      c = fk_getch ();
+      if (c > KEY_CODE_YES)
+	{
+	  switch (c)
+	    {
+	    case KEY_F (1):
+	      c = AF1;
+	      break;
+	    case KEY_F (2):
+	      c = AF2;
+	      break;
+	    case KEY_F (3):
+	      c = AF3;
+	      break;
+	    case KEY_F (4):
+	      c = AF4;
+	      break;
+	    case KEY_F (5):
+	      c = AF5;
+	      break;
+	    case KEY_F (6):
+	      c = AF6;
+	      break;
+	    case KEY_F (7):
+	      c = AF7;
+	      break;
+	    case KEY_F (8):
+	      c = AF8;
+	      break;
+	    case KEY_F (9):
+	      c = AF9;
+	      break;
+	    case KEY_F (10):
+	      c = AF10;
+	      break;
+	    case KEY_UP:
+	      c = BUP;
+	      break;
+	    case KEY_DOWN:
+	      c = BDO;
+	      break;
+	    case KEY_LEFT:
+	      c = CCLE;
+	      break;
+	    case KEY_RIGHT:
+	      c = CCRI;
+	      break;
+	    case KEY_SFIND:
+	      c = EINFG;
+	      break;
+	    case KEY_IC:
+	      c = CPS1;
+	      break;
+	    case KEY_DC:
+	      c = CBUP;
+	      break;
+	    case KEY_PPAGE:
+	      c = CEND;
+	      break;
+	    case KEY_NPAGE:
+	      c = CBDO;
+	      break;
+	    case KEY_BACKSPACE:
+	      c = AltBS;
+	      break;
+	    case KEY_HELP:
+	      c = AF1;
+	      break;
+	    case KEY_LL:
+	      c = CEND;
+	      break;
+	    case KEY_PREVIOUS:
+	      c = BUP + 512;
+	      break;
+	    case KEY_NEXT:
+	      c = BDO + 512;
+	      break;
+	    case KEY_HOME:
+	      c = CPS1 + 512;
+	      break;
+	    case KEY_END:
+	      c = CEND + 512;
+	      break;
+	    default:
+	      c = 0;
+	      break;
+	    }
+	  bk = bioskey ();
+	  if (bk & 3)
+	    c += 512;
+	  else if (bk & 4)
+	    c += 514;
+	}
+      else if (c != WPE_ESC)
+	c = e_tast_sim (c);
+    }
+  return (c);
 }
 
 #else // #ifdef NCURSES : i.e. FALSE
-int e_t_getch()
+int
+e_t_getch ()
 {
- int c, c2, pshift, bk;
+  int c, c2, pshift, bk;
 
- pshift = 0;
- e_refresh();
- if ((c = fk_getch()) != WPE_ESC)
- {
-  if (key_f[20] && c == *key_f[20])
-   return(WPE_DC);
-  else if (key_f[17] && c == *key_f[17])
-   return(ENTF);
-  else if ( c == WPE_TAB )
-  {
-   bk = bioskey();
-   if (bk & 3)
-    return (WPE_BTAB);
-   else
-    return (WPE_TAB);
-  }
-  else
-   return(c);
- }
- else if ((c = fk_getch()) == WPE_CR)
-  return(WPE_ESC);
- bk = bioskey();
- if (bk & 3)
-  pshift = 512;
- else if (bk & 4)
-  pshift = 514;
- if (c == WPE_ESC)
- {
-  if ((c = fk_getch()) == WPE_ESC)
-   return(WPE_ESC);
-  if ((c2 = e_find_key(c, 1, 1)))
-   return(c2 + pshift);
- }
- if ((c2 = e_find_key((char)c, 1, 0)))
-  return(c2 + pshift);
- return(e_tast_sim(c + pshift));
+  pshift = 0;
+  e_refresh ();
+  if ((c = fk_getch ()) != WPE_ESC)
+    {
+      if (key_f[20] && c == *key_f[20])
+	return (WPE_DC);
+      else if (key_f[17] && c == *key_f[17])
+	return (ENTF);
+      else if (c == WPE_TAB)
+	{
+	  bk = bioskey ();
+	  if (bk & 3)
+	    return (WPE_BTAB);
+	  else
+	    return (WPE_TAB);
+	}
+      else
+	return (c);
+    }
+  else if ((c = fk_getch ()) == WPE_CR)
+    return (WPE_ESC);
+  bk = bioskey ();
+  if (bk & 3)
+    pshift = 512;
+  else if (bk & 4)
+    pshift = 514;
+  if (c == WPE_ESC)
+    {
+      if ((c = fk_getch ()) == WPE_ESC)
+	return (WPE_ESC);
+      if ((c2 = e_find_key (c, 1, 1)))
+	return (c2 + pshift);
+    }
+  if ((c2 = e_find_key ((char) c, 1, 0)))
+    return (c2 + pshift);
+  return (e_tast_sim (c + pshift));
 }
 
 char e_key_save[10];
 
-int e_find_key(int c, int j, int sw)
+int
+e_find_key (int c, int j, int sw)
 {
-   int i, k;
-   e_key_save[j] = c;
-   e_key_save[j+1] = '\0';
-   for(i = 0; i < KEYFN; i++)
-   {  if(key_f[i] == NULL) continue;
-      for(k = 1; k <= j && e_key_save[k] == *(key_f[i] + k); k++);
-      if(k > j)
-      {  if(*(key_f[i] + k) != '\0') return(e_find_key(fk_getch(), j+1, sw));
-	 else if(sw)
-	 {  switch(i)
-	    {  case 0:  return(AF1);
-	       case 1:  return(AF2);
-	       case 2:  return(AF3);
-	       case 3:  return(AF4);
-	       case 4:  return(AF5);
-	       case 5:  return(AF6);
-	       case 6:  return(AF7);
-	       case 7:  return(AF8);
-	       case 8:  return(AF9);
-	       case 9:  return(AF10);
-	       case 10:  return(BUP);
-	       case 11:  return(BDO);
-	       case 12:  return(CCLE);
-	       case 13:  return(CCRI);
-	       case 14:  return(EINFG);
-	       case 15:  return(CPS1);
-	       case 16:  return(CBUP);
-	       case 17:  return(ENTF);
-	       case 18:  return(CEND);
-	       case 19:  return(CBDO);
-	       case 20:  return(AltBS);
-	       case 21:  return(AF1);
-	       case 22:  return(CEND);
-	       case 33:  return(BUP+512);
-	       case 34:  return(BDO+512);
-	       case 35:  return(CCLE+512);
-	       case 36:  return(CCRI+512);
-	       case 37:  return(CPS1+512);
-	       case 38:  return(CBUP+512);
-	       case 39:  return(CEND+512);
-	       case 40:  return(CBDO+512);
-	       case 41:  return(CEND);
-	       default:  return(0);
+  int i, k;
+  e_key_save[j] = c;
+  e_key_save[j + 1] = '\0';
+  for (i = 0; i < KEYFN; i++)
+    {
+      if (key_f[i] == NULL)
+	continue;
+      for (k = 1; k <= j && e_key_save[k] == *(key_f[i] + k); k++);
+      if (k > j)
+	{
+	  if (*(key_f[i] + k) != '\0')
+	    return (e_find_key (fk_getch (), j + 1, sw));
+	  else if (sw)
+	    {
+	      switch (i)
+		{
+		case 0:
+		  return (AF1);
+		case 1:
+		  return (AF2);
+		case 2:
+		  return (AF3);
+		case 3:
+		  return (AF4);
+		case 4:
+		  return (AF5);
+		case 5:
+		  return (AF6);
+		case 6:
+		  return (AF7);
+		case 7:
+		  return (AF8);
+		case 8:
+		  return (AF9);
+		case 9:
+		  return (AF10);
+		case 10:
+		  return (BUP);
+		case 11:
+		  return (BDO);
+		case 12:
+		  return (CCLE);
+		case 13:
+		  return (CCRI);
+		case 14:
+		  return (EINFG);
+		case 15:
+		  return (CPS1);
+		case 16:
+		  return (CBUP);
+		case 17:
+		  return (ENTF);
+		case 18:
+		  return (CEND);
+		case 19:
+		  return (CBDO);
+		case 20:
+		  return (AltBS);
+		case 21:
+		  return (AF1);
+		case 22:
+		  return (CEND);
+		case 33:
+		  return (BUP + 512);
+		case 34:
+		  return (BDO + 512);
+		case 35:
+		  return (CCLE + 512);
+		case 36:
+		  return (CCRI + 512);
+		case 37:
+		  return (CPS1 + 512);
+		case 38:
+		  return (CBUP + 512);
+		case 39:
+		  return (CEND + 512);
+		case 40:
+		  return (CBDO + 512);
+		case 41:
+		  return (CEND);
+		default:
+		  return (0);
+		}
 	    }
-	 }
-	 else
-	 {  switch(i)
-	    {  case 0:  return(F1);
-	       case 1:  return(F2);
-	       case 2:  return(F3);
-	       case 3:  return(F4);
-	       case 4:  return(F5);
-	       case 5:  return(F6);
-	       case 6:  return(F7);
-	       case 7:  return(F8);
-	       case 8:  return(F9);
-	       case 9:  return(F10);
-	       case 10:  return(CUP);
-	       case 11:  return(CDO);
-	       case 12:  return(CLE);
-	       case 13:  return(CRI);
-	       case 14:  return(EINFG);
-	       case 15:  return(POS1);
-	       case 16:  return(BUP);
-	       case 17:  return(ENTF);
-	       case 18:  return(ENDE);
-	       case 19:  return(BDO);
-	       case 20:  return(WPE_DC);
-	       case 21:  return(HELP);
-	       case 22:  return(ENDE);
-	       case 23:  return(SF1);
-	       case 24:  return(SF2);
-	       case 25:  return(SF3);
-	       case 26:  return(SF4);
-	       case 27:  return(SF5);
-	       case 28:  return(SF6);
-	       case 29:  return(SF7);
-	       case 30:  return(SF8);
-	       case 31:  return(SF9);
-	       case 32:  return(SF10);
-	       case 33:  return(CUP+512);
-	       case 34:  return(CDO+512);
-	       case 35:  return(CLE+512);
-	       case 36:  return(CRI+512);
-	       case 37:  return(POS1+512);
-	       case 38:  return(BUP+512);
-	       case 39:  return(ENDE+512);
-	       case 40:  return(BDO+512);
-	       case 41:  return(ENDE);
-	       default:  return(0);
+	  else
+	    {
+	      switch (i)
+		{
+		case 0:
+		  return (F1);
+		case 1:
+		  return (F2);
+		case 2:
+		  return (F3);
+		case 3:
+		  return (F4);
+		case 4:
+		  return (F5);
+		case 5:
+		  return (F6);
+		case 6:
+		  return (F7);
+		case 7:
+		  return (F8);
+		case 8:
+		  return (F9);
+		case 9:
+		  return (F10);
+		case 10:
+		  return (CUP);
+		case 11:
+		  return (CDO);
+		case 12:
+		  return (CLE);
+		case 13:
+		  return (CRI);
+		case 14:
+		  return (EINFG);
+		case 15:
+		  return (POS1);
+		case 16:
+		  return (BUP);
+		case 17:
+		  return (ENTF);
+		case 18:
+		  return (ENDE);
+		case 19:
+		  return (BDO);
+		case 20:
+		  return (WPE_DC);
+		case 21:
+		  return (HELP);
+		case 22:
+		  return (ENDE);
+		case 23:
+		  return (SF1);
+		case 24:
+		  return (SF2);
+		case 25:
+		  return (SF3);
+		case 26:
+		  return (SF4);
+		case 27:
+		  return (SF5);
+		case 28:
+		  return (SF6);
+		case 29:
+		  return (SF7);
+		case 30:
+		  return (SF8);
+		case 31:
+		  return (SF9);
+		case 32:
+		  return (SF10);
+		case 33:
+		  return (CUP + 512);
+		case 34:
+		  return (CDO + 512);
+		case 35:
+		  return (CLE + 512);
+		case 36:
+		  return (CRI + 512);
+		case 37:
+		  return (POS1 + 512);
+		case 38:
+		  return (BUP + 512);
+		case 39:
+		  return (ENDE + 512);
+		case 40:
+		  return (BDO + 512);
+		case 41:
+		  return (ENDE);
+		default:
+		  return (0);
+		}
 	    }
-	 }
-      }
-   }
-   return(0);
+	}
+    }
+  return (0);
 }
 #endif // #ifdef NCURSES i.e. FALSE
 
-int fk_t_locate(int x, int y)
+int
+fk_t_locate (int x, int y)
 {
- if (col_num > 0)
- {
-  fk_colset(e_gt_col(cur_x, cur_y));
+  if (col_num > 0)
+    {
+      fk_colset (e_gt_col (cur_x, cur_y));
 //#ifdef NCURSES
 #if defined(HAVE_LIBNCURSES) || defined(HAVE_LIBCURSES)
-  /* Causes problems.  Reason unknown. - Dennis */
-  /*mvaddch(cur_y,cur_x,e_gt_char(cur_x, cur_y));*/
+      /* Causes problems.  Reason unknown. - Dennis */
+      /*mvaddch(cur_y,cur_x,e_gt_char(cur_x, cur_y)); */
 #else
-  fputc(e_gt_char(cur_x, cur_y), stdout);
+      fputc (e_gt_char (cur_x, cur_y), stdout);
 #endif
- }
- cur_x = x;
- cur_y = y;
- term_move(x, y);
- return(y);
+    }
+  cur_x = x;
+  cur_y = y;
+  term_move (x, y);
+  return (y);
 }
 
-int fk_t_mouse(int *g)
+int
+fk_t_mouse (int *g)
 {
- UNUSED(g);
- return(0);
+  UNUSED (g);
+  return (0);
 }
 
-int e_t_switch_screen(int sw)
+int
+e_t_switch_screen (int sw)
 {
- static int sav_sw = -1;
+  static int sav_sw = -1;
 
- if (sw == sav_sw)
-  return(0);
- sav_sw = sw;
- if (sw && beg_scr)
- {
-  term_refresh();
+  if (sw == sav_sw)
+    return (0);
+  sav_sw = sw;
+  if (sw && beg_scr)
+    {
+      term_refresh ();
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
-  if (sav_cur)
-   e_putp(sav_cur);
-  e_putp(beg_scr);
+      if (sav_cur)
+	e_putp (sav_cur);
+      e_putp (beg_scr);
 #endif
- }
- else if (!sw && swt_scr)
- {
+    }
+  else if (!sw && swt_scr)
+    {
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
-  e_putp(swt_scr);
-  if (res_cur)
-   e_putp(res_cur);
+      e_putp (swt_scr);
+      if (res_cur)
+	e_putp (res_cur);
 #endif
-  term_refresh();
- }
- else
-  return(-1);
- return(0);
+      term_refresh ();
+    }
+  else
+    return (-1);
+  return (0);
 }
 
-int e_t_deb_out(FENSTER *f)
+int
+e_t_deb_out (FENSTER * f)
 {
 //#ifndef NCURSES
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
- if (!swt_scr || !beg_scr)
+  if (!swt_scr || !beg_scr)
 #endif
-  return(e_error("Your terminal don\'t use begin/end cup", 0, f->fb));
- e_d_switch_out(1);
- getchar();
- e_d_switch_out(0);
- return(0);
+    return (e_error ("Your terminal don\'t use begin/end cup", 0, f->fb));
+  e_d_switch_out (1);
+  getchar ();
+  e_d_switch_out (0);
+  return (0);
 }
 
-int e_d_switch_screen(int sw)
+int
+e_d_switch_screen (int sw)
 {
 #ifdef DEBUGGER
- if (!sw)
-  e_g_sys_ini();
- else
-  e_g_sys_end();
+  if (!sw)
+    e_g_sys_ini ();
+  else
+    e_g_sys_end ();
 #endif
-  return((*e_u_switch_screen)(sw));
+  return ((*e_u_switch_screen) (sw));
 }
 
-int e_t_d_switch_out(int sw)
+int
+e_t_d_switch_out (int sw)
 {
- int i, j;
- static int save_sw = 32000;
+  int i, j;
+  static int save_sw = 32000;
 
- if (save_sw == sw)
-  return(0);
- save_sw = sw;
- if (sw && e_d_switch_screen(0))
- {
-  term_move(0, 0);
+  if (save_sw == sw)
+    return (0);
+  save_sw = sw;
+  if (sw && e_d_switch_screen (0))
+    {
+      term_move (0, 0);
 #if !defined(HAVE_LIBNCURSES) && !defined(HAVE_LIBCURSES)
-  e_putp(att_no);
+      e_putp (att_no);
 #endif
-  for(i = 0; i < MAXSLNS; i++)
-   for (j = 0; j < MAXSCOL; j++)
-    e_d_putchar(' ');
-  term_move(0, 0);
-  term_refresh();
- }
- else if (!sw)
- {
-  e_d_switch_screen(1);
-  e_abs_refr();
-  e_refresh();
- }
- return(sw);
+      for (i = 0; i < MAXSLNS; i++)
+	for (j = 0; j < MAXSCOL; j++)
+	  e_d_putchar (' ');
+      term_move (0, 0);
+      term_refresh ();
+    }
+  else if (!sw)
+    {
+      e_d_switch_screen (1);
+      e_abs_refr ();
+      e_refresh ();
+    }
+  return (sw);
 }
 
-void e_exitm(char *s, int n)
+void
+e_exitm (char *s, int n)
 {
- e_endwin();
- if (n != 0)
-  printf("\n%s\n", s);
- exit(n);
+  e_endwin ();
+  if (n != 0)
+    printf ("\n%s\n", s);
+  exit (n);
 }
 
-int e_s_sys_ini()
+int
+e_s_sys_ini ()
 {
- (*e_u_sys_ini)();
-  return((*e_u_switch_screen)(0));
+  (*e_u_sys_ini) ();
+  return ((*e_u_switch_screen) (0));
 }
 
-int e_s_sys_end()
+int
+e_s_sys_end ()
 {
- (*e_u_switch_screen)(1);
- return((*e_u_sys_end)());
+  (*e_u_switch_screen) (1);
+  return ((*e_u_sys_end) ());
 }
 
-#endif  /*  Is UNIX       */
-
+#endif /*  Is UNIX       */

--- a/src/we_unix.c
+++ b/src/we_unix.c
@@ -11,14 +11,14 @@
 #include "options.h"
 
 #ifdef UNIX
-# include <unistd.h>
+#include <unistd.h>
 #endif
 
 #ifdef XWPE_DLL
 #include <dlfcn.h>
 #else
-int WpeXtermInit(int *argc, char **argv);
-int WpeTermInit(int *argc, char **argv);
+int WpeXtermInit (int *argc, char **argv);
+int WpeTermInit (int *argc, char **argv);
 #endif
 
 #include <termios.h>
@@ -30,7 +30,7 @@ int WpeTermInit(int *argc, char **argv);
 #include <locale.h>
 //#ifndef TERMCAP
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
-#  include<curses.h>
+#include<curses.h>
 #endif
 
 #include "edit.h"		/*   exchange for D.S.  */
@@ -39,51 +39,52 @@ int WpeTermInit(int *argc, char **argv);
 #include "we_progn.h"
 
 #ifndef HAVE_SYMLINK
-#  define lstat(x,y)  stat(x,y)
-#  undef S_ISLNK
-#  define S_ISLNK(x)  0
+#define lstat(x,y)  stat(x,y)
+#undef S_ISLNK
+#define S_ISLNK(x)  0
 #endif
 
 
 char *schirm = NULL;
 char e_we_sw = 0;
 
-void WpeSignalUnknown(int sig);
-void WpeSignalChild(int sig);
+void WpeSignalUnknown (int sig);
+void WpeSignalChild (int sig);
 
-void (*WpeMouseChangeShape)(WpeMouseShape new_shape);
-void (*WpeMouseRestoreShape)(void);
-void (*WpeDisplayEnd)(void);
-int (*fk_u_locate)(int x, int y);
-int (*fk_u_cursor)(int x);
-int (*e_u_initscr)(int argc, char *argv[]);
-int (*fk_u_putchar)(int c);
-int (*u_bioskey)(void);
-int (*e_frb_u_menue)(int sw, int xa, int ya, FENSTER *f, int md);
-COLOR (*e_s_u_clr)(int f, int b);
-COLOR (*e_n_u_clr)(int fb);
-void (*e_pr_u_col_kasten)(int xa, int ya, int x, int y, FENSTER *f, int sw);
-int (*fk_mouse)(int g[]);
-int (*e_u_refresh)(void);
-int (*e_u_getch)(void);
-int (*e_u_sys_ini)(void);
-int (*e_u_sys_end)(void);
-int (*e_u_system)(const char *exe);
-int (*e_make_urect)(int xa, int ya, int xe, int ye, int sw);
-int (*e_make_urect_abs)(int xa, int ya, int xe, int ye, int sw);
-int (*e_u_d_switch_out)(int sw);
-int (*e_u_switch_screen)(int sw);
-int (*e_u_deb_out)(struct FNST *f);
-int (*e_u_cp_X_to_buffer)(struct FNST *f);
-int (*e_u_copy_X_buffer)(struct FNST *f);
-int (*e_u_paste_X_buffer)(struct FNST *f);
-int (*e_u_kbhit)(void);
-int (*e_u_change)(view *pic);
-int (*e_u_ini_size)(void);
-int (*e_get_pic_urect)(int xa, int ya, int xe, int ye, struct view_struct *pic);
-int (*e_u_s_sys_end)(void);
-int (*e_u_s_sys_ini)(void);
-void (*e_u_setlastpic)(view *pic);
+void (*WpeMouseChangeShape) (WpeMouseShape new_shape);
+void (*WpeMouseRestoreShape) (void);
+void (*WpeDisplayEnd) (void);
+int (*fk_u_locate) (int x, int y);
+int (*fk_u_cursor) (int x);
+int (*e_u_initscr) (int argc, char *argv[]);
+int (*fk_u_putchar) (int c);
+int (*u_bioskey) (void);
+int (*e_frb_u_menue) (int sw, int xa, int ya, FENSTER * f, int md);
+COLOR (*e_s_u_clr) (int f, int b);
+COLOR (*e_n_u_clr) (int fb);
+void (*e_pr_u_col_kasten) (int xa, int ya, int x, int y, FENSTER * f, int sw);
+int (*fk_mouse) (int g[]);
+int (*e_u_refresh) (void);
+int (*e_u_getch) (void);
+int (*e_u_sys_ini) (void);
+int (*e_u_sys_end) (void);
+int (*e_u_system) (const char *exe);
+int (*e_make_urect) (int xa, int ya, int xe, int ye, int sw);
+int (*e_make_urect_abs) (int xa, int ya, int xe, int ye, int sw);
+int (*e_u_d_switch_out) (int sw);
+int (*e_u_switch_screen) (int sw);
+int (*e_u_deb_out) (struct FNST * f);
+int (*e_u_cp_X_to_buffer) (struct FNST * f);
+int (*e_u_copy_X_buffer) (struct FNST * f);
+int (*e_u_paste_X_buffer) (struct FNST * f);
+int (*e_u_kbhit) (void);
+int (*e_u_change) (view * pic);
+int (*e_u_ini_size) (void);
+int (*e_get_pic_urect) (int xa, int ya, int xe, int ye,
+			struct view_struct * pic);
+int (*e_u_s_sys_end) (void);
+int (*e_u_s_sys_ini) (void);
+void (*e_u_setlastpic) (view * pic);
 
 FARBE *u_fb, *x_fb;
 
@@ -107,696 +108,825 @@ char *extbyte = NULL, *altextbyte = NULL;
 char *altschirm = NULL;
 view *e_X_l_pic = NULL;
 
-void WpeNullFunction(void)
+void
+WpeNullFunction (void)
 {
 }
 
-int WpeZeroFunction(void)
+int
+WpeZeroFunction (void)
 {
- return(0);
+  return (0);
 }
 
-int e_ini_unix(int *argc, char **argv)
+int
+e_ini_unix (int *argc, char **argv)
 {
- extern OPT opt[];
- int i, debug;
- struct sigaction act;
+  extern OPT opt[];
+  int i, debug;
+  struct sigaction act;
 #ifdef XWPE_DLL
- int (*initfunc)(int *argc, char **argv);
+  int (*initfunc) (int *argc, char **argv);
 #endif
 
- setlocale(LC_ALL, "");
- u_fb = NULL;
- x_fb = NULL;
- debug = 0;
- for (i = 1; i < *argc; i++)
- {
-  if (strcmp("--debug", argv[i]) == 0)
-  {
-   debug = 1;
-  }
- }
- for (i = strlen(argv[0])-1; i >= 0 && *(argv[0] + i) != DIRC; i--)
-  ;
+  setlocale (LC_ALL, "");
+  u_fb = NULL;
+  x_fb = NULL;
+  debug = 0;
+  for (i = 1; i < *argc; i++)
+    {
+      if (strcmp ("--debug", argv[i]) == 0)
+	{
+	  debug = 1;
+	}
+    }
+  for (i = strlen (argv[0]) - 1; i >= 0 && *(argv[0] + i) != DIRC; i--)
+    ;
 #ifndef NO_XWINDOWS
- if (*(argv[0]+i+1) == 'x')
-  e_we_sw = 1;
- else
-  e_we_sw = 0;
+  if (*(argv[0] + i + 1) == 'x')
+    e_we_sw = 1;
+  else
+    e_we_sw = 0;
 #endif
 #ifdef PROG
- if (!strncmp("wpe", (argv[0] + i + e_we_sw + 1), 3))
-  e_we_sw |= 2;
+  if (!strncmp ("wpe", (argv[0] + i + e_we_sw + 1), 3))
+    e_we_sw |= 2;
 #endif
 #ifdef XWPE_DLL
- if (WpeIsXwin())
- {
-  libxwpe = dlopen(LIBRARY_DIR"/libxwpe-x11.so", RTLD_NOW);
- }
- else
- {
-  libxwpe = dlopen(LIBRARY_DIR"/libxwpe-term.so",RTLD_NOW);
- }
- if (!libxwpe)
- {
-  printf("%s\n", dlerror());
-  exit(0);
- }
- initfunc = dlsym(libxwpe, "WpeDllInit");
- if (initfunc)
- {
-  (*initfunc)(argc, argv);
- }
- else
- {
-  printf("%s\n", dlerror());
-  exit(0);
- }
+  if (WpeIsXwin ())
+    {
+      libxwpe = dlopen (LIBRARY_DIR "/libxwpe-x11.so", RTLD_NOW);
+    }
+  else
+    {
+      libxwpe = dlopen (LIBRARY_DIR "/libxwpe-term.so", RTLD_NOW);
+    }
+  if (!libxwpe)
+    {
+      printf ("%s\n", dlerror ());
+      exit (0);
+    }
+  initfunc = dlsym (libxwpe, "WpeDllInit");
+  if (initfunc)
+    {
+      (*initfunc) (argc, argv);
+    }
+  else
+    {
+      printf ("%s\n", dlerror ());
+      exit (0);
+    }
 #else
 #ifndef NO_XWINDOWS
- if (WpeIsXwin())
- {
-  WpeXtermInit(argc, argv);
- }
- else
+  if (WpeIsXwin ())
+    {
+      WpeXtermInit (argc, argv);
+    }
+  else
 #endif
- {
-  WpeTermInit(argc, argv);
- }
+    {
+      WpeTermInit (argc, argv);
+    }
 #endif
- if (WpeIsProg())
- {
+  if (WpeIsProg ())
+    {
 #ifndef DEBUGGER
-  opt[0].x = 2, opt[1].x = 7, opt[2].x = 14; opt[3].x = 21; opt[4].x = 30;
-  opt[9].t = opt[7].t; opt[9].x = 74; opt[9].s = opt[7].s; opt[9].as = opt[7].as;
-  opt[8].t = opt[6].t; opt[8].x = 65; opt[8].s = opt[6].s; opt[8].as = opt[6].as;
-  opt[7].t = opt[5].t; opt[7].x = 55; opt[7].s = opt[5].s; opt[7].as = opt[5].as;
-  opt[6].t = "Project"; opt[6].x = 45; opt[6].s = 'P'; opt[6].as = AltP;
-  opt[5].t = "Run"; opt[5].x = 38; opt[5].s = 'R'; opt[5].as = AltR;
-  MENOPT = 10;
-  e_mn_men = 2;
+      opt[0].x = 2, opt[1].x = 7, opt[2].x = 14;
+      opt[3].x = 21;
+      opt[4].x = 30;
+      opt[9].t = opt[7].t;
+      opt[9].x = 74;
+      opt[9].s = opt[7].s;
+      opt[9].as = opt[7].as;
+      opt[8].t = opt[6].t;
+      opt[8].x = 65;
+      opt[8].s = opt[6].s;
+      opt[8].as = opt[6].as;
+      opt[7].t = opt[5].t;
+      opt[7].x = 55;
+      opt[7].s = opt[5].s;
+      opt[7].as = opt[5].as;
+      opt[6].t = "Project";
+      opt[6].x = 45;
+      opt[6].s = 'P';
+      opt[6].as = AltP;
+      opt[5].t = "Run";
+      opt[5].x = 38;
+      opt[5].s = 'R';
+      opt[5].as = AltR;
+      MENOPT = 10;
+      e_mn_men = 2;
 #else
-  opt[0].x = 2, opt[1].x = 6, opt[2].x = 12; opt[3].x = 18; opt[4].x = 26;
-  opt[10].t = opt[7].t; opt[10].x = 74; opt[10].s = opt[7].s; opt[10].as = opt[7].as;
-  opt[9].t = opt[6].t; opt[9].x = 65; opt[9].s = opt[6].s; opt[9].as = opt[6].as;
-  opt[8].t = opt[5].t; opt[8].x = 56; opt[8].s = opt[5].s; opt[8].as = opt[5].as;
-  opt[7].t = "Project"; opt[7].x = 47; opt[7].s = 'P'; opt[7].as = AltP;
-  opt[6].t = "Debug"; opt[6].x = 40; opt[6].s = 'D'; opt[6].as = AltD;
-  opt[5].t = "Run"; opt[5].x = 34; opt[5].s = 'R'; opt[5].as = AltR;
-  MENOPT = 11;
-  e_mn_men = 1;
+      opt[0].x = 2, opt[1].x = 6, opt[2].x = 12;
+      opt[3].x = 18;
+      opt[4].x = 26;
+      opt[10].t = opt[7].t;
+      opt[10].x = 74;
+      opt[10].s = opt[7].s;
+      opt[10].as = opt[7].as;
+      opt[9].t = opt[6].t;
+      opt[9].x = 65;
+      opt[9].s = opt[6].s;
+      opt[9].as = opt[6].as;
+      opt[8].t = opt[5].t;
+      opt[8].x = 56;
+      opt[8].s = opt[5].s;
+      opt[8].as = opt[5].as;
+      opt[7].t = "Project";
+      opt[7].x = 47;
+      opt[7].s = 'P';
+      opt[7].as = AltP;
+      opt[6].t = "Debug";
+      opt[6].x = 40;
+      opt[6].s = 'D';
+      opt[6].as = AltD;
+      opt[5].t = "Run";
+      opt[5].x = 34;
+      opt[5].s = 'R';
+      opt[5].as = AltR;
+      MENOPT = 11;
+      e_mn_men = 1;
 #endif
- }
+    }
 
- /* Unknown error signal handling */
- act.sa_handler = WpeSignalUnknown;
- sigfillset(&act.sa_mask); /* Mask all signals while running */
- act.sa_flags = 0;
- if (!debug)
- {
-  sigaction(SIGQUIT, &act, NULL);
-  sigaction(SIGILL, &act, NULL);
-  sigaction(SIGABRT, &act, NULL);
-  sigaction(SIGFPE, &act, NULL);
-  sigaction(SIGSEGV, &act, NULL);
+  /* Unknown error signal handling */
+  act.sa_handler = WpeSignalUnknown;
+  sigfillset (&act.sa_mask);	/* Mask all signals while running */
+  act.sa_flags = 0;
+  if (!debug)
+    {
+      sigaction (SIGQUIT, &act, NULL);
+      sigaction (SIGILL, &act, NULL);
+      sigaction (SIGABRT, &act, NULL);
+      sigaction (SIGFPE, &act, NULL);
+      sigaction (SIGSEGV, &act, NULL);
 #ifdef SIGTRAP
-  sigaction(SIGTRAP, &act, NULL);
+      sigaction (SIGTRAP, &act, NULL);
 #endif
 #ifdef SIGIOT
-  sigaction(SIGIOT, &act, NULL);
+      sigaction (SIGIOT, &act, NULL);
 #endif
 #ifdef SIGBUS
-  sigaction(SIGBUS, &act, NULL);
+      sigaction (SIGBUS, &act, NULL);
 #endif
- }
- /* Ignore SIGINT */
- act.sa_handler = SIG_IGN;
- sigaction(SIGINT, &act, NULL);
- /* Catch SIGCHLD */
- act.sa_handler = WpeSignalChild;
- act.sa_flags = SA_NOCLDSTOP;
- sigaction(SIGCHLD, &act, NULL);
- return(*argc);
+    }
+  /* Ignore SIGINT */
+  act.sa_handler = SIG_IGN;
+  sigaction (SIGINT, &act, NULL);
+  /* Catch SIGCHLD */
+  act.sa_handler = WpeSignalChild;
+  act.sa_flags = SA_NOCLDSTOP;
+  sigaction (SIGCHLD, &act, NULL);
+  return (*argc);
 }
 
-int e_abs_refr()
+int
+e_abs_refr ()
 {
- extern char *altschirm;
- int i;
+  extern char *altschirm;
+  int i;
 
- for(i = 0; i < 2 * MAXSCOL * MAXSLNS; i++)
-  altschirm[i] = 0;
- return(0);
+  for (i = 0; i < 2 * MAXSCOL * MAXSLNS; i++)
+    altschirm[i] = 0;
+  return (0);
 }
 
-void e_refresh_area(int x, int y, int width, int height)
+void
+e_refresh_area (int x, int y, int width, int height)
 {
- extern char *altschirm;
- char *curloc;
- int i,j;
+  extern char *altschirm;
+  char *curloc;
+  int i, j;
 
- if (width + x > MAXSCOL)
- {
-  width = MAXSCOL - x;
- }
- if (height + y > MAXSLNS)
- {
-  height = MAXSLNS - y;
- }
- curloc = altschirm + ((x + (y * MAXSCOL)) * 2);
- for (j = 0; j < height; j++, curloc += MAXSCOL * 2)
- {
-  for (i = 0; i < width; i ++)
-  {
-   curloc[i * 2] = 0;
-   curloc[i * 2 + 1] = 0;
-  }
- }
+  if (width + x > MAXSCOL)
+    {
+      width = MAXSCOL - x;
+    }
+  if (height + y > MAXSLNS)
+    {
+      height = MAXSLNS - y;
+    }
+  curloc = altschirm + ((x + (y * MAXSCOL)) * 2);
+  for (j = 0; j < height; j++, curloc += MAXSCOL * 2)
+    {
+      for (i = 0; i < width; i++)
+	{
+	  curloc[i * 2] = 0;
+	  curloc[i * 2 + 1] = 0;
+	}
+    }
 }
 
-int e_tast_sim(int c)
+int
+e_tast_sim (int c)
 {
- if (c >= 'A' && c <= 'Z')
-  return(c + 1024 - 'A');
- switch(c)
- {
-  case 'a':  return(AltA);
-  case 'b':  return(AltB);
-  case 'c':  return(AltC);
-  case 'd':  return(AltD);
-  case 'e':  return(AltE);
-  case 'f':  return(AltF);
-  case 'g':  return(AltG);
-  case 'h':  return(AltH);
-  case 'i':  return(AltI);
-  case 'j':  return(AltJ);
-  case 'k':  return(AltK);
-  case 'l':  return(AltL);
-  case 'm':  return(AltM);
-  case 'n':  return(AltN);
-  case 'o':  return(AltO);
-  case 'p':  return(AltP);
-  case 'q':  return(AltQ);
-  case 'r':  return(AltR);
-  case 's':  return(AltS);
-  case 't':  return(AltT);
-  case 'u':  return(AltU);
-  case 'v':  return(AltV);
-  case 'w':  return(AltW);
-  case 'x':  return(AltX);
-  case 'y':  return(AltY);
-  case 'z':  return(AltZ);
-  case '1':  return(Alt1);
-  case '2':  return(Alt2);
-  case '3':  return(Alt3);
-  case '4':  return(Alt4);
-  case '5':  return(Alt5);
-  case '6':  return(Alt6);
-  case '7':  return(Alt7);
-  case '8':  return(Alt8);
-  case '9':  return(Alt9);
-  case '0':  return(Alt0);
-  case ' ':  return(AltBl);
-  case '#':  return(AltSYS);
-  case CtrlA:  return(CBUP);
-  case CtrlE:  return(CBDO);
-  case CtrlB:  return(CCLE);
-  case CtrlF:  return(CCRI);
-  case CtrlP:  return(CPS1);
-  case CtrlN:  return(CEND);
-  case CtrlH:  return(AltBS);
-  default:  return(0);
- }
+  if (c >= 'A' && c <= 'Z')
+    return (c + 1024 - 'A');
+  switch (c)
+    {
+    case 'a':
+      return (AltA);
+    case 'b':
+      return (AltB);
+    case 'c':
+      return (AltC);
+    case 'd':
+      return (AltD);
+    case 'e':
+      return (AltE);
+    case 'f':
+      return (AltF);
+    case 'g':
+      return (AltG);
+    case 'h':
+      return (AltH);
+    case 'i':
+      return (AltI);
+    case 'j':
+      return (AltJ);
+    case 'k':
+      return (AltK);
+    case 'l':
+      return (AltL);
+    case 'm':
+      return (AltM);
+    case 'n':
+      return (AltN);
+    case 'o':
+      return (AltO);
+    case 'p':
+      return (AltP);
+    case 'q':
+      return (AltQ);
+    case 'r':
+      return (AltR);
+    case 's':
+      return (AltS);
+    case 't':
+      return (AltT);
+    case 'u':
+      return (AltU);
+    case 'v':
+      return (AltV);
+    case 'w':
+      return (AltW);
+    case 'x':
+      return (AltX);
+    case 'y':
+      return (AltY);
+    case 'z':
+      return (AltZ);
+    case '1':
+      return (Alt1);
+    case '2':
+      return (Alt2);
+    case '3':
+      return (Alt3);
+    case '4':
+      return (Alt4);
+    case '5':
+      return (Alt5);
+    case '6':
+      return (Alt6);
+    case '7':
+      return (Alt7);
+    case '8':
+      return (Alt8);
+    case '9':
+      return (Alt9);
+    case '0':
+      return (Alt0);
+    case ' ':
+      return (AltBl);
+    case '#':
+      return (AltSYS);
+    case CtrlA:
+      return (CBUP);
+    case CtrlE:
+      return (CBDO);
+    case CtrlB:
+      return (CCLE);
+    case CtrlF:
+      return (CCRI);
+    case CtrlP:
+      return (CPS1);
+    case CtrlN:
+      return (CEND);
+    case CtrlH:
+      return (AltBS);
+    default:
+      return (0);
+    }
 }
 
-void WpeSignalUnknown(int sig)
+void
+WpeSignalUnknown (int sig)
 {
 /*    psignal(sig, "Xwpe");   */
- printf("Xwpe: unexpected signal %d, exiting ...\n", sig);
- e_exit(1);
+  printf ("Xwpe: unexpected signal %d, exiting ...\n", sig);
+  e_exit (1);
 }
 
-void WpeSignalChild(int sig)
+void
+WpeSignalChild (int sig)
 {
- UNUSED(sig);
- int statloc;
+  UNUSED (sig);
+  int statloc;
 
- wait(&statloc);
+  wait (&statloc);
 }
 
 static int e_bool_exit = 0;
 
-void e_err_save()
+void
+e_err_save ()
 {
- ECNT *cn = WpeEditor;
- int i;
- unsigned long maxname;
- FENSTER *f;
- BUFFER *b;
+  ECNT *cn = WpeEditor;
+  int i;
+  unsigned long maxname;
+  FENSTER *f;
+  BUFFER *b;
 
- /* Quick fix to multiple emergency save problems */
- if (e_bool_exit)
-  return ;
- e_bool_exit = 1;
- for (i = 0; i <= cn->mxedt; i++)
- {
-  if (DTMD_ISTEXT(cn->f[i]->dtmd))
-  {
-   f = cn->f[i];
-   b = cn->f[i]->b;
-   if (b->mxlines > 1 || b->bf[0].len > 0)
-   {
-    /* Check if file system could have an autosave or emergency save file
-       >12 check is to eliminate dos file systems */
-    if (((maxname = pathconf(f->dirct, _PC_NAME_MAX)) >= strlen(f->datnam) + 4) &&
-      (maxname > 12))
+  /* Quick fix to multiple emergency save problems */
+  if (e_bool_exit)
+    return;
+  e_bool_exit = 1;
+  for (i = 0; i <= cn->mxedt; i++)
     {
-     strcat(f->datnam, ".ESV");
-     printf("Try to save %s!\n", f->datnam);
-     if (!e_save(f))
-      printf("File %s saved!\n", f->datnam);
+      if (DTMD_ISTEXT (cn->f[i]->dtmd))
+	{
+	  f = cn->f[i];
+	  b = cn->f[i]->b;
+	  if (b->mxlines > 1 || b->bf[0].len > 0)
+	    {
+	      /* Check if file system could have an autosave or emergency save file
+	         >12 check is to eliminate dos file systems */
+	      if (((maxname =
+		    pathconf (f->dirct,
+			      _PC_NAME_MAX)) >= strlen (f->datnam) + 4)
+		  && (maxname > 12))
+		{
+		  strcat (f->datnam, ".ESV");
+		  printf ("Try to save %s!\n", f->datnam);
+		  if (!e_save (f))
+		    printf ("File %s saved!\n", f->datnam);
+		}
+	    }
+	}
     }
-   }
-  }
- }
 }
 
-void e_exit(int n)
+void
+e_exit (int n)
 {
 #ifdef DEBUGGER
- extern int e_d_pid;
+  extern int e_d_pid;
 
- if (e_d_pid)
-  kill(e_d_pid, 7);
+  if (e_d_pid)
+    kill (e_d_pid, 7);
 #endif
- (*WpeDisplayEnd)();
- (*e_u_switch_screen)(0);
- if (n != 0)
- {
-  printf("\nError-Exit!   Code: %d!\n", n);
-  e_err_save();
- }
- exit(n);
+  (*WpeDisplayEnd) ();
+  (*e_u_switch_screen) (0);
+  if (n != 0)
+    {
+      printf ("\nError-Exit!   Code: %d!\n", n);
+      e_err_save ();
+    }
+  exit (n);
 }
 
-char *e_mkfilepath(char *dr, char *fn, char *fl)
+char *
+e_mkfilepath (char *dr, char *fn, char *fl)
 {
- strcpy(fl, dr);
- if (dr[strlen(dr)-1] != DIRC)
- {
-  strcat(fl, DIRS);
- }
- strcat(fl, fn);
- return(fl);
+  strcpy (fl, dr);
+  if (dr[strlen (dr) - 1] != DIRC)
+    {
+      strcat (fl, DIRS);
+    }
+  strcat (fl, fn);
+  return (fl);
 }
 
-int e_compstr(char *a, char *b)
+int
+e_compstr (char *a, char *b)
 {
- int n, k;
- char *ctmp, *cp;
+  int n, k;
+  char *ctmp, *cp;
 
- if (a[0] == '*' && !a[1])
-  return(0);
- if (!a[0] || !b[0])
-  return(a[0] - b[0]);
- if (a[0] == '*' && a[1] == '*')
-  return(e_compstr(++a, b));
- for (n = a[0] == '*' ? 2 : 1;
-   a[n] != '*' && a[n] != '?' && a[n] != '[' && a[n]; n++)
-  ;
- if (a[0] == '*')
- {
-  n--;
-  a++;
-  if (a[0] == '?')
-  {
-   cp = malloc((strlen(a)+1)*sizeof(char));
-   strcpy(cp, a);
-   cp[0] = '*';
-   n = e_compstr(cp, ++b);
-   free(cp);
-   return(n);
-  }
-  else if (a[0] == '[')
-  {
-   while (*b && (n = e_compstr(a, b)))
-    b++;
-   return(n);
-  }
-  ctmp = malloc(n+1);
-  for (k = 0; k < n; k++)
-   ctmp[k] = a[k];
-  ctmp[n] = '\0';
-  cp = strstr(b, ctmp);
-  free(ctmp);
-  if (cp == NULL)
-   return((a[0] - b[0]) ? a[0] - b[0] : -1);
-  if (!a[n] && !cp[n])
-   return(0);
-  if (!a[n])
-   return(e_compstr(a-1, cp+1));
-  if (!(k = e_compstr(a+n, cp+n)))
-   return(0);
-  return(e_compstr(a-1, cp+1));
- }
- else if (a[0] == '?')
- {
-  n--;  a++;  b++;
- }
- else if (a[0] == '[')
- {
-  if (a[1] == '!')
-  {
-   for (k = 2; a[k] && (a[k] != ']' || k == 2) && a[k] != b[0]; k++)
-    if (a[k+1] == '-' && b[0] >= a[k] && b[0] <= a[k+2])
-     return(-b[0]);
-   if (a[k] != ']')
-    return(-b[0]);
-   n-=(k+1);  a+=(k+1);  b++;
-  }
-  else
-  {
-   for (k = 1; a[k] && (a[k] != ']' || k == 1) && a[k] != b[0]; k++)
-    if (a[k+1] == '-' && b[0] >= a[k] && b[0] <= a[k+2])
-     break;
-   if (a[k] == ']' || a[k] == '\0')
-    return(-b[0]);
-   for (; a[k] && (a[k] != ']'); k++)
+  if (a[0] == '*' && !a[1])
+    return (0);
+  if (!a[0] || !b[0])
+    return (a[0] - b[0]);
+  if (a[0] == '*' && a[1] == '*')
+    return (e_compstr (++a, b));
+  for (n = a[0] == '*' ? 2 : 1;
+       a[n] != '*' && a[n] != '?' && a[n] != '[' && a[n]; n++)
     ;
-   n-=(k+1);  a+=(k+1);  b++;
-  }
- }
- if (n <= 0)
-  return(e_compstr(a, b));
- if ((k = strncmp(a, b, n)) != 0)
-  return(k);
- return(e_compstr(a+n, b+n));
+  if (a[0] == '*')
+    {
+      n--;
+      a++;
+      if (a[0] == '?')
+	{
+	  cp = malloc ((strlen (a) + 1) * sizeof (char));
+	  strcpy (cp, a);
+	  cp[0] = '*';
+	  n = e_compstr (cp, ++b);
+	  free (cp);
+	  return (n);
+	}
+      else if (a[0] == '[')
+	{
+	  while (*b && (n = e_compstr (a, b)))
+	    b++;
+	  return (n);
+	}
+      ctmp = malloc (n + 1);
+      for (k = 0; k < n; k++)
+	ctmp[k] = a[k];
+      ctmp[n] = '\0';
+      cp = strstr (b, ctmp);
+      free (ctmp);
+      if (cp == NULL)
+	return ((a[0] - b[0]) ? a[0] - b[0] : -1);
+      if (!a[n] && !cp[n])
+	return (0);
+      if (!a[n])
+	return (e_compstr (a - 1, cp + 1));
+      if (!(k = e_compstr (a + n, cp + n)))
+	return (0);
+      return (e_compstr (a - 1, cp + 1));
+    }
+  else if (a[0] == '?')
+    {
+      n--;
+      a++;
+      b++;
+    }
+  else if (a[0] == '[')
+    {
+      if (a[1] == '!')
+	{
+	  for (k = 2; a[k] && (a[k] != ']' || k == 2) && a[k] != b[0]; k++)
+	    if (a[k + 1] == '-' && b[0] >= a[k] && b[0] <= a[k + 2])
+	      return (-b[0]);
+	  if (a[k] != ']')
+	    return (-b[0]);
+	  n -= (k + 1);
+	  a += (k + 1);
+	  b++;
+	}
+      else
+	{
+	  for (k = 1; a[k] && (a[k] != ']' || k == 1) && a[k] != b[0]; k++)
+	    if (a[k + 1] == '-' && b[0] >= a[k] && b[0] <= a[k + 2])
+	      break;
+	  if (a[k] == ']' || a[k] == '\0')
+	    return (-b[0]);
+	  for (; a[k] && (a[k] != ']'); k++)
+	    ;
+	  n -= (k + 1);
+	  a += (k + 1);
+	  b++;
+	}
+    }
+  if (n <= 0)
+    return (e_compstr (a, b));
+  if ((k = strncmp (a, b, n)) != 0)
+    return (k);
+  return (e_compstr (a + n, b + n));
 }
 
-struct dirfile *e_find_files(char *sufile, int sw)
+struct dirfile *
+e_find_files (char *sufile, int sw)
 {
- char           *stmp, *tmpst, *sfile, *sdir;
- struct dirfile *df = malloc(sizeof(struct dirfile));
- DIR            *dirp;
- struct dirent  *dp;
- struct stat     buf;
- struct stat     lbuf;
- int             i, n, cexist, sizeSdir;
- unsigned int    sizeStmp;
+  char *stmp, *tmpst, *sfile, *sdir;
+  struct dirfile *df = malloc (sizeof (struct dirfile));
+  DIR *dirp;
+  struct dirent *dp;
+  struct stat buf;
+  struct stat lbuf;
+  int i, n, cexist, sizeSdir;
+  unsigned int sizeStmp;
 
- df->name = NULL;
- df->anz = 0;
- for (n = strlen(sufile); n >= 0 && sufile[n] != DIRC; n--);
- sfile = sufile + 1 + n;
- if (n <= 0)
- {
-  sizeSdir = 2;
-  sdir = (char *)malloc(2 * sizeof(char));
-  sdir[0] = n ? '.' : DIRC;
-  sdir[1] = '\0';
- }
- else
- {
-  sizeSdir = n + 1;
-  sdir = (char *)malloc((n + 1) * sizeof(char));
-  for (i = 0; i < n; i++)
-   sdir[i] = sufile[i];
-  sdir[n] = '\0';
- }
- if (!(dirp = opendir(sdir)))
- {
-  free(sdir);
-  return(df);
- }
- sizeStmp = 256;
- stmp = (char *)malloc(sizeStmp);
- while((dp = readdir(dirp)) != NULL)
- {
-  if (!(sw & 1) && dp->d_name[0] == '.' && sfile[0] != '.')
-   continue;
-  if (!e_compstr(sfile, dp->d_name))
-  {
-   if (sizeSdir + strlen(dp->d_name) + 10 > sizeStmp)
-   {
-    while (sizeSdir + strlen(dp->d_name) + 10 > sizeStmp)
-     sizeStmp <<= 1;
-    stmp = (char *)realloc(stmp, sizeStmp);
-   }
-
-   e_mkfilepath(sdir, dp->d_name, stmp);
-   lstat(stmp, &lbuf);
-   stat(stmp, &buf);
-
-   /* check existence of the file */
-   cexist = access(stmp, F_OK);
-
-   /* we accept it as a file if
-      - a regular file
-      - link and it does not point to anything
-      - link and it points to a non-directory */
-   if ((S_ISREG(buf.st_mode) ||
-     (S_ISLNK(lbuf.st_mode) &&
-     (cexist || (cexist == 0 && !S_ISDIR(buf.st_mode))))) &&
-     (!(sw & 2) || (buf.st_mode & 0111)) )
-   {
-    if (df->anz == 0)
-     df->name = malloc((df->anz + 1) * sizeof(char *));
-    else
-     df->name = realloc(df->name, (df->anz + 1) * sizeof(char *));
-    if (df->name == NULL || !(tmpst = malloc(strlen(dp->d_name) + 1)))
+  df->name = NULL;
+  df->anz = 0;
+  for (n = strlen (sufile); n >= 0 && sufile[n] != DIRC; n--);
+  sfile = sufile + 1 + n;
+  if (n <= 0)
     {
-     df->anz = 0;
-     closedir(dirp);
-     free(stmp);
-     free(sdir);
-     return(df);
+      sizeSdir = 2;
+      sdir = (char *) malloc (2 * sizeof (char));
+      sdir[0] = n ? '.' : DIRC;
+      sdir[1] = '\0';
     }
-    strcpy(tmpst, dp->d_name);
-    for (n = df->anz; n > 0 && strcmp(*(df->name + n - 1), tmpst) > 0; n--)
-     *(df->name + n) = *(df->name + n - 1);
-    *(df->name + n) = tmpst;
-    (df->anz)++;
-   }
-  }
- }
- closedir(dirp);
- free(stmp);
- free(sdir);
- return(df);
+  else
+    {
+      sizeSdir = n + 1;
+      sdir = (char *) malloc ((n + 1) * sizeof (char));
+      for (i = 0; i < n; i++)
+	sdir[i] = sufile[i];
+      sdir[n] = '\0';
+    }
+  if (!(dirp = opendir (sdir)))
+    {
+      free (sdir);
+      return (df);
+    }
+  sizeStmp = 256;
+  stmp = (char *) malloc (sizeStmp);
+  while ((dp = readdir (dirp)) != NULL)
+    {
+      if (!(sw & 1) && dp->d_name[0] == '.' && sfile[0] != '.')
+	continue;
+      if (!e_compstr (sfile, dp->d_name))
+	{
+	  if (sizeSdir + strlen (dp->d_name) + 10 > sizeStmp)
+	    {
+	      while (sizeSdir + strlen (dp->d_name) + 10 > sizeStmp)
+		sizeStmp <<= 1;
+	      stmp = (char *) realloc (stmp, sizeStmp);
+	    }
+
+	  e_mkfilepath (sdir, dp->d_name, stmp);
+	  lstat (stmp, &lbuf);
+	  stat (stmp, &buf);
+
+	  /* check existence of the file */
+	  cexist = access (stmp, F_OK);
+
+	  /* we accept it as a file if
+	     - a regular file
+	     - link and it does not point to anything
+	     - link and it points to a non-directory */
+	  if ((S_ISREG (buf.st_mode) ||
+	       (S_ISLNK (lbuf.st_mode) &&
+		(cexist || (cexist == 0 && !S_ISDIR (buf.st_mode))))) &&
+	      (!(sw & 2) || (buf.st_mode & 0111)))
+	    {
+	      if (df->anz == 0)
+		df->name = malloc ((df->anz + 1) * sizeof (char *));
+	      else
+		df->name =
+		  realloc (df->name, (df->anz + 1) * sizeof (char *));
+	      if (df->name == NULL
+		  || !(tmpst = malloc (strlen (dp->d_name) + 1)))
+		{
+		  df->anz = 0;
+		  closedir (dirp);
+		  free (stmp);
+		  free (sdir);
+		  return (df);
+		}
+	      strcpy (tmpst, dp->d_name);
+	      for (n = df->anz;
+		   n > 0 && strcmp (*(df->name + n - 1), tmpst) > 0; n--)
+		*(df->name + n) = *(df->name + n - 1);
+	      *(df->name + n) = tmpst;
+	      (df->anz)++;
+	    }
+	}
+    }
+  closedir (dirp);
+  free (stmp);
+  free (sdir);
+  return (df);
 }
 
-struct dirfile *e_find_dir(char *sufile, int sw)
+struct dirfile *
+e_find_dir (char *sufile, int sw)
 {
- char           *stmp, *tmpst, *sfile, *sdir;
- struct dirfile *df = malloc(sizeof(struct dirfile));
- DIR            *dirp;
- struct dirent  *dp;
- struct stat     buf;
- int             i, n, sizeSdir;
- unsigned int    sizeStmp;
+  char *stmp, *tmpst, *sfile, *sdir;
+  struct dirfile *df = malloc (sizeof (struct dirfile));
+  DIR *dirp;
+  struct dirent *dp;
+  struct stat buf;
+  int i, n, sizeSdir;
+  unsigned int sizeStmp;
 
- df->name = NULL;
- df->anz = 0;
- for (n = strlen(sufile); n >= 0 && sufile[n] != DIRC; n--);
- sfile = sufile + 1;
- sfile = sfile + n;
- if (n <= 0)
- {
-  sizeSdir = 2;
-  sdir = malloc(2 * sizeof(char));
-  sdir[0] = n ? '.' : DIRC;
-  sdir[1] = '\0';
- }
- else
- {
-  sizeSdir = n + 1;
-  sdir = malloc((n + 1) * sizeof(char));
-  for (i = 0; i < n; i++)
-   sdir[i] = sufile[i];
-  sdir[n] = '\0';
- }
- if (!(dirp = opendir(sdir)))
- {
-  free(sdir);
-  return(df);
- }
- sizeStmp = 256;
- stmp = (char *)malloc(sizeStmp);
- while ((dp = readdir(dirp)) != NULL)
- {
-  if (!sw && dp->d_name[0] == '.' && sfile[0] != '.')
-   continue;
-  if (!e_compstr(sfile, dp->d_name) && strcmp(dp->d_name, ".") &&
-    strcmp(dp->d_name, ".."))
-  {
-   if (sizeSdir + strlen(dp->d_name) + 10 > sizeStmp)
-   {
-    while (sizeSdir + strlen(dp->d_name) + 10 > sizeStmp)
-     sizeStmp <<= 1;
-    stmp = (char *)realloc(stmp, sizeStmp);
-   }
-   stat(e_mkfilepath(sdir, dp->d_name, stmp), &buf);
-
-   /* we accept _only_ real, existing directories */
-   if (S_ISDIR(buf.st_mode))
-   {
-
-    if (df->anz == 0)
-     df->name = malloc((df->anz + 1) * sizeof(char *));
-    else
-     df->name = realloc(df->name, (df->anz + 1) * sizeof(char *));
-    if (df->name == NULL || !(tmpst = malloc(strlen(dp->d_name) + 1)))
+  df->name = NULL;
+  df->anz = 0;
+  for (n = strlen (sufile); n >= 0 && sufile[n] != DIRC; n--);
+  sfile = sufile + 1;
+  sfile = sfile + n;
+  if (n <= 0)
     {
-     df->anz = 0;
-     closedir(dirp);
-     free(sdir);
-     free(stmp);
-     return(df);
+      sizeSdir = 2;
+      sdir = malloc (2 * sizeof (char));
+      sdir[0] = n ? '.' : DIRC;
+      sdir[1] = '\0';
     }
-    strcpy(tmpst, dp->d_name);
-    for (n = df->anz; n > 0 && strcmp(*(df->name + n - 1), tmpst) > 0; n--)
-     *(df->name + n) = *(df->name + n - 1);
-    *(df->name + n) = tmpst;
-    (df->anz)++;
-   }
-  }
- }
- closedir(dirp);
- free(sdir);
- free(stmp);
- return(df);
+  else
+    {
+      sizeSdir = n + 1;
+      sdir = malloc ((n + 1) * sizeof (char));
+      for (i = 0; i < n; i++)
+	sdir[i] = sufile[i];
+      sdir[n] = '\0';
+    }
+  if (!(dirp = opendir (sdir)))
+    {
+      free (sdir);
+      return (df);
+    }
+  sizeStmp = 256;
+  stmp = (char *) malloc (sizeStmp);
+  while ((dp = readdir (dirp)) != NULL)
+    {
+      if (!sw && dp->d_name[0] == '.' && sfile[0] != '.')
+	continue;
+      if (!e_compstr (sfile, dp->d_name) && strcmp (dp->d_name, ".") &&
+	  strcmp (dp->d_name, ".."))
+	{
+	  if (sizeSdir + strlen (dp->d_name) + 10 > sizeStmp)
+	    {
+	      while (sizeSdir + strlen (dp->d_name) + 10 > sizeStmp)
+		sizeStmp <<= 1;
+	      stmp = (char *) realloc (stmp, sizeStmp);
+	    }
+	  stat (e_mkfilepath (sdir, dp->d_name, stmp), &buf);
+
+	  /* we accept _only_ real, existing directories */
+	  if (S_ISDIR (buf.st_mode))
+	    {
+
+	      if (df->anz == 0)
+		df->name = malloc ((df->anz + 1) * sizeof (char *));
+	      else
+		df->name =
+		  realloc (df->name, (df->anz + 1) * sizeof (char *));
+	      if (df->name == NULL
+		  || !(tmpst = malloc (strlen (dp->d_name) + 1)))
+		{
+		  df->anz = 0;
+		  closedir (dirp);
+		  free (sdir);
+		  free (stmp);
+		  return (df);
+		}
+	      strcpy (tmpst, dp->d_name);
+	      for (n = df->anz;
+		   n > 0 && strcmp (*(df->name + n - 1), tmpst) > 0; n--)
+		*(df->name + n) = *(df->name + n - 1);
+	      *(df->name + n) = tmpst;
+	      (df->anz)++;
+	    }
+	}
+    }
+  closedir (dirp);
+  free (sdir);
+  free (stmp);
+  return (df);
 }
 
 #include <time.h>
 
-char *e_file_info(char *filen, char *str, int *num, int sw)
+char *
+e_file_info (char *filen, char *str, int *num, int sw)
 {
- struct tm *ttm;
- struct stat buf[1];
+  struct tm *ttm;
+  struct stat buf[1];
 
- stat(filen, buf);
- ttm = localtime(&(buf->st_mtime));
- sprintf(str, "%c%c%c%c%c%c%c%c%c%c  %-13s  %6ld  %2.2u.%2.2u.%4.4u  %2.2u.%2.2u",
-   buf->st_mode & 040000 ? 'd' : '-',
-   buf->st_mode & 0400 ? 'r' : '-',
-   buf->st_mode & 0200 ? 'w' : '-',
-   buf->st_mode & 0100 ? 'x' : '-',
-   buf->st_mode & 040 ? 'r' : '-',
-   buf->st_mode & 020 ? 'w' : '-',
-   buf->st_mode & 010 ? 'x' : '-',
-   buf->st_mode & 04 ? 'r' : '-',
-   buf->st_mode & 02 ? 'w' : '-',
-   buf->st_mode & 01 ? 'x' : '-',
-   filen,
-   buf->st_size, ttm->tm_mday,
-   ttm->tm_mon + 1, ttm->tm_year + 1900, ttm->tm_hour, ttm->tm_min);
- if (sw & 1) *num = buf->st_mtime;
- else if (sw & 2) *num = buf->st_size;
- return(str);
+  stat (filen, buf);
+  ttm = localtime (&(buf->st_mtime));
+  sprintf (str,
+	   "%c%c%c%c%c%c%c%c%c%c  %-13s  %6ld  %2.2u.%2.2u.%4.4u  %2.2u.%2.2u",
+	   buf->st_mode & 040000 ? 'd' : '-', buf->st_mode & 0400 ? 'r' : '-',
+	   buf->st_mode & 0200 ? 'w' : '-', buf->st_mode & 0100 ? 'x' : '-',
+	   buf->st_mode & 040 ? 'r' : '-', buf->st_mode & 020 ? 'w' : '-',
+	   buf->st_mode & 010 ? 'x' : '-', buf->st_mode & 04 ? 'r' : '-',
+	   buf->st_mode & 02 ? 'w' : '-', buf->st_mode & 01 ? 'x' : '-',
+	   filen, buf->st_size, ttm->tm_mday, ttm->tm_mon + 1,
+	   ttm->tm_year + 1900, ttm->tm_hour, ttm->tm_min);
+  if (sw & 1)
+    *num = buf->st_mtime;
+  else if (sw & 2)
+    *num = buf->st_size;
+  return (str);
 }
 
-void ini_repaint(ECNT *cn)
+void
+ini_repaint (ECNT * cn)
 {
- e_cls(cn->fb->df.fb, cn->fb->dc);
- e_ini_desk(cn);
+  e_cls (cn->fb->df.fb, cn->fb->dc);
+  e_ini_desk (cn);
 }
 
-void end_repaint()
+void
+end_repaint ()
 {
-   e_refresh();
+  e_refresh ();
 }
 
-int e_recover(ECNT *cn)
+int
+e_recover (ECNT * cn)
 {
- struct dirfile *files;
- FENSTER *f = NULL;
- BUFFER *b;
- SCHIRM *s;
- int i;
+  struct dirfile *files;
+  FENSTER *f = NULL;
+  BUFFER *b;
+  SCHIRM *s;
+  int i;
 
- files = e_find_files("*.ESV", 1);
- for (i = 0; i < files->anz; i++)
- {
-  e_edit(cn, files->name[i]);
-  f = cn->f[cn->mxedt];
-  f->datnam[strlen(f->datnam)-4] = '\0';
-  if (!strcmp(f->datnam, BUFFER_NAME))
-  {
-   s = cn->f[cn->mxedt]->s;
-   b = cn->f[cn->mxedt]->b;
-   s->mark_end.y = b->mxlines - 1;
-   s->mark_end.x = b->bf[b->mxlines-1].len;
-   e_edt_copy(f);
-   e_close_window(f);
-  }
-  else f->save = 1;
+  files = e_find_files ("*.ESV", 1);
+  for (i = 0; i < files->anz; i++)
+    {
+      e_edit (cn, files->name[i]);
+      f = cn->f[cn->mxedt];
+      f->datnam[strlen (f->datnam) - 4] = '\0';
+      if (!strcmp (f->datnam, BUFFER_NAME))
+	{
+	  s = cn->f[cn->mxedt]->s;
+	  b = cn->f[cn->mxedt]->b;
+	  s->mark_end.y = b->mxlines - 1;
+	  s->mark_end.x = b->bf[b->mxlines - 1].len;
+	  e_edt_copy (f);
+	  e_close_window (f);
+	}
+      else
+	f->save = 1;
 #ifdef PROG
-  if (WpeIsProg()) e_add_synt_tl(f->datnam, f);
+      if (WpeIsProg ())
+	e_add_synt_tl (f->datnam, f);
 #endif
-  if ((f->ed->edopt & ED_ALWAYS_AUTO_INDENT) ||
-    ((f->ed->edopt & ED_SOURCE_AUTO_INDENT) && f->c_st)) 
-   f->flg = 1;
- }
- freedf(files);
- return(0);
+      if ((f->ed->edopt & ED_ALWAYS_AUTO_INDENT) ||
+	  ((f->ed->edopt & ED_SOURCE_AUTO_INDENT) && f->c_st))
+	f->flg = 1;
+    }
+  freedf (files);
+  return (0);
 }
 
-int e_frb_t_menue(int sw, int xa, int ya, FENSTER *f, int md)
+int
+e_frb_t_menue (int sw, int xa, int ya, FENSTER * f, int md)
 {
- COLOR *frb = &(f->fb->er);
- int i, j, y, c=1, fb, fsv;
+  COLOR *frb = &(f->fb->er);
+  int i, j, y, c = 1, fb, fsv;
 
- if (md == 1) sw += 11;
- else if (md == 2) sw += 16;
- else if (md == 3) sw += 32;
- fsv = fb = frb[sw].fb;
- if (fb == 0) y = 0;
- else
-  for (y = 1, j = fb; j > 1; y++)
-   j /= 2;
- do
- {
-  if (c == CDO) y = y < 6 ? y + 1 : 0;
-  else if (c == CUP) y = y > 0 ? y - 1 : 6;
-  if (y == 0) fb = 0;
+  if (md == 1)
+    sw += 11;
+  else if (md == 2)
+    sw += 16;
+  else if (md == 3)
+    sw += 32;
+  fsv = fb = frb[sw].fb;
+  if (fb == 0)
+    y = 0;
   else
-   for (i = 1, fb = 1; i < y; i++)
-    fb *= 2;
-  frb[sw] = e_n_clr(fb);
-  e_pr_t_col_kasten(xa, ya, fb, fb, f, 1);
-  e_pr_ed_beispiel(1, 2, f, sw, md);
+    for (y = 1, j = fb; j > 1; y++)
+      j /= 2;
+  do
+    {
+      if (c == CDO)
+	y = y < 6 ? y + 1 : 0;
+      else if (c == CUP)
+	y = y > 0 ? y - 1 : 6;
+      if (y == 0)
+	fb = 0;
+      else
+	for (i = 1, fb = 1; i < y; i++)
+	  fb *= 2;
+      frb[sw] = e_n_clr (fb);
+      e_pr_t_col_kasten (xa, ya, fb, fb, f, 1);
+      e_pr_ed_beispiel (1, 2, f, sw, md);
 #if  MOUSE
-  if ((c=e_getch()) == -1) c = e_opt_ck_mouse(xa, ya, md);
+      if ((c = e_getch ()) == -1)
+	c = e_opt_ck_mouse (xa, ya, md);
 #else
-  c = e_getch();
+      c = e_getch ();
 #endif
- } while (c != WPE_ESC && c != WPE_CR && c > -2);
- if (c == WPE_ESC || c < -1) frb[sw] = e_n_clr(fsv);
- return(frb[sw].fb);
+    }
+  while (c != WPE_ESC && c != WPE_CR && c > -2);
+  if (c == WPE_ESC || c < -1)
+    frb[sw] = e_n_clr (fsv);
+  return (frb[sw].fb);
 }
 
 /*   draw colors box  */
-void e_pr_t_col_kasten(int xa, int ya, int x, int y, FENSTER * f, int sw)
+void
+e_pr_t_col_kasten (int xa, int ya, int x, int y, FENSTER * f, int sw)
 {
- int rfrb, xe = xa + 14, ye = ya + 8;
+  int rfrb, xe = xa + 14, ye = ya + 8;
 
- if (x == 0) y = 0;
- else
-  for (rfrb = x, y = 1; rfrb > 1; y++)
-   rfrb /= 2;
- rfrb = sw == 0 ? f->fb->nt.fb : f->fb->fs.fb;
- e_std_rahmen(xa, ya, xe, ye, "Colors", 0, rfrb, 0);
+  if (x == 0)
+    y = 0;
+  else
+    for (rfrb = x, y = 1; rfrb > 1; y++)
+      rfrb /= 2;
+  rfrb = sw == 0 ? f->fb->nt.fb : f->fb->fs.fb;
+  e_std_rahmen (xa, ya, xe, ye, "Colors", 0, rfrb, 0);
 /*     e_pr_str((xa+xe-8)/2, ya, "Colors", rfrb, 0, 1, 
                                         f->fb->ms.f+16*(rfrb/16), 0);
 */
- e_pr_nstr(xa+2, ya+1, xe-xa-1, "A_NORMAL   ", 0, 0);
- e_pr_nstr(xa+2, ya+2, xe-xa-1, "A_STANDOUT ", A_STANDOUT, A_STANDOUT);
- e_pr_nstr(xa+2, ya+3, xe-xa-1, "A_UNDERLINE", A_UNDERLINE, A_UNDERLINE);
- e_pr_nstr(xa+2, ya+4, xe-xa-1, "A_REVERSE  ", A_REVERSE, A_REVERSE);
- e_pr_nstr(xa+2, ya+5, xe-xa-1, "A_BLINK    ", A_BLINK, A_BLINK);
- e_pr_nstr(xa+2, ya+6, xe-xa-1, "A_DIM      ", A_DIM, A_DIM);
- e_pr_nstr(xa+2, ya+7, xe-xa-1, "A_BOLD     ", A_BOLD, A_BOLD);
+  e_pr_nstr (xa + 2, ya + 1, xe - xa - 1, "A_NORMAL   ", 0, 0);
+  e_pr_nstr (xa + 2, ya + 2, xe - xa - 1, "A_STANDOUT ", A_STANDOUT,
+	     A_STANDOUT);
+  e_pr_nstr (xa + 2, ya + 3, xe - xa - 1, "A_UNDERLINE", A_UNDERLINE,
+	     A_UNDERLINE);
+  e_pr_nstr (xa + 2, ya + 4, xe - xa - 1, "A_REVERSE  ", A_REVERSE,
+	     A_REVERSE);
+  e_pr_nstr (xa + 2, ya + 5, xe - xa - 1, "A_BLINK    ", A_BLINK, A_BLINK);
+  e_pr_nstr (xa + 2, ya + 6, xe - xa - 1, "A_DIM      ", A_DIM, A_DIM);
+  e_pr_nstr (xa + 2, ya + 7, xe - xa - 1, "A_BOLD     ", A_BOLD, A_BOLD);
 
- fk_locate(xa+4, ya + y + 1);
+  fk_locate (xa + 4, ya + y + 1);
 }
-

--- a/src/we_unix.h
+++ b/src/we_unix.h
@@ -8,63 +8,64 @@
 #include "we_mouse.h"
 #include "we_opt.h"
 
-typedef enum wpeMouseShape {
- WpeEditingShape, WpeDebuggingShape, WpeWorkingShape, WpeErrorShape,
- WpeSelectionShape, WpeLastShape
+typedef enum wpeMouseShape
+{
+  WpeEditingShape, WpeDebuggingShape, WpeWorkingShape, WpeErrorShape,
+  WpeSelectionShape, WpeLastShape
 } WpeMouseShape;
 
 /*   we_unix.c   */
-int e_abs_refr(void);
-void e_refresh_area(int x, int y, int width, int height);
-void WpeNullFunction(void);
-int WpeZeroFunction();
-int e_tast_sim(int c);
-void e_err_save(void);
-void e_exit(int n);
-char *e_mkfilepath(char *dr, char *fn, char *fl);
-int e_compstr(char *a, char *b);
-struct dirfile *e_find_files(char *sufile, int sw);
-struct dirfile *e_find_dir(char *sufile, int sw);
-char *e_file_info(char *filen, char *str, int *num, int sw);
-void ini_repaint(ECNT *cn);
-void end_repaint(void);
-int e_frb_t_menue(int sw, int xa, int ya, FENSTER *f, int md);
-void e_pr_t_col_kasten(int xa, int ya, int x, int y, FENSTER *f, int sw);
-int e_ini_unix(int *argc, char **argv);
-int e_recover(ECNT *cn);
-int e_ini_schirm(int argc, char **argv);
+int e_abs_refr (void);
+void e_refresh_area (int x, int y, int width, int height);
+void WpeNullFunction (void);
+int WpeZeroFunction ();
+int e_tast_sim (int c);
+void e_err_save (void);
+void e_exit (int n);
+char *e_mkfilepath (char *dr, char *fn, char *fl);
+int e_compstr (char *a, char *b);
+struct dirfile *e_find_files (char *sufile, int sw);
+struct dirfile *e_find_dir (char *sufile, int sw);
+char *e_file_info (char *filen, char *str, int *num, int sw);
+void ini_repaint (ECNT * cn);
+void end_repaint (void);
+int e_frb_t_menue (int sw, int xa, int ya, FENSTER * f, int md);
+void e_pr_t_col_kasten (int xa, int ya, int x, int y, FENSTER * f, int sw);
+int e_ini_unix (int *argc, char **argv);
+int e_recover (ECNT * cn);
+int e_ini_schirm (int argc, char **argv);
 
-extern int (*fk_u_locate)(int x, int y);
-extern int (*fk_u_cursor)(int x);
-extern int (*e_u_initscr)(int argc, char *argv[]);
-extern int (*fk_u_putchar)(int c);
-extern int (*u_bioskey)(void);
-extern int (*e_frb_u_menue)(int sw, int xa, int ya, FENSTER *f, int md);
-extern COLOR (*e_s_u_clr)(int f, int b);
-extern COLOR (*e_n_u_clr)(int fb);
-extern void (*e_pr_u_col_kasten)(int xa, int ya, int x, 
-					int y, FENSTER *f, int sw);
-extern int (*fk_mouse)(int g[]);
-extern int (*e_u_refresh)(void);
-extern int (*e_u_getch)(void);
-extern int (*e_u_sys_ini)(void);
-extern int (*e_u_sys_end)(void);
-extern void (*WpeMouseChangeShape)(WpeMouseShape new_shape);
-extern void (*WpeMouseRestoreShape)(void);
-extern int (*e_u_d_switch_out)(int sw);
-extern int (*e_u_switch_screen)(int sw);
-extern int (*e_u_deb_out)(FENSTER *f);
-extern int (*e_u_cp_X_to_buffer)(FENSTER *f);
-extern int (*e_u_copy_X_buffer)(FENSTER *f);
-extern int (*e_u_paste_X_buffer)(FENSTER *f);
-extern int (*e_u_change)(view *pic);
+extern int (*fk_u_locate) (int x, int y);
+extern int (*fk_u_cursor) (int x);
+extern int (*e_u_initscr) (int argc, char *argv[]);
+extern int (*fk_u_putchar) (int c);
+extern int (*u_bioskey) (void);
+extern int (*e_frb_u_menue) (int sw, int xa, int ya, FENSTER * f, int md);
+extern COLOR (*e_s_u_clr) (int f, int b);
+extern COLOR (*e_n_u_clr) (int fb);
+extern void (*e_pr_u_col_kasten) (int xa, int ya, int x,
+				  int y, FENSTER * f, int sw);
+extern int (*fk_mouse) (int g[]);
+extern int (*e_u_refresh) (void);
+extern int (*e_u_getch) (void);
+extern int (*e_u_sys_ini) (void);
+extern int (*e_u_sys_end) (void);
+extern void (*WpeMouseChangeShape) (WpeMouseShape new_shape);
+extern void (*WpeMouseRestoreShape) (void);
+extern int (*e_u_d_switch_out) (int sw);
+extern int (*e_u_switch_screen) (int sw);
+extern int (*e_u_deb_out) (FENSTER * f);
+extern int (*e_u_cp_X_to_buffer) (FENSTER * f);
+extern int (*e_u_copy_X_buffer) (FENSTER * f);
+extern int (*e_u_paste_X_buffer) (FENSTER * f);
+extern int (*e_u_change) (view * pic);
 //extern int (*e_u_ini_size)(void);
-extern int (*e_u_s_sys_end)(void);
-extern int (*e_u_s_sys_ini)(void);
-extern void (*e_u_setlastpic)(view *pic);
-extern int (*e_u_system)(const char *exe);
-extern int (*e_u_kbhit)(void);
-extern void (*WpeDisplayEnd)(void);
+extern int (*e_u_s_sys_end) (void);
+extern int (*e_u_s_sys_ini) (void);
+extern void (*e_u_setlastpic) (view * pic);
+extern int (*e_u_system) (const char *exe);
+extern int (*e_u_kbhit) (void);
+extern void (*WpeDisplayEnd) (void);
 
 extern char e_we_sw;
 

--- a/src/we_wind.c
+++ b/src/we_wind.c
@@ -17,1062 +17,1228 @@
 #include "we_prog.h"
 
 #ifdef UNIX
-# include <unistd.h>
+#include <unistd.h>
 #endif
 
 #define MAXSVSTR 20
 
-int e_make_xr_rahmen(int xa, int ya, int xe, int ye, int sw);
+int e_make_xr_rahmen (int xa, int ya, int xe, int ye, int sw);
 
 /* break string into multiple line to fit into windows 
 
    REM: Caller has to free returned vector!!! 
 */
-char **StringToStringArray(char *str, int *maxLen, int minWidth, int *anzahl)
+char **
+StringToStringArray (char *str, int *maxLen, int minWidth, int *anzahl)
 {
- int i, j, k, anz = 0, mxlen = 0, max = 0.8 * MAXSCOL;
- char **s = malloc(sizeof(char*));
+  int i, j, k, anz = 0, mxlen = 0, max = 0.8 * MAXSCOL;
+  char **s = malloc (sizeof (char *));
 
- for (k = 0, i = 0; str[i]; i++)
- {
-  if((i-k) == max || str[i] == '\n')
-  {
-   j = i-1;
-   if (str[i] != '\n') 
-    for (; j > 0 && !isspace(str[j]); j--)
-     ;
-   if(j > k)
-    i = j;
-   anz++;
-   s = realloc(s, anz * sizeof(char *));
-   s[anz-1] = malloc((i - k + 2) * sizeof(char));
-   for (j = k; j <= i; j++)
-    s[anz-1][j-k] = str[j];
-   if (isspace(str[j-1]))
-    j--;
-   if (mxlen < (j-k))
+  for (k = 0, i = 0; str[i]; i++)
+    {
+      if ((i - k) == max || str[i] == '\n')
+	{
+	  j = i - 1;
+	  if (str[i] != '\n')
+	    for (; j > 0 && !isspace (str[j]); j--)
+	      ;
+	  if (j > k)
+	    i = j;
+	  anz++;
+	  s = realloc (s, anz * sizeof (char *));
+	  s[anz - 1] = malloc ((i - k + 2) * sizeof (char));
+	  for (j = k; j <= i; j++)
+	    s[anz - 1][j - k] = str[j];
+	  if (isspace (str[j - 1]))
+	    j--;
+	  if (mxlen < (j - k))
+	    mxlen = j - k;
+	  s[anz - 1][j - k] = '\0';
+	  k = i + 1;
+	}
+    }
+  anz++;
+  s = realloc (s, anz * sizeof (char *));
+  s[anz - 1] = malloc ((i - k + 2) * sizeof (char));
+  for (j = k; j <= i; j++)
+    s[anz - 1][j - k] = str[j];
+  if (mxlen < (j - k))
     mxlen = j - k;
-   s[anz-1][j-k] = '\0';
-   k = i+1;
-  }
- }
- anz++;
- s = realloc(s, anz * sizeof(char *));
- s[anz-1] = malloc((i - k + 2) * sizeof(char));
- for (j = k; j <= i; j++)
-  s[anz-1][j-k] = str[j];
- if (mxlen < (j-k))
-  mxlen = j - k;
- if (mxlen < minWidth)
-  mxlen = minWidth;
+  if (mxlen < minWidth)
+    mxlen = minWidth;
 
- *maxLen = mxlen;
- *anzahl = anz;
+  *maxLen = mxlen;
+  *anzahl = anz;
 
- return (s);
+  return (s);
 }
 
 /*
       Print error message        */
-int e_error(char *text, int sw, FARBE *f)
+int
+e_error (char *text, int sw, FARBE * f)
 {
- view *pic = NULL;
- int len, i, xa, xe, ya = 8, ye = 14;
- char *header = NULL;
+  view *pic = NULL;
+  int len, i, xa, xe, ya = 8, ye = 14;
+  char *header = NULL;
 
- fk_cursor(0);
- WpeMouseChangeShape(WpeErrorShape);
- if ((len = strlen((char *)text)) < 20 ) len = 20;
- xa = (80-len)/2 - 2;
- xe = 82 - (80-len)/2;
- if (sw == -1) header = "Message";
- else if (sw == 0) header = "Error";
- else if (sw == 1) header = "Serious Error";
- else if (sw == 2) header = "Fatal Error";
+  fk_cursor (0);
+  WpeMouseChangeShape (WpeErrorShape);
+  if ((len = strlen ((char *) text)) < 20)
+    len = 20;
+  xa = (80 - len) / 2 - 2;
+  xe = 82 - (80 - len) / 2;
+  if (sw == -1)
+    header = "Message";
+  else if (sw == 0)
+    header = "Error";
+  else if (sw == 1)
+    header = "Serious Error";
+  else if (sw == 2)
+    header = "Fatal Error";
 
- if (sw < 2) pic = e_std_kst(xa, ya, xe, ye, header, 1, f->nr.fb, f->nt.fb, f->ne.fb);
- if (sw == 2 || pic == NULL)
- {
-  pic = e_open_view(xa, ya, xe, ye, 0, 0);
-  e_std_rahmen(xa, ya, xe, ye, header, 1, 0, 0);
- }
- if (sw < 2)
- {
-  e_pr_str((xe + xa - e_str_len((unsigned char *)text))/2,
-    ya + 2, text, f->nt.fb, 0, 0, 0, 0);
-  e_pr_str((xe + xa - 4)/2, ya + 4, " OK ", f->nz.fb, 1, -1,
-    f->ns.fb, f->nt.fb);
- }
- else
- {
-  e_pr_str((xe + xa - e_str_len((unsigned char *)text))/2,
-    ya + 2, text, 112, 0, 0, 0, 0);
-  e_pr_str((xe + xa - 4)/2, ya + 4, " OK ", 32, 1, -1, 46, 112);
- }
- do
- {
+  if (sw < 2)
+    pic = e_std_kst (xa, ya, xe, ye, header, 1, f->nr.fb, f->nt.fb, f->ne.fb);
+  if (sw == 2 || pic == NULL)
+    {
+      pic = e_open_view (xa, ya, xe, ye, 0, 0);
+      e_std_rahmen (xa, ya, xe, ye, header, 1, 0, 0);
+    }
+  if (sw < 2)
+    {
+      e_pr_str ((xe + xa - e_str_len ((unsigned char *) text)) / 2,
+		ya + 2, text, f->nt.fb, 0, 0, 0, 0);
+      e_pr_str ((xe + xa - 4) / 2, ya + 4, " OK ", f->nz.fb, 1, -1,
+		f->ns.fb, f->nt.fb);
+    }
+  else
+    {
+      e_pr_str ((xe + xa - e_str_len ((unsigned char *) text)) / 2,
+		ya + 2, text, 112, 0, 0, 0, 0);
+      e_pr_str ((xe + xa - 4) / 2, ya + 4, " OK ", 32, 1, -1, 46, 112);
+    }
+  do
+    {
 #if  MOUSE
-  if ((i = toupper(e_getch())) == -1)
-   i = e_er_mouse(xa+3, ya,(xe+xa-4)/2, ya+4);
+      if ((i = toupper (e_getch ())) == -1)
+	i = e_er_mouse (xa + 3, ya, (xe + xa - 4) / 2, ya + 4);
 #else
-  i = toupper(e_getch());
+      i = toupper (e_getch ());
 #endif
- } while (i != WPE_ESC && i != WPE_CR && i != 'O');
- WpeMouseRestoreShape();
- if (pic != NULL) e_close_view(pic, 1);
- else e_cls(0, ' ');
- fk_cursor(1);
- if (sw == 1) e_quit(WpeEditor->f[WpeEditor->mxedt]);
- if (sw > 0) WpeExit(sw);
- return(sw);
+    }
+  while (i != WPE_ESC && i != WPE_CR && i != 'O');
+  WpeMouseRestoreShape ();
+  if (pic != NULL)
+    e_close_view (pic, 1);
+  else
+    e_cls (0, ' ');
+  fk_cursor (1);
+  if (sw == 1)
+    e_quit (WpeEditor->f[WpeEditor->mxedt]);
+  if (sw > 0)
+    WpeExit (sw);
+  return (sw);
 }
 
 /*   message with selection        */
-int e_message(int sw, char *str, FENSTER *f)
+int
+e_message (int sw, char *str, FENSTER * f)
 {
- int i, ret, mxlen = 0, anz = 0;
- char **s;
- W_OPTSTR *o = e_init_opt_kst(f);
+  int i, ret, mxlen = 0, anz = 0;
+  char **s;
+  W_OPTSTR *o = e_init_opt_kst (f);
 
- if (!o)
-  return(-1);
+  if (!o)
+    return (-1);
 
- s = StringToStringArray(str, &mxlen, 22, &anz);
+  s = StringToStringArray (str, &mxlen, 22, &anz);
 
- o->ye = MAXSLNS - 6;
- o->ya = o->ye - anz - 5;
- o->xa = (MAXSCOL - mxlen - 6)/2;
- o->xe = o->xa + mxlen + 6;
+  o->ye = MAXSLNS - 6;
+  o->ya = o->ye - anz - 5;
+  o->xa = (MAXSCOL - mxlen - 6) / 2;
+  o->xe = o->xa + mxlen + 6;
 
- o->bgsw = 0;
- o->name = "Message";
- for (i = 0; i < anz; i++)
- {
-  e_add_txtstr((o->xe-o->xa-strlen(s[i]))/2, 2+i, s[i], o);
-  free(s[i]);
- }
- free(s);
- if (!sw)
- {
-  o->crsw = AltO;
-  e_add_bttstr((o->xe-o->xa-4)/2, o->ye-o->ya-2, 0, AltO, "Ok", NULL, o);
- }
- else
- {
-  o->crsw = AltY;
-  e_add_bttstr(4, o->ye-o->ya-2, 0, AltY, "Yes", NULL, o);
-  e_add_bttstr((o->xe-o->xa-2)/2, o->ye-o->ya-2, 0, AltN, "No", NULL, o);
-  e_add_bttstr(o->xe-o->xa-9, o->ye-o->ya-2, -1, WPE_ESC, "Cancel", NULL, o);
- }
- ret = e_opt_kst(o);
- freeostr(o);
- return(ret == WPE_ESC ? WPE_ESC : (ret == AltN ? 'N' : 'Y'));
+  o->bgsw = 0;
+  o->name = "Message";
+  for (i = 0; i < anz; i++)
+    {
+      e_add_txtstr ((o->xe - o->xa - strlen (s[i])) / 2, 2 + i, s[i], o);
+      free (s[i]);
+    }
+  free (s);
+  if (!sw)
+    {
+      o->crsw = AltO;
+      e_add_bttstr ((o->xe - o->xa - 4) / 2, o->ye - o->ya - 2, 0, AltO, "Ok",
+		    NULL, o);
+    }
+  else
+    {
+      o->crsw = AltY;
+      e_add_bttstr (4, o->ye - o->ya - 2, 0, AltY, "Yes", NULL, o);
+      e_add_bttstr ((o->xe - o->xa - 2) / 2, o->ye - o->ya - 2, 0, AltN, "No",
+		    NULL, o);
+      e_add_bttstr (o->xe - o->xa - 9, o->ye - o->ya - 2, -1, WPE_ESC,
+		    "Cancel", NULL, o);
+    }
+  ret = e_opt_kst (o);
+  freeostr (o);
+  return (ret == WPE_ESC ? WPE_ESC : (ret == AltN ? 'N' : 'Y'));
 }
 
 /*         First opening of a window                 */
-void e_firstl(FENSTER *f, int sw)
+void
+e_firstl (FENSTER * f, int sw)
 {
- f->pic = NULL;
- f->pic = e_ed_kst(f, f->pic, sw);
- if (f->pic == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
+  f->pic = NULL;
+  f->pic = e_ed_kst (f, f->pic, sw);
+  if (f->pic == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
 }
 
 /*         Writing of the file type    */
-int e_pr_filetype(FENSTER *f)
+int
+e_pr_filetype (FENSTER * f)
 {
- int frb = f->fb->es.fb;
+  int frb = f->fb->es.fb;
 
- e_pr_char(f->a.x+2, f->e.y, 'A', frb);
- if (f->ins == 0 || f->ins == 2)
-  e_pr_char(f->a.x+16, f->e.y, 'O', frb);
- else if (f->ins == 8)
-  e_pr_char(f->a.x+16, f->e.y, 'R', frb);
- else
-  e_pr_char(f->a.x+16, f->e.y, 'I', frb);
- if (f->ins > 1)
-  e_pr_char(f->a.x+17, f->e.y, 'S', frb);
- else
-  e_pr_char(f->a.x+17, f->e.y, 'L', frb);
- return(0);
+  e_pr_char (f->a.x + 2, f->e.y, 'A', frb);
+  if (f->ins == 0 || f->ins == 2)
+    e_pr_char (f->a.x + 16, f->e.y, 'O', frb);
+  else if (f->ins == 8)
+    e_pr_char (f->a.x + 16, f->e.y, 'R', frb);
+  else
+    e_pr_char (f->a.x + 16, f->e.y, 'I', frb);
+  if (f->ins > 1)
+    e_pr_char (f->a.x + 17, f->e.y, 'S', frb);
+  else
+    e_pr_char (f->a.x + 17, f->e.y, 'L', frb);
+  return (0);
 }
 
 /*   open section of screen and save background  */
-view *e_open_view(int xa, int ya, int xe, int ye, int col, int sw)
+view *
+e_open_view (int xa, int ya, int xe, int ye, int col, int sw)
 {
- view *pic = malloc(sizeof(view));
- int i, j;
+  view *pic = malloc (sizeof (view));
+  int i, j;
 
- if (pic == NULL) return(NULL);
- pic->a.x = xa;
- pic->a.y = ya;
+  if (pic == NULL)
+    return (NULL);
+  pic->a.x = xa;
+  pic->a.y = ya;
 #ifndef NEWSTYLE
- if(!WpeIsXwin())
- {
+  if (!WpeIsXwin ())
+    {
+      pic->e.x = xe;
+      pic->e.y = ye;
+    }
+  else
+    {
+      pic->e.x = xe < MAXSCOL - 2 ? xe + 2 : xe < MAXSCOL - 1 ? xe + 1 : xe;
+      pic->e.y = ye < MAXSLNS - 2 ? ye + 1 : ye;
+    }
+#else
   pic->e.x = xe;
   pic->e.y = ye;
- }
- else
- {
-  pic->e.x = xe < MAXSCOL-2 ? xe + 2 : xe < MAXSCOL-1 ? xe + 1 : xe;
-  pic->e.y = ye < MAXSLNS-2 ? ye + 1 : ye;
- }
-#else
- pic->e.x = xe;
- pic->e.y = ye;
 #endif
- if (sw!=0)
- {
+  if (sw != 0)
+    {
 #if defined(NEWSTYLE) && !defined(NO_XWINDOWS)
-  pic->p = malloc((pic->e.x - pic->a.x + 1) * 3 * (pic->e.y - pic->a.y + 1));
+      pic->p =
+	malloc ((pic->e.x - pic->a.x + 1) * 3 * (pic->e.y - pic->a.y + 1));
 #else
-  pic->p = malloc((pic->e.x - pic->a.x + 1) * 2 * (pic->e.y - pic->a.y + 1));
+      pic->p =
+	malloc ((pic->e.x - pic->a.x + 1) * 2 * (pic->e.y - pic->a.y + 1));
 #endif
-  if (pic->p == NULL) {  free(pic);  return(NULL);  }
-  for (j = pic->a.y; j <= pic->e.y; ++j)
-   for (i = 2*pic->a.x; i <= 2*pic->e.x+1; ++i)
-    *( pic->p + (j-pic->a.y)*2*(pic->e.x-pic->a.x+1) + (i-2*pic->a.x) ) = e_gt_byte(i, j);
+      if (pic->p == NULL)
+	{
+	  free (pic);
+	  return (NULL);
+	}
+      for (j = pic->a.y; j <= pic->e.y; ++j)
+	for (i = 2 * pic->a.x; i <= 2 * pic->e.x + 1; ++i)
+	  *(pic->p + (j - pic->a.y) * 2 * (pic->e.x - pic->a.x + 1) +
+	    (i - 2 * pic->a.x)) = e_gt_byte (i, j);
 #if defined(NEWSTYLE) && !defined(NO_XWINDOWS)
-  e_get_pic_xrect(xa, ya, xe, ye, pic);
+      e_get_pic_xrect (xa, ya, xe, ye, pic);
 #endif
- }
- else pic->p = (char *)0;
- if (sw < 2)
- {
-  for (j = ya; j <= ye; ++j)
-   for (i = xa; i <= xe; ++i)
-    e_pr_char(i, j, ' ', col);
- }
+    }
+  else
+    pic->p = (char *) 0;
+  if (sw < 2)
+    {
+      for (j = ya; j <= ye; ++j)
+	for (i = xa; i <= xe; ++i)
+	  e_pr_char (i, j, ' ', col);
+    }
 #ifndef NO_XWINDOWS
- if (WpeIsXwin()) (*e_u_setlastpic)(pic);
+  if (WpeIsXwin ())
+    (*e_u_setlastpic) (pic);
 #endif
 #ifndef NEWSTYLE
- if (WpeIsXwin())
- {
-  if (sw != 0)
-  {
-   if (xe < MAXSCOL-1) for(i = ya+1; i <= ye+1 && i < MAXSLNS-1; i++)
-    e_pt_col(xe+1, i, SHDCOL);
-   if (xe < MAXSCOL-2) for(i = ya+1; i <= ye+1 && i < MAXSLNS-1; i++)
-    e_pt_col(xe+2, i, SHDCOL);
-   if (ye < MAXSLNS-2) for(i = xa+2; i <= xe; i++) e_pt_col(i, ye+1, SHDCOL);
-  }
- }
+  if (WpeIsXwin ())
+    {
+      if (sw != 0)
+	{
+	  if (xe < MAXSCOL - 1)
+	    for (i = ya + 1; i <= ye + 1 && i < MAXSLNS - 1; i++)
+	      e_pt_col (xe + 1, i, SHDCOL);
+	  if (xe < MAXSCOL - 2)
+	    for (i = ya + 1; i <= ye + 1 && i < MAXSLNS - 1; i++)
+	      e_pt_col (xe + 2, i, SHDCOL);
+	  if (ye < MAXSLNS - 2)
+	    for (i = xa + 2; i <= xe; i++)
+	      e_pt_col (i, ye + 1, SHDCOL);
+	}
+    }
 #endif
- return(pic);
+  return (pic);
 }
 
 /*   close screen section - refresh background  */
-int e_close_view(view *pic, int sw)
+int
+e_close_view (view * pic, int sw)
 {
- int i, j;
+  int i, j;
 #ifndef NO_XWINDOWS
- if (WpeIsXwin()) (*e_u_setlastpic)(NULL);
+  if (WpeIsXwin ())
+    (*e_u_setlastpic) (NULL);
 #endif
- if (pic == NULL) return(-1);
- if (sw != 0 && pic->p != NULL)
- {
-  for (j = pic->a.y; j <= pic->e.y; ++j)
-   for (i = 2*pic->a.x; i <= 2*pic->e.x+1; ++i)
-    e_pt_byte(i, j, *(pic->p + (j-pic->a.y)*2*(pic->e.x-pic->a.x+1) + (i-2*pic->a.x)));
+  if (pic == NULL)
+    return (-1);
+  if (sw != 0 && pic->p != NULL)
+    {
+      for (j = pic->a.y; j <= pic->e.y; ++j)
+	for (i = 2 * pic->a.x; i <= 2 * pic->e.x + 1; ++i)
+	  e_pt_byte (i, j,
+		     *(pic->p +
+		       (j - pic->a.y) * 2 * (pic->e.x - pic->a.x + 1) + (i -
+									 2 *
+									 pic->
+									 a.
+									 x)));
 #if defined(NEWSTYLE) && !defined(NO_XWINDOWS)
-  e_put_pic_xrect(pic);
+      e_put_pic_xrect (pic);
 #endif
- }
- else if (sw != 0)
- {
-  for (j = pic->a.y; j <= pic->e.y; ++j)
-   for (i = pic->a.x; i <= pic->e.x; ++i)
-    e_pr_char(i, j, ' ', 0);
- }
- if (sw < 2)
- {
-  if (pic->p != NULL) free(pic->p);
-  free(pic);
- }
- e_refresh();
- return(sw);
+    }
+  else if (sw != 0)
+    {
+      for (j = pic->a.y; j <= pic->e.y; ++j)
+	for (i = pic->a.x; i <= pic->e.x; ++i)
+	  e_pr_char (i, j, ' ', 0);
+    }
+  if (sw < 2)
+    {
+      if (pic->p != NULL)
+	free (pic->p);
+      free (pic);
+    }
+  e_refresh ();
+  return (sw);
 }
 
 /*    Frame for edit window   */
-void e_ed_rahmen(FENSTER *f, int sw)
+void
+e_ed_rahmen (FENSTER * f, int sw)
 {
- extern char *e_hlp;
- extern int nblst;
- extern WOPT *blst;
- char *header = NULL;
+  extern char *e_hlp;
+  extern int nblst;
+  extern WOPT *blst;
+  char *header = NULL;
 
- if (!DTMD_ISTEXT(f->dtmd))
- {
-  if (f->datnam[0]) header = f->datnam;
-  if (f->dtmd == DTMD_FILEDROPDOWN)
-   e_std_rahmen(f->a.x, f->a.y, f->e.x, f->e.y, header, sw, f->fb->er.fb,
-     f->fb->es.fb);
-  else
-   e_std_rahmen(f->a.x, f->a.y, f->e.x, f->e.y, header, sw, f->fb->nr.fb,
-     f->fb->ne.fb);
-  if (f->winnum < 10 && f->winnum >= 0)
-   e_pr_char(f->e.x-6, f->a.y, '0' + f->winnum, f->fb->nr.fb);
-  else if (f->winnum >= 0)
-   e_pr_char(f->e.x-6, f->a.y, 'A' - 10 + f->winnum, f->fb->nr.fb);
-  if (sw > 0 && (f->dtmd == DTMD_FILEMANAGER || f->dtmd == DTMD_DATA))
-  {
-   if (f->zoom == 0)
-    e_pr_char(f->e.x-3, f->a.y, WZN, f->fb->ne.fb);
-   else
-    e_pr_char(f->e.x-3, f->a.y, WZY, f->fb->ne.fb);
+  if (!DTMD_ISTEXT (f->dtmd))
+    {
+      if (f->datnam[0])
+	header = f->datnam;
+      if (f->dtmd == DTMD_FILEDROPDOWN)
+	e_std_rahmen (f->a.x, f->a.y, f->e.x, f->e.y, header, sw,
+		      f->fb->er.fb, f->fb->es.fb);
+      else
+	e_std_rahmen (f->a.x, f->a.y, f->e.x, f->e.y, header, sw,
+		      f->fb->nr.fb, f->fb->ne.fb);
+      if (f->winnum < 10 && f->winnum >= 0)
+	e_pr_char (f->e.x - 6, f->a.y, '0' + f->winnum, f->fb->nr.fb);
+      else if (f->winnum >= 0)
+	e_pr_char (f->e.x - 6, f->a.y, 'A' - 10 + f->winnum, f->fb->nr.fb);
+      if (sw > 0 && (f->dtmd == DTMD_FILEMANAGER || f->dtmd == DTMD_DATA))
+	{
+	  if (f->zoom == 0)
+	    e_pr_char (f->e.x - 3, f->a.y, WZN, f->fb->ne.fb);
+	  else
+	    e_pr_char (f->e.x - 3, f->a.y, WZY, f->fb->ne.fb);
 #ifdef NEWSTYLE
-   if (!WpeIsXwin())
-   {
+	  if (!WpeIsXwin ())
+	    {
 #endif
-    e_pr_char(f->e.x-4, f->a.y, '[', f->fb->nr.fb);
-    e_pr_char(f->e.x-2, f->a.y, ']', f->fb->nr.fb);
+	      e_pr_char (f->e.x - 4, f->a.y, '[', f->fb->nr.fb);
+	      e_pr_char (f->e.x - 2, f->a.y, ']', f->fb->nr.fb);
 #ifdef NEWSTYLE
-   }
-   else
-    e_make_xrect(f->e.x-4, f->a.y, f->e.x-2, f->a.y, 0);
+	    }
+	  else
+	    e_make_xrect (f->e.x - 4, f->a.y, f->e.x - 2, f->a.y, 0);
 #endif
-   blst = f->blst;
-   nblst = f->nblst;
-   e_hlp = f->hlp_str;
-   e_pr_uul(f->fb);
-  }
+	  blst = f->blst;
+	  nblst = f->nblst;
+	  e_hlp = f->hlp_str;
+	  e_pr_uul (f->fb);
+	}
 #ifdef NEWSTYLE
-  if (WpeIsXwin())
-   e_make_xr_rahmen(f->a.x, f->a.y, f->e.x, f->e.y, sw);
+      if (WpeIsXwin ())
+	e_make_xr_rahmen (f->a.x, f->a.y, f->e.x, f->e.y, sw);
 #endif
-  return;
- }
- if (f->datnam[0])
- {
-  if (strcmp(f->dirct, f->ed->dirct) == 0 ||
-    f->dtmd == DTMD_HELP || strcmp(f->datnam, BUFFER_NAME) == 0 ||
-    NUM_COLS_ON_SCREEN < 40)
-  {
-   header = (char *)malloc(strlen(f->datnam) + 1);
-   strcpy(header, f->datnam);
-  }
-  else
-  {
-   header = (char *)malloc(strlen(f->dirct) + strlen(f->datnam) + 1);
-   strcpy(header, f->dirct);
-   strcat(header, f->datnam);
-  }
- }
- e_std_rahmen(f->a.x, f->a.y, f->e.x, f->e.y, header, sw, f->fb->er.fb,
-   f->fb->es.fb);
- if (header)
-  free(header);
- if (sw > 0)
- {
-  e_mouse_bar(f->e.x, f->a.y+1, NUM_LINES_ON_SCREEN - 1, 0, f->fb->em.fb);
-  e_mouse_bar(f->a.x+19, f->e.y, NUM_COLS_ON_SCREEN - 20, 1, f->fb->em.fb);
-  if (f->zoom == 0)
-   e_pr_char(f->e.x-3, f->a.y, WZN, f->fb->es.fb);
-  else
-   e_pr_char(f->e.x-3, f->a.y, WZY, f->fb->es.fb);
+      return;
+    }
+  if (f->datnam[0])
+    {
+      if (strcmp (f->dirct, f->ed->dirct) == 0 ||
+	  f->dtmd == DTMD_HELP || strcmp (f->datnam, BUFFER_NAME) == 0 ||
+	  NUM_COLS_ON_SCREEN < 40)
+	{
+	  header = (char *) malloc (strlen (f->datnam) + 1);
+	  strcpy (header, f->datnam);
+	}
+      else
+	{
+	  header =
+	    (char *) malloc (strlen (f->dirct) + strlen (f->datnam) + 1);
+	  strcpy (header, f->dirct);
+	  strcat (header, f->datnam);
+	}
+    }
+  e_std_rahmen (f->a.x, f->a.y, f->e.x, f->e.y, header, sw, f->fb->er.fb,
+		f->fb->es.fb);
+  if (header)
+    free (header);
+  if (sw > 0)
+    {
+      e_mouse_bar (f->e.x, f->a.y + 1, NUM_LINES_ON_SCREEN - 1, 0,
+		   f->fb->em.fb);
+      e_mouse_bar (f->a.x + 19, f->e.y, NUM_COLS_ON_SCREEN - 20, 1,
+		   f->fb->em.fb);
+      if (f->zoom == 0)
+	e_pr_char (f->e.x - 3, f->a.y, WZN, f->fb->es.fb);
+      else
+	e_pr_char (f->e.x - 3, f->a.y, WZY, f->fb->es.fb);
 #ifdef NEWSTYLE
-  if (!WpeIsXwin())
-  {
+      if (!WpeIsXwin ())
+	{
 #endif
-   e_pr_char(f->e.x-4, f->a.y, '[', f->fb->er.fb);
-   e_pr_char(f->e.x-2, f->a.y, ']', f->fb->er.fb);
+	  e_pr_char (f->e.x - 4, f->a.y, '[', f->fb->er.fb);
+	  e_pr_char (f->e.x - 2, f->a.y, ']', f->fb->er.fb);
 #ifdef NEWSTYLE
-  }
-  else
-   e_make_xrect(f->e.x-4, f->a.y, f->e.x-2, f->a.y, 0);
+	}
+      else
+	e_make_xrect (f->e.x - 4, f->a.y, f->e.x - 2, f->a.y, 0);
 #endif
-  e_pr_filetype(f);
-  if (WpeIsXwin() && NUM_LINES_ON_SCREEN > 8)
-  {
+      e_pr_filetype (f);
+      if (WpeIsXwin () && NUM_LINES_ON_SCREEN > 8)
+	{
 #if !defined(NO_XWINDOWS) && defined(NEWSTYLE)
-   e_pr_char(f->a.x, f->a.y + 2, 'F', f->fb->em.fb);
-   e_make_xrect(f->a.x, f->a.y+2, f->a.x, f->a.y+2, 0);
-   e_pr_char(f->a.x, f->a.y + 4, 'R', f->fb->em.fb);
-   e_make_xrect(f->a.x, f->a.y+4, f->a.x, f->a.y+4, 0);
-   e_pr_char(f->a.x, f->a.y + 6, 'A', f->fb->em.fb);
-   e_make_xrect(f->a.x, f->a.y+6, f->a.x, f->a.y+6, 0);
-   if (f->ins != 8)
-   {
-    e_pr_char(f->a.x, f->a.y + 8, 'S', f->fb->em.fb);
-    e_make_xrect(f->a.x, f->a.y+8, f->a.x, f->a.y+8, 0);
-   }
+	  e_pr_char (f->a.x, f->a.y + 2, 'F', f->fb->em.fb);
+	  e_make_xrect (f->a.x, f->a.y + 2, f->a.x, f->a.y + 2, 0);
+	  e_pr_char (f->a.x, f->a.y + 4, 'R', f->fb->em.fb);
+	  e_make_xrect (f->a.x, f->a.y + 4, f->a.x, f->a.y + 4, 0);
+	  e_pr_char (f->a.x, f->a.y + 6, 'A', f->fb->em.fb);
+	  e_make_xrect (f->a.x, f->a.y + 6, f->a.x, f->a.y + 6, 0);
+	  if (f->ins != 8)
+	    {
+	      e_pr_char (f->a.x, f->a.y + 8, 'S', f->fb->em.fb);
+	      e_make_xrect (f->a.x, f->a.y + 8, f->a.x, f->a.y + 8, 0);
+	    }
 #else
-   e_pr_char(f->a.x, f->a.y + 2, 'F', f->fb->em.fb);
-   e_pr_char(f->a.x, f->a.y + 3, MCI, f->fb->em.fb);
-   e_pr_char(f->a.x, f->a.y + 4, 'R', f->fb->em.fb);
-   e_pr_char(f->a.x, f->a.y + 5, MCI, f->fb->em.fb);
-   e_pr_char(f->a.x, f->a.y + 6, 'A', f->fb->em.fb);
-   if (f->ins != 8)
-   {
-    e_pr_char(f->a.x, f->a.y + 7, MCI, f->fb->em.fb);
-    e_pr_char(f->a.x, f->a.y + 8, 'S', f->fb->em.fb);
-   }
+	  e_pr_char (f->a.x, f->a.y + 2, 'F', f->fb->em.fb);
+	  e_pr_char (f->a.x, f->a.y + 3, MCI, f->fb->em.fb);
+	  e_pr_char (f->a.x, f->a.y + 4, 'R', f->fb->em.fb);
+	  e_pr_char (f->a.x, f->a.y + 5, MCI, f->fb->em.fb);
+	  e_pr_char (f->a.x, f->a.y + 6, 'A', f->fb->em.fb);
+	  if (f->ins != 8)
+	    {
+	      e_pr_char (f->a.x, f->a.y + 7, MCI, f->fb->em.fb);
+	      e_pr_char (f->a.x, f->a.y + 8, 'S', f->fb->em.fb);
+	    }
 #endif
-  }
-  e_zlsplt(f);
-  blst = f->blst;
-  nblst = f->nblst;
-  e_hlp = f->hlp_str;
-  e_pr_uul(f->fb);
- }
- if (f->winnum < 10 && f->winnum >= 0)
-  e_pr_char(f->e.x-6, f->a.y, '0' + f->winnum, f->fb->er.fb);
- else if (f->winnum >= 0)
-  e_pr_char(f->e.x-6, f->a.y, 'A' - 10 + f->winnum, f->fb->er.fb);
+	}
+      e_zlsplt (f);
+      blst = f->blst;
+      nblst = f->nblst;
+      e_hlp = f->hlp_str;
+      e_pr_uul (f->fb);
+    }
+  if (f->winnum < 10 && f->winnum >= 0)
+    e_pr_char (f->e.x - 6, f->a.y, '0' + f->winnum, f->fb->er.fb);
+  else if (f->winnum >= 0)
+    e_pr_char (f->e.x - 6, f->a.y, 'A' - 10 + f->winnum, f->fb->er.fb);
 #ifdef NEWSTYLE
- if (WpeIsXwin())
-  e_make_xr_rahmen(f->a.x, f->a.y, f->e.x, f->e.y, sw);
+  if (WpeIsXwin ())
+    e_make_xr_rahmen (f->a.x, f->a.y, f->e.x, f->e.y, sw);
 #endif
 }
 
 /*   Output - screen content */
-int e_schirm(FENSTER *f, int sw)
+int
+e_schirm (FENSTER * f, int sw)
 {
- int j;
+  int j;
 
- if (f->dtmd == DTMD_FILEMANAGER)
-  return(WpeDrawFileManager(f));
- else if (f->dtmd == DTMD_DATA)
-  return(e_data_schirm(f));
- else if (f->dtmd == DTMD_FILEDROPDOWN)
-  return(e_pr_file_window((FLWND*)f->b, 1, sw, f->fb->er.fb, f->fb->ez.fb,
-    f->fb->frft.fb));
- if (NUM_LINES_OFF_SCREEN_TOP < 0)
-  NUM_LINES_OFF_SCREEN_TOP = 0;
+  if (f->dtmd == DTMD_FILEMANAGER)
+    return (WpeDrawFileManager (f));
+  else if (f->dtmd == DTMD_DATA)
+    return (e_data_schirm (f));
+  else if (f->dtmd == DTMD_FILEDROPDOWN)
+    return (e_pr_file_window
+	    ((FLWND *) f->b, 1, sw, f->fb->er.fb, f->fb->ez.fb,
+	     f->fb->frft.fb));
+  if (NUM_LINES_OFF_SCREEN_TOP < 0)
+    NUM_LINES_OFF_SCREEN_TOP = 0;
 
 #ifdef PROG
- if (f->c_sw)
-  for (j = NUM_LINES_OFF_SCREEN_TOP; j < f->b->mxlines && j < LINE_NUM_ON_SCREEN_BOTTOM ; j++ )
-   e_pr_c_line(j, f);
- else
+  if (f->c_sw)
+    for (j = NUM_LINES_OFF_SCREEN_TOP;
+	 j < f->b->mxlines && j < LINE_NUM_ON_SCREEN_BOTTOM; j++)
+      e_pr_c_line (j, f);
+  else
 #endif
-  for (j = NUM_LINES_OFF_SCREEN_TOP; j < f->b->mxlines && j < LINE_NUM_ON_SCREEN_BOTTOM ; j++ )
-   e_pr_line(j, f);
- for (; j < LINE_NUM_ON_SCREEN_BOTTOM ; j++ )
-  e_blk((NUM_COLS_ON_SCREEN - 1), f->a.x + 1, j - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, f->fb->et.fb);
- return(j);
+    for (j = NUM_LINES_OFF_SCREEN_TOP;
+	 j < f->b->mxlines && j < LINE_NUM_ON_SCREEN_BOTTOM; j++)
+      e_pr_line (j, f);
+  for (; j < LINE_NUM_ON_SCREEN_BOTTOM; j++)
+    e_blk ((NUM_COLS_ON_SCREEN - 1), f->a.x + 1,
+	   j - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, f->fb->et.fb);
+  return (j);
 }
 
 /*   Move and modify window */
-int e_size_move(FENSTER *f)
+int
+e_size_move (FENSTER * f)
 {
- int xa = f->a.x, ya = f->a.y, xe = f->e.x, ye = f->e.y;
- int c = 0, xmin = 26, ymin = 3;
+  int xa = f->a.x, ya = f->a.y, xe = f->e.x, ye = f->e.y;
+  int c = 0, xmin = 26, ymin = 3;
 
- e_ed_rahmen(f, 0);
- if (f->dtmd == DTMD_FILEDROPDOWN)
-  xmin = 15;
- else if (!DTMD_ISTEXT(f->dtmd))
-  ymin = 9;
- while ((c = e_getch()) != WPE_ESC && c != WPE_CR)
- {
-  switch (c)
-  {
-   case CLE:
-    if (xa > 0) {  xa--; xe--;  }
-    break;
-   case CRI:
-    if (xe < MAXSCOL-1) {  xa++; xe++;  }
-    break;
-   case CUP:
-    if (ya > 1) {  ya--; ye--;  }
-    break;
-   case CDO:
-    if (ye < MAXSLNS-2) {  ya++; ye++;  }
-    break;
-   case SCLE:
-   case CCLE:
-    if ((xe - xa) > xmin) xe--;
-    break;
-   case SCRI:
-   case CCRI:
-    if (xe < MAXSCOL-1) xe++;
-    break;
-   case SCUP:
-   case BUP:
-    if ((ye - ya) > ymin) ye--;
-    break;
-   case SCDO:
-   case BDO:
-    if (ye < MAXSLNS-2) ye++;
-    break;
-  }
-  if (xa != f->a.x || ya != f->a.y || xe != f->e.x || ye != f->e.y)
-  {
-   f->a.x = xa;
-   f->a.y = ya;
-   f->e.x = xe;
-   f->e.y = ye;
-   f->pic = e_ed_kst(f, f->pic, 0);
-   if (f->pic == NULL)  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-   if (f->dtmd == DTMD_FILEDROPDOWN)
-   {
-    FLWND *fw = (FLWND*) f->b;
-    fw->xa = f->a.x+1; fw->xe = f->e.x;
-    fw->ya = f->a.y+1; fw->ye = f->e.y;
-   }
-   e_cursor(f, 0);
-   e_schirm(f, 0);
-  }
- }
- e_ed_rahmen(f, 1);
- return(c);
+  e_ed_rahmen (f, 0);
+  if (f->dtmd == DTMD_FILEDROPDOWN)
+    xmin = 15;
+  else if (!DTMD_ISTEXT (f->dtmd))
+    ymin = 9;
+  while ((c = e_getch ()) != WPE_ESC && c != WPE_CR)
+    {
+      switch (c)
+	{
+	case CLE:
+	  if (xa > 0)
+	    {
+	      xa--;
+	      xe--;
+	    }
+	  break;
+	case CRI:
+	  if (xe < MAXSCOL - 1)
+	    {
+	      xa++;
+	      xe++;
+	    }
+	  break;
+	case CUP:
+	  if (ya > 1)
+	    {
+	      ya--;
+	      ye--;
+	    }
+	  break;
+	case CDO:
+	  if (ye < MAXSLNS - 2)
+	    {
+	      ya++;
+	      ye++;
+	    }
+	  break;
+	case SCLE:
+	case CCLE:
+	  if ((xe - xa) > xmin)
+	    xe--;
+	  break;
+	case SCRI:
+	case CCRI:
+	  if (xe < MAXSCOL - 1)
+	    xe++;
+	  break;
+	case SCUP:
+	case BUP:
+	  if ((ye - ya) > ymin)
+	    ye--;
+	  break;
+	case SCDO:
+	case BDO:
+	  if (ye < MAXSLNS - 2)
+	    ye++;
+	  break;
+	}
+      if (xa != f->a.x || ya != f->a.y || xe != f->e.x || ye != f->e.y)
+	{
+	  f->a.x = xa;
+	  f->a.y = ya;
+	  f->e.x = xe;
+	  f->e.y = ye;
+	  f->pic = e_ed_kst (f, f->pic, 0);
+	  if (f->pic == NULL)
+	    e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+	  if (f->dtmd == DTMD_FILEDROPDOWN)
+	    {
+	      FLWND *fw = (FLWND *) f->b;
+	      fw->xa = f->a.x + 1;
+	      fw->xe = f->e.x;
+	      fw->ya = f->a.y + 1;
+	      fw->ye = f->e.y;
+	    }
+	  e_cursor (f, 0);
+	  e_schirm (f, 0);
+	}
+    }
+  e_ed_rahmen (f, 1);
+  return (c);
 }
 
 /*       Standard Box                                  */
-view *e_std_kst(int xa, int ya, int xe, int ye, char *name, int sw, int fr,
-  int ft, int fes)
+view *
+e_std_kst (int xa, int ya, int xe, int ye, char *name, int sw, int fr,
+	   int ft, int fes)
 {
- view *pic = e_open_view(xa, ya, xe, ye, ft, 1);
- if (pic == NULL) return (NULL);
- e_std_rahmen(xa, ya, xe, ye, name, sw, fr, fes);
- return(pic);
+  view *pic = e_open_view (xa, ya, xe, ye, ft, 1);
+  if (pic == NULL)
+    return (NULL);
+  e_std_rahmen (xa, ya, xe, ye, name, sw, fr, fes);
+  return (pic);
 }
 
-view *e_change_pic(int xa, int ya, int xe, int ye, view *pic, int sw, int frb)
+view *
+e_change_pic (int xa, int ya, int xe, int ye, view * pic, int sw, int frb)
 {
-   int i, j;
-   int box = 2, ax, ay, ex, ey;
-   view *newpic;
-   if(sw<0) {  sw = -sw; box = 1;  }
-   if (pic == NULL)
-   {  newpic = e_open_view(xa, ya, xe, ye, frb, box);
-      if (newpic == NULL) return (NULL);
-   }
-   else if (xa > pic->e.x || xe < pic->a.x ||
-                                          ya > pic->e.y || ye < pic->a.y)
-   {  e_close_view(pic, box);
-      newpic = e_open_view(xa, ya, xe, ye, frb, box);
-      if (newpic == NULL) return (NULL);
-   }
-   else
-   {
-      newpic = malloc(sizeof(view));
-      if(newpic == NULL)  return(NULL);
+  int i, j;
+  int box = 2, ax, ay, ex, ey;
+  view *newpic;
+  if (sw < 0)
+    {
+      sw = -sw;
+      box = 1;
+    }
+  if (pic == NULL)
+    {
+      newpic = e_open_view (xa, ya, xe, ye, frb, box);
+      if (newpic == NULL)
+	return (NULL);
+    }
+  else if (xa > pic->e.x || xe < pic->a.x || ya > pic->e.y || ye < pic->a.y)
+    {
+      e_close_view (pic, box);
+      newpic = e_open_view (xa, ya, xe, ye, frb, box);
+      if (newpic == NULL)
+	return (NULL);
+    }
+  else
+    {
+      newpic = malloc (sizeof (view));
+      if (newpic == NULL)
+	return (NULL);
       newpic->a.x = xa;
       newpic->a.y = ya;
 #ifndef NEWSTYLE
-      if(!WpeIsXwin())
-      {  newpic->e.x = xe;
-	 newpic->e.y = ye;
-      }
+      if (!WpeIsXwin ())
+	{
+	  newpic->e.x = xe;
+	  newpic->e.y = ye;
+	}
       else
-      {  newpic->e.x = xe < MAXSCOL-2 ? xe + 2 : xe < MAXSCOL-1 ? xe + 1 : xe;
-	 newpic->e.y = ye < MAXSLNS-2 ? ye + 1 : ye;
-      }
+	{
+	  newpic->e.x =
+	    xe < MAXSCOL - 2 ? xe + 2 : xe < MAXSCOL - 1 ? xe + 1 : xe;
+	  newpic->e.y = ye < MAXSLNS - 2 ? ye + 1 : ye;
+	}
 #else
       newpic->e.x = xe;
       newpic->e.y = ye;
 #endif
 #if !defined(NO_XWINDOWS) && defined(NEWSTYLE)
-      newpic->p = malloc( (newpic->e.x - newpic->a.x + 1) * 3
-				* (newpic->e.y - newpic->a.y + 1) );
+      newpic->p = malloc ((newpic->e.x - newpic->a.x + 1) * 3
+			  * (newpic->e.y - newpic->a.y + 1));
 #else
-      newpic->p = malloc( (newpic->e.x - newpic->a.x + 1) * 2
-				* (newpic->e.y - newpic->a.y + 1) );
+      newpic->p = malloc ((newpic->e.x - newpic->a.x + 1) * 2
+			  * (newpic->e.y - newpic->a.y + 1));
 #endif
-      if (newpic->p == NULL) {  free(newpic);  return(NULL);  }
+      if (newpic->p == NULL)
+	{
+	  free (newpic);
+	  return (NULL);
+	}
       ax = pic->a.x > newpic->a.x ? pic->a.x : newpic->a.x;
       ay = pic->a.y > newpic->a.y ? pic->a.y : newpic->a.y;
       ex = pic->e.x < newpic->e.x ? pic->e.x : newpic->e.x;
       ey = pic->e.y < newpic->e.y ? pic->e.y : newpic->e.y;
       for (j = ay; j <= ey; ++j)
-      for (i = 2*ax; i <= 2*ex+1; ++i)
-      {  *(newpic->p + 2*(newpic->e.x-newpic->a.x+1)*(j-newpic->a.y)
-				+ (i-2*newpic->a.x))
-                   = *(pic->p + 2*(pic->e.x-pic->a.x+1)*(j-pic->a.y)
-                                 + (i - 2*pic->a.x) );
-      }
-      
+	for (i = 2 * ax; i <= 2 * ex + 1; ++i)
+	  {
+	    *(newpic->p +
+	      2 * (newpic->e.x - newpic->a.x + 1) * (j - newpic->a.y) + (i -
+									 2 *
+									 newpic->
+									 a.
+									 x)) =
+	      *(pic->p + 2 * (pic->e.x - pic->a.x + 1) * (j - pic->a.y) +
+		(i - 2 * pic->a.x));
+	  }
+
       for (j = newpic->a.y; j < ay; ++j)
-      for (i = 2*newpic->a.x; i <= 2*newpic->e.x+1; ++i)
-      {  *(newpic->p + 2*(newpic->e.x-newpic->a.x+1)*(j-newpic->a.y)
-		+ (i-2*newpic->a.x)) = e_gt_byte(i, j);
-      }
-      
+	for (i = 2 * newpic->a.x; i <= 2 * newpic->e.x + 1; ++i)
+	  {
+	    *(newpic->p +
+	      2 * (newpic->e.x - newpic->a.x + 1) * (j - newpic->a.y) + (i -
+									 2 *
+									 newpic->
+									 a.
+									 x)) =
+	      e_gt_byte (i, j);
+	  }
+
       for (j = newpic->e.y; j > ey; --j)
-      for (i = 2*newpic->a.x; i <= 2*newpic->e.x+1; ++i)
-      {  *(newpic->p + 2*(newpic->e.x-newpic->a.x+1)*(j-newpic->a.y)
-		+ (i-2*newpic->a.x)) = e_gt_byte(i, j);
-      }
-      
+	for (i = 2 * newpic->a.x; i <= 2 * newpic->e.x + 1; ++i)
+	  {
+	    *(newpic->p +
+	      2 * (newpic->e.x - newpic->a.x + 1) * (j - newpic->a.y) + (i -
+									 2 *
+									 newpic->
+									 a.
+									 x)) =
+	      e_gt_byte (i, j);
+	  }
+
       for (j = newpic->a.y; j <= newpic->e.y; ++j)
-      for (i = 2*newpic->a.x; i < 2*ax; ++i)
-      {  *(newpic->p + 2*(newpic->e.x-newpic->a.x+1)*(j-newpic->a.y)
-		+ (i-2*newpic->a.x)) = e_gt_byte(i, j);
-      }
-      
+	for (i = 2 * newpic->a.x; i < 2 * ax; ++i)
+	  {
+	    *(newpic->p +
+	      2 * (newpic->e.x - newpic->a.x + 1) * (j - newpic->a.y) + (i -
+									 2 *
+									 newpic->
+									 a.
+									 x)) =
+	      e_gt_byte (i, j);
+	  }
+
       for (j = newpic->a.y; j <= newpic->e.y; ++j)
-      for (i = 2*(ex+1); i <= 2*newpic->e.x + 1; ++i)
-      {  *(newpic->p + 2*(newpic->e.x-newpic->a.x+1)*(j-newpic->a.y)
-		+ (i-2*newpic->a.x)) = e_gt_byte(i, j);
-      }
+	for (i = 2 * (ex + 1); i <= 2 * newpic->e.x + 1; ++i)
+	  {
+	    *(newpic->p +
+	      2 * (newpic->e.x - newpic->a.x + 1) * (j - newpic->a.y) + (i -
+									 2 *
+									 newpic->
+									 a.
+									 x)) =
+	      e_gt_byte (i, j);
+	  }
       for (j = pic->a.y; j < ya; ++j)
-      for (i = 2*pic->a.x; i <= 2*pic->e.x+1; ++i)
-      e_pt_byte(i, j, *( pic->p + (j-pic->a.y)*2
-                         *(pic->e.x-pic->a.x+1) + (i-2*pic->a.x) ) );
+	for (i = 2 * pic->a.x; i <= 2 * pic->e.x + 1; ++i)
+	  e_pt_byte (i, j, *(pic->p + (j - pic->a.y) * 2
+			     * (pic->e.x - pic->a.x + 1) + (i -
+							    2 * pic->a.x)));
       for (j = pic->a.y; j <= pic->e.y; ++j)
-      for (i = 2*pic->a.x; i < 2*xa; i=i+1)
-      e_pt_byte(i, j, *( pic->p + (j-pic->a.y)*2
-                       *(pic->e.x-pic->a.x+1) + (i - 2*pic->a.x) ) );
+	for (i = 2 * pic->a.x; i < 2 * xa; i = i + 1)
+	  e_pt_byte (i, j, *(pic->p + (j - pic->a.y) * 2
+			     * (pic->e.x - pic->a.x + 1) + (i -
+							    2 * pic->a.x)));
       for (j = pic->e.y; j > ye; --j)
-      for (i = 2*pic->a.x; i <= 2*pic->e.x+1; ++i)
-      e_pt_byte(i, j, *( pic->p + (j-pic->a.y)*2
-                       *(pic->e.x-pic->a.x+1) + (i-2*pic->a.x) ) );
+	for (i = 2 * pic->a.x; i <= 2 * pic->e.x + 1; ++i)
+	  e_pt_byte (i, j, *(pic->p + (j - pic->a.y) * 2
+			     * (pic->e.x - pic->a.x + 1) + (i -
+							    2 * pic->a.x)));
       for (j = pic->e.y; j >= pic->a.y; --j)
-      for (i = 2*pic->e.x + 1; i > 2*xe; --i)
-      e_pt_byte(i, j, *( pic->p + (j-pic->a.y)*2
-                       *(pic->e.x-pic->a.x+1) + (i-2*pic->a.x) ) );
+	for (i = 2 * pic->e.x + 1; i > 2 * xe; --i)
+	  e_pt_byte (i, j, *(pic->p + (j - pic->a.y) * 2
+			     * (pic->e.x - pic->a.x + 1) + (i -
+							    2 * pic->a.x)));
 #if !defined(NO_XWINDOWS) && defined(NEWSTYLE)
-      e_put_pic_xrect(pic);
-      e_get_pic_xrect(xa, ya, xe, ye, newpic);
+      e_put_pic_xrect (pic);
+      e_get_pic_xrect (xa, ya, xe, ye, newpic);
 #endif
 #ifndef NEWSTYLE
-      if (WpeIsXwin())
-      {  if(xe < MAXSCOL-1) for(i = ya+1; i <= ye+1 && i < MAXSLNS-1; i++) 
-						e_pt_col(xe+1, i, SHDCOL);
-         if(xe < MAXSCOL-2) for(i = ya+1; i <= ye+1 && i < MAXSLNS-1; i++)
-						e_pt_col(xe+2, i, SHDCOL);
-         if(ye < MAXSLNS-2) for(i = xa+2; i <= xe; i++)
-      						e_pt_col(i, ye+1, SHDCOL);
-      }
+      if (WpeIsXwin ())
+	{
+	  if (xe < MAXSCOL - 1)
+	    for (i = ya + 1; i <= ye + 1 && i < MAXSLNS - 1; i++)
+	      e_pt_col (xe + 1, i, SHDCOL);
+	  if (xe < MAXSCOL - 2)
+	    for (i = ya + 1; i <= ye + 1 && i < MAXSLNS - 1; i++)
+	      e_pt_col (xe + 2, i, SHDCOL);
+	  if (ye < MAXSLNS - 2)
+	    for (i = xa + 2; i <= xe; i++)
+	      e_pt_col (i, ye + 1, SHDCOL);
+	}
 #endif
-      free(pic->p);
-      free(pic);
-   }
+      free (pic->p);
+      free (pic);
+    }
 #ifndef NO_XWINDOWS
-   if (WpeIsXwin()) (*e_u_setlastpic)(newpic);
+  if (WpeIsXwin ())
+    (*e_u_setlastpic) (newpic);
 #endif
-   return(newpic);
+  return (newpic);
 }
 
-view *e_ed_kst(FENSTER *f, view *pic, int sw)
+view *
+e_ed_kst (FENSTER * f, view * pic, int sw)
 {
-   view *newpic = e_change_pic(f->a.x, f->a.y, f->e.x,
-				f->e.y, pic, sw, f->fb->er.fb);
-   e_ed_rahmen(f, sw);
-   return(newpic);
+  view *newpic = e_change_pic (f->a.x, f->a.y, f->e.x,
+			       f->e.y, pic, sw, f->fb->er.fb);
+  e_ed_rahmen (f, sw);
+  return (newpic);
 }
 
 /*    delete buffer     */
-int e_close_buffer(BUFFER *b)
+int
+e_close_buffer (BUFFER * b)
 {
- int i;
+  int i;
 
- if (b != NULL)
- {
-  e_remove_undo(b->ud, b->cn->numundo + 1);
-  if (b->bf != NULL)
-  {
-   for (i = 0; i < b->mxlines; i++)
-   {
-    if (b->bf[i].s != NULL)
-     free( b->bf[i].s );
-    b->bf[i].s = NULL;
-   }
-   free(b->bf);
-  }
-  free(b);
- }
- return(0);
+  if (b != NULL)
+    {
+      e_remove_undo (b->ud, b->cn->numundo + 1);
+      if (b->bf != NULL)
+	{
+	  for (i = 0; i < b->mxlines; i++)
+	    {
+	      if (b->bf[i].s != NULL)
+		free (b->bf[i].s);
+	      b->bf[i].s = NULL;
+	    }
+	  free (b->bf);
+	}
+      free (b);
+    }
+  return (0);
 }
 
 /*    close window */
-int e_close_window(FENSTER *f)
+int
+e_close_window (FENSTER * f)
 {
- ECNT *cn = f->ed;
- FENSTER *f0 = f->ed->f[0];
- int c = 0;
- unsigned long maxname;
- char text[256];
+  ECNT *cn = f->ed;
+  FENSTER *f0 = f->ed->f[0];
+  int c = 0;
+  unsigned long maxname;
+  char text[256];
 
- f = cn->f[cn->mxedt];
- if (f->dtmd == DTMD_FILEMANAGER)
- {
-  FLBFFR *b = (FLBFFR *)f->b;
+  f = cn->f[cn->mxedt];
+  if (f->dtmd == DTMD_FILEMANAGER)
+    {
+      FLBFFR *b = (FLBFFR *) f->b;
 
-  free(f->dirct);
-  free(b->rdfile);
-  freedf(b->df);  freedf(b->fw->df);
-  freedf(b->dd);  freedf(b->cd);  freedf(b->dw->df);
-  free(b->fw);
-  free(b->dw);
-  free(b);
-  (cn->mxedt)--;
-  cn->curedt = cn->edt[cn->mxedt];
-  e_close_view(f->pic, 1);
-  if (f != f0 && f != NULL)
-  {
-   e_free_find(&f->fd);
-   free(f);
-  }
-  if (cn->mxedt > 0)
-  {
-   f = cn->f[cn->mxedt];
-   e_ed_rahmen(f, 1);
-  }
-  return(0);
- }
- if (f->dtmd == DTMD_DATA)
- {
-  FLWND *fw = (FLWND *)f->b;
-  int swt = f->ins;
+      free (f->dirct);
+      free (b->rdfile);
+      freedf (b->df);
+      freedf (b->fw->df);
+      freedf (b->dd);
+      freedf (b->cd);
+      freedf (b->dw->df);
+      free (b->fw);
+      free (b->dw);
+      free (b);
+      (cn->mxedt)--;
+      cn->curedt = cn->edt[cn->mxedt];
+      e_close_view (f->pic, 1);
+      if (f != f0 && f != NULL)
+	{
+	  e_free_find (&f->fd);
+	  free (f);
+	}
+      if (cn->mxedt > 0)
+	{
+	  f = cn->f[cn->mxedt];
+	  e_ed_rahmen (f, 1);
+	}
+      return (0);
+    }
+  if (f->dtmd == DTMD_DATA)
+    {
+      FLWND *fw = (FLWND *) f->b;
+      int swt = f->ins;
 
 #ifdef PROG
-  if (swt == 4 && f->save)
-   e_p_update_prj_fl(f);
+      if (swt == 4 && f->save)
+	e_p_update_prj_fl (f);
 #endif
-  if (f->dirct)
-   free(f->dirct);
-  if (swt == 7)
-   freedf(fw->df);
-  free(fw);
+      if (f->dirct)
+	free (f->dirct);
+      if (swt == 7)
+	freedf (fw->df);
+      free (fw);
+      (cn->mxedt)--;
+      cn->curedt = cn->edt[cn->mxedt];
+      e_close_view (f->pic, 1);
+      if (f != f0 && f != NULL)
+	{
+	  e_free_find (&f->fd);
+	  free (f);
+	}
+      if (cn->mxedt > 0 && (swt < 5 || swt == 7))
+	{
+	  f = cn->f[cn->mxedt];
+	  e_ed_rahmen (f, 1);
+	}
+      return (0);
+    }
+  if (f == NULL || f->ed->mxedt <= 0)
+    return (0);
+  if (f != f0)
+    {
+      if (f->save != 0 && f->ins != 8)
+	{
+	  sprintf (text, "File %s NOT saved!\nDo you want to save File ?",
+		   f->datnam);
+	  c = e_message (1, text, f);
+	  if (c == WPE_ESC)
+	    return (c);
+	  else if (c == 'Y')
+	    e_save (f);
+	}
+      /* Check if file system could have an autosave or emergency save file
+         >12 check is to eliminate dos file systems */
+      if (((maxname =
+	    pathconf (f->dirct, _PC_NAME_MAX)) >= strlen (f->datnam) + 4)
+	  && (maxname > 12))
+	{
+	  remove (e_make_postf (text, f->datnam, ".ASV"));
+	  remove (e_make_postf (text, f->datnam, ".ESV"));
+	}
+      if (strcmp (f->datnam, "Messages") && strcmp (f->datnam, "Watches"))
+	e_close_buffer (f->b);
+      if (f->dtmd == DTMD_HELP && f->ins == 8)
+	e_help_free (f);
+      if (f->datnam != NULL)
+	free (f->datnam);
+      if (f->dirct != NULL)
+	free (f->dirct);
+      if (f && f->s != NULL)
+	free (f->s);
+    }
   (cn->mxedt)--;
   cn->curedt = cn->edt[cn->mxedt];
-  e_close_view(f->pic, 1);
+  e_close_view (f->pic, 1);
   if (f != f0 && f != NULL)
-  {
-   e_free_find(&f->fd);
-   free(f);
-  }
-  if (cn->mxedt > 0 && (swt < 5 || swt == 7))
-  {
-   f = cn->f[cn->mxedt];
-   e_ed_rahmen(f, 1);
-  }
-  return(0);
- }
- if (f == NULL || f->ed->mxedt <= 0)
-  return(0);
- if (f != f0)
- {
-  if (f->save != 0 && f->ins != 8)
-  {
-   sprintf(text, "File %s NOT saved!\nDo you want to save File ?", f->datnam);
-   c = e_message(1, text, f);
-   if (c == WPE_ESC)
-    return(c);
-   else if (c == 'Y')
-    e_save(f);
-  }
-  /* Check if file system could have an autosave or emergency save file
-     >12 check is to eliminate dos file systems */
-  if (((maxname = pathconf(f->dirct, _PC_NAME_MAX)) >= strlen(f->datnam) + 4) &&
-    (maxname > 12))
-  {
-   remove(e_make_postf(text, f->datnam, ".ASV"));
-   remove(e_make_postf(text, f->datnam, ".ESV"));
-  }
-  if (strcmp(f->datnam, "Messages") && strcmp(f->datnam, "Watches"))
-   e_close_buffer(f->b);
-  if (f->dtmd == DTMD_HELP && f->ins == 8)
-   e_help_free(f);
-  if (f->datnam != NULL)
-   free(f->datnam);
-  if (f->dirct != NULL)
-   free(f->dirct);
-  if (f && f->s != NULL)
-   free(f->s);
- }
- (cn->mxedt)--;
- cn->curedt = cn->edt[cn->mxedt];
- e_close_view(f->pic, 1);
- if (f != f0 && f != NULL)
- {
-  e_free_find(&f->fd);
-  free(f);
- }
- if (cn->mxedt > 0)
- {
-  f = cn->f[cn->mxedt];
-  e_ed_rahmen(f, 1);
- }
- return(c);
+    {
+      e_free_find (&f->fd);
+      free (f);
+    }
+  if (cn->mxedt > 0)
+    {
+      f = cn->f[cn->mxedt];
+      e_ed_rahmen (f, 1);
+    }
+  return (c);
 }
 
 /*    Toggle among windows  */
-int e_rep_win_tree(ECNT *cn)
+int
+e_rep_win_tree (ECNT * cn)
 {
- int i;
+  int i;
 
- if (cn->mxedt <= 0) return(0);
- ini_repaint(cn);
- for ( i = 1; i < cn->mxedt; i++)
- {
-  e_firstl(cn->f[i], 0);
-  e_schirm(cn->f[i], 0);
- }
- e_firstl(cn->f[i], 1);
- e_schirm(cn->f[i], 1);
- e_cursor(cn->f[i], 1);
- end_repaint();
- return(0);
+  if (cn->mxedt <= 0)
+    return (0);
+  ini_repaint (cn);
+  for (i = 1; i < cn->mxedt; i++)
+    {
+      e_firstl (cn->f[i], 0);
+      e_schirm (cn->f[i], 0);
+    }
+  e_firstl (cn->f[i], 1);
+  e_schirm (cn->f[i], 1);
+  e_cursor (cn->f[i], 1);
+  end_repaint ();
+  return (0);
 }
 
-void e_switch_window(int num, FENSTER *f)
+void
+e_switch_window (int num, FENSTER * f)
 {
- ECNT *cn = f->ed;
- FENSTER *ft;
- int n, i, te;
+  ECNT *cn = f->ed;
+  FENSTER *ft;
+  int n, i, te;
 
- for (n = 1; cn->edt[n] != num && n < cn->mxedt; n++)
-  ;
- if (n >= cn->mxedt) return;
- for (i = cn->mxedt; i >= 1; i--)
- {
-  free(cn->f[i]->pic->p);
-  free(cn->f[i]->pic);
- }
- ft = cn->f[n];
- te = cn->edt[n];
- for ( i = n; i < cn->mxedt; i++)
- {
-  cn->edt[i] = cn->edt[i+1];
-  cn->f[i] = cn->f[i+1];
- }
- cn->f[i] = ft;
- cn->edt[i] = te;
- cn->curedt = num;
- e_rep_win_tree(cn);
+  for (n = 1; cn->edt[n] != num && n < cn->mxedt; n++)
+    ;
+  if (n >= cn->mxedt)
+    return;
+  for (i = cn->mxedt; i >= 1; i--)
+    {
+      free (cn->f[i]->pic->p);
+      free (cn->f[i]->pic);
+    }
+  ft = cn->f[n];
+  te = cn->edt[n];
+  for (i = n; i < cn->mxedt; i++)
+    {
+      cn->edt[i] = cn->edt[i + 1];
+      cn->f[i] = cn->f[i + 1];
+    }
+  cn->f[i] = ft;
+  cn->edt[i] = te;
+  cn->curedt = num;
+  e_rep_win_tree (cn);
 }
 
 /*    zoom windows   */
-int e_ed_zoom(FENSTER *f)
+int
+e_ed_zoom (FENSTER * f)
 {
- if (f->ed->mxedt > 0)
- {
-  if(f->zoom == 0)
-  {
-   f->sa = e_set_pnt(f->a.x, f->a.y);
-   f->se = e_set_pnt(f->e.x, f->e.y);
-   f->a = e_set_pnt(0, 1);
-   f->e = e_set_pnt(MAXSCOL-1, MAXSLNS-2);
-   f->zoom = 1;
-  }
-  else
-  {
-   f->a = e_set_pnt(f->sa.x, f->sa.y);
-   f->e = e_set_pnt(f->se.x, f->se.y);
-   f->zoom = 0;
-  }
-  f->pic = e_ed_kst(f, f->pic, 1);
-  if(f->pic == NULL)  e_error(e_msg[ERR_LOWMEM], 1, f->fb);
-  e_cursor(f, 1);
-  e_schirm(f, 1);
- }
- return(WPE_ESC);
+  if (f->ed->mxedt > 0)
+    {
+      if (f->zoom == 0)
+	{
+	  f->sa = e_set_pnt (f->a.x, f->a.y);
+	  f->se = e_set_pnt (f->e.x, f->e.y);
+	  f->a = e_set_pnt (0, 1);
+	  f->e = e_set_pnt (MAXSCOL - 1, MAXSLNS - 2);
+	  f->zoom = 1;
+	}
+      else
+	{
+	  f->a = e_set_pnt (f->sa.x, f->sa.y);
+	  f->e = e_set_pnt (f->se.x, f->se.y);
+	  f->zoom = 0;
+	}
+      f->pic = e_ed_kst (f, f->pic, 1);
+      if (f->pic == NULL)
+	e_error (e_msg[ERR_LOWMEM], 1, f->fb);
+      e_cursor (f, 1);
+      e_schirm (f, 1);
+    }
+  return (WPE_ESC);
 }
 
 /*   cascade windows   */
-int e_ed_cascade(FENSTER *f)
+int
+e_ed_cascade (FENSTER * f)
 {
- ECNT *cn = f->ed;
- int i;
+  ECNT *cn = f->ed;
+  int i;
 
- if (cn->mxedt < 1)
-  return 0; /* no windows open */
- for (i = cn->mxedt; i >= 1; i--)
- {
-  free(cn->f[i]->pic->p);
-  free(cn->f[i]->pic);
-  cn->f[i]->a = e_set_pnt(i-1, i);
-  cn->f[i]->e = e_set_pnt(MAXSCOL-1-cn->mxedt+i, MAXSLNS-2-cn->mxedt+i);
- }
- ini_repaint(cn);
- for ( i = 1; i < cn->mxedt; i++)
- {
-  e_firstl(cn->f[i], 0);
-  e_schirm(cn->f[i], 0);
- }
- e_firstl(cn->f[i], 1);
- e_schirm(cn->f[i], 1);
- e_cursor(cn->f[i], 1);
- end_repaint();
- return(0);
+  if (cn->mxedt < 1)
+    return 0;			/* no windows open */
+  for (i = cn->mxedt; i >= 1; i--)
+    {
+      free (cn->f[i]->pic->p);
+      free (cn->f[i]->pic);
+      cn->f[i]->a = e_set_pnt (i - 1, i);
+      cn->f[i]->e =
+	e_set_pnt (MAXSCOL - 1 - cn->mxedt + i, MAXSLNS - 2 - cn->mxedt + i);
+    }
+  ini_repaint (cn);
+  for (i = 1; i < cn->mxedt; i++)
+    {
+      e_firstl (cn->f[i], 0);
+      e_schirm (cn->f[i], 0);
+    }
+  e_firstl (cn->f[i], 1);
+  e_schirm (cn->f[i], 1);
+  e_cursor (cn->f[i], 1);
+  end_repaint ();
+  return (0);
 }
 
 /*   Tile windows   */
-int e_ed_tile(FENSTER *f)
+int
+e_ed_tile (FENSTER * f)
 {
- ECNT *cn = f->ed;
- POINT atmp[MAXEDT+1];
- POINT etmp[MAXEDT+1];
- int i, j, ni, nj;
- int editwin = 0; /* number of editor windows */
- int editorwin[MAXEDT + 1];
- int maxlines = MAXSLNS;
+  ECNT *cn = f->ed;
+  POINT atmp[MAXEDT + 1];
+  POINT etmp[MAXEDT + 1];
+  int i, j, ni, nj;
+  int editwin = 0;		/* number of editor windows */
+  int editorwin[MAXEDT + 1];
+  int maxlines = MAXSLNS;
 
- for (i = cn->mxedt; i >= 1; i--)
- {
-  if ((!(cn->edopt & ED_OLD_TILE_METHOD)) && (!DTMD_ISTEXT(cn->f[i]->dtmd) ||
-    ((WpeIsProg()) && ((strcmp(cn->f[i]->datnam, "Messages") == 0) ||
-    (strcmp(cn->f[i]->datnam, "Watches") == 0)))))
-  {
-   editorwin[i] = 0;
-  }
-  else
-  {
-   editwin++;
-   editorwin[i] = 1;
-  }
- }
- if (editwin < 1)
-  return(0);
- if ((!(cn->edopt & ED_OLD_TILE_METHOD)) && (WpeIsProg()))
- {
-  maxlines -= MAXSLNS / 3 - 1;
- }
- for (i = cn->mxedt; i >= 1; i--)
- {
-  free(cn->f[i]->pic->p);
-  free(cn->f[i]->pic);
- }
- for (ni = editwin, nj = 1; ni > 1; ni--)
- {
-  nj = editwin / ni;
-  if (editwin % ni)
-   nj++;
-  if (nj >= ni)
-   break;
- }
- if (nj*ni < editwin)
-  nj++;
- for (j = 0; j < nj; j++)
- {
-  for (i = 0; i < ni; i++)
-  {
-   if (j == 0)
-   {
-    if (i == 0)
+  for (i = cn->mxedt; i >= 1; i--)
     {
-     atmp[j*ni+i].x = i * MAXSCOL / ni;
-     etmp[j*ni+i].x = (i + 1) * MAXSCOL / ni - 1;
-     if (etmp[j*ni+i].x - atmp[j*ni+i].x < 26)
-      etmp[j*ni+i].x = atmp[j*ni+i].x + 26;
+      if ((!(cn->edopt & ED_OLD_TILE_METHOD))
+	  && (!DTMD_ISTEXT (cn->f[i]->dtmd)
+	      || ((WpeIsProg ())
+		  && ((strcmp (cn->f[i]->datnam, "Messages") == 0)
+		      || (strcmp (cn->f[i]->datnam, "Watches") == 0)))))
+	{
+	  editorwin[i] = 0;
+	}
+      else
+	{
+	  editwin++;
+	  editorwin[i] = 1;
+	}
     }
-    else
+  if (editwin < 1)
+    return (0);
+  if ((!(cn->edopt & ED_OLD_TILE_METHOD)) && (WpeIsProg ()))
     {
-     etmp[j*ni+i].x = (i + 1) * MAXSCOL / ni - 1;
-     atmp[j*ni+i].x = etmp[j*ni+i-1].x + 1;
-     if (etmp[j*ni+i].x - atmp[j*ni+i].x < 26)
-      etmp[j*ni+i].x = atmp[j*ni+i].x + 26;
-     if (etmp[j*ni+i].x >= MAXSCOL)
-     {
-      etmp[j*ni+i].x = MAXSCOL - 1;
-      atmp[j*ni+i].x = etmp[j*ni+i].x - 26;
-     }
+      maxlines -= MAXSLNS / 3 - 1;
     }
-   }
-   else
-   {
-    atmp[j*ni+i].x = atmp[(j-1)*ni+i].x;
-    etmp[j*ni+i].x = etmp[(j-1)*ni+i].x;
-    /* make the last window full width */
-    if ((j * ni + i) == (editwin - 1))
-     etmp[j * ni + i].x = MAXSCOL - 1;
-   }
-  }
- }
- for (i = 0; i < ni; i++)
- {
+  for (i = cn->mxedt; i >= 1; i--)
+    {
+      free (cn->f[i]->pic->p);
+      free (cn->f[i]->pic);
+    }
+  for (ni = editwin, nj = 1; ni > 1; ni--)
+    {
+      nj = editwin / ni;
+      if (editwin % ni)
+	nj++;
+      if (nj >= ni)
+	break;
+    }
+  if (nj * ni < editwin)
+    nj++;
   for (j = 0; j < nj; j++)
-  {
-   if (i == 0)
-   {
-    if (j == 0)
     {
-     atmp[j*ni+i].y = j * (maxlines-2) / nj + 1;
-     etmp[j*ni+i].y = (j + 1) * (maxlines-2) / nj;
-     if (etmp[j*ni+i].y - atmp[j*ni+i].y < 3)
-      etmp[j*ni+i].y = atmp[j*ni+i].y + 3;
+      for (i = 0; i < ni; i++)
+	{
+	  if (j == 0)
+	    {
+	      if (i == 0)
+		{
+		  atmp[j * ni + i].x = i * MAXSCOL / ni;
+		  etmp[j * ni + i].x = (i + 1) * MAXSCOL / ni - 1;
+		  if (etmp[j * ni + i].x - atmp[j * ni + i].x < 26)
+		    etmp[j * ni + i].x = atmp[j * ni + i].x + 26;
+		}
+	      else
+		{
+		  etmp[j * ni + i].x = (i + 1) * MAXSCOL / ni - 1;
+		  atmp[j * ni + i].x = etmp[j * ni + i - 1].x + 1;
+		  if (etmp[j * ni + i].x - atmp[j * ni + i].x < 26)
+		    etmp[j * ni + i].x = atmp[j * ni + i].x + 26;
+		  if (etmp[j * ni + i].x >= MAXSCOL)
+		    {
+		      etmp[j * ni + i].x = MAXSCOL - 1;
+		      atmp[j * ni + i].x = etmp[j * ni + i].x - 26;
+		    }
+		}
+	    }
+	  else
+	    {
+	      atmp[j * ni + i].x = atmp[(j - 1) * ni + i].x;
+	      etmp[j * ni + i].x = etmp[(j - 1) * ni + i].x;
+	      /* make the last window full width */
+	      if ((j * ni + i) == (editwin - 1))
+		etmp[j * ni + i].x = MAXSCOL - 1;
+	    }
+	}
     }
-    else
+  for (i = 0; i < ni; i++)
     {
-     etmp[j*ni+i].y = (j + 1) * (maxlines-2) / nj;
-     atmp[j*ni+i].y = etmp[(j-1)*ni+i].y + 1;
-     if (etmp[j*ni+i].y - atmp[j*ni+i].y < 3)
-      etmp[j*ni+i].y = atmp[j*ni+i].y + 3;
-     if (etmp[j*ni+i].y > maxlines - 2)
-     {
-      etmp[j*ni+i].y = maxlines - 2;
-      atmp[j*ni+i].y = etmp[j*ni+i].y - 3;
-     }
+      for (j = 0; j < nj; j++)
+	{
+	  if (i == 0)
+	    {
+	      if (j == 0)
+		{
+		  atmp[j * ni + i].y = j * (maxlines - 2) / nj + 1;
+		  etmp[j * ni + i].y = (j + 1) * (maxlines - 2) / nj;
+		  if (etmp[j * ni + i].y - atmp[j * ni + i].y < 3)
+		    etmp[j * ni + i].y = atmp[j * ni + i].y + 3;
+		}
+	      else
+		{
+		  etmp[j * ni + i].y = (j + 1) * (maxlines - 2) / nj;
+		  atmp[j * ni + i].y = etmp[(j - 1) * ni + i].y + 1;
+		  if (etmp[j * ni + i].y - atmp[j * ni + i].y < 3)
+		    etmp[j * ni + i].y = atmp[j * ni + i].y + 3;
+		  if (etmp[j * ni + i].y > maxlines - 2)
+		    {
+		      etmp[j * ni + i].y = maxlines - 2;
+		      atmp[j * ni + i].y = etmp[j * ni + i].y - 3;
+		    }
+		}
+	    }
+	  else
+	    {
+	      atmp[j * ni + i].y = atmp[j * ni + i - 1].y;
+	      etmp[j * ni + i].y = etmp[j * ni + i - 1].y;
+	    }
+	}
     }
-   }
-   else
-   {
-    atmp[j*ni+i].y = atmp[j*ni+i-1].y;
-    etmp[j*ni+i].y = etmp[j*ni+i-1].y;
-   }
-  }
- }
- for (i = 0, j = 1; i < editwin; i++, j++)
- {
-  while (!editorwin[j]) j++;
-  cn->f[j]->a = e_set_pnt(atmp[i].x, atmp[i].y);
-  cn->f[j]->e = e_set_pnt(etmp[i].x, etmp[i].y);
-  cn->f[j]->zoom = 0; /* Make sure zoom is off */
- }
- ini_repaint(cn);
- for ( i = 1; i < cn->mxedt; i++)
- {
-  e_firstl(cn->f[i], 0);
-  e_schirm(cn->f[i], 0);
- }
- e_firstl(cn->f[i], 1);
- e_schirm(cn->f[i], 1);
- e_cursor(cn->f[i], 1);
- end_repaint();
- return(0);
+  for (i = 0, j = 1; i < editwin; i++, j++)
+    {
+      while (!editorwin[j])
+	j++;
+      cn->f[j]->a = e_set_pnt (atmp[i].x, atmp[i].y);
+      cn->f[j]->e = e_set_pnt (etmp[i].x, etmp[i].y);
+      cn->f[j]->zoom = 0;	/* Make sure zoom is off */
+    }
+  ini_repaint (cn);
+  for (i = 1; i < cn->mxedt; i++)
+    {
+      e_firstl (cn->f[i], 0);
+      e_schirm (cn->f[i], 0);
+    }
+  e_firstl (cn->f[i], 1);
+  e_schirm (cn->f[i], 1);
+  e_cursor (cn->f[i], 1);
+  end_repaint ();
+  return (0);
 }
 
 /*   call next window   */
-int e_ed_next(FENSTER *f)
+int
+e_ed_next (FENSTER * f)
 {
- if (f->ed->mxedt > 0) e_switch_window(f->ed->edt[1], f);
- return(0);
+  if (f->ed->mxedt > 0)
+    e_switch_window (f->ed->edt[1], f);
+  return (0);
 }
 
 /*   write a line (screen content)     */
-void e_pr_line(int y, FENSTER *f)
+void
+e_pr_line (int y, FENSTER * f)
 {
- BUFFER *b = f->b;
- SCHIRM *s = f->s;
- int i, j, k, frb;
+  BUFFER *b = f->b;
+  SCHIRM *s = f->s;
+  int i, j, k, frb;
 #ifdef DEBUGGER
- int fsw = 0;
+  int fsw = 0;
 #endif
 
- for (i = j = 0; j < NUM_COLS_OFF_SCREEN_LEFT; j++, i++)
- {
-  if (*(b->bf[y].s + i) == WPE_TAB)
-   j += (f->ed->tabn - j % f->ed->tabn - 1);
-  else if(((unsigned char) *(b->bf[y].s + i)) > 126)
-  {
-   j++;
-   if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' ')
-    j++;
-  }
-  else if (*(b->bf[y].s + i) < ' ') j++;
- }
- if (j > NUM_COLS_OFF_SCREEN_LEFT) i--;
+  for (i = j = 0; j < NUM_COLS_OFF_SCREEN_LEFT; j++, i++)
+    {
+      if (*(b->bf[y].s + i) == WPE_TAB)
+	j += (f->ed->tabn - j % f->ed->tabn - 1);
+      else if (((unsigned char) *(b->bf[y].s + i)) > 126)
+	{
+	  j++;
+	  if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' ')
+	    j++;
+	}
+      else if (*(b->bf[y].s + i) < ' ')
+	j++;
+    }
+  if (j > NUM_COLS_OFF_SCREEN_LEFT)
+    i--;
 #ifdef DEBUGGER
- for (j = 1; j <= s->brp[0]; j++)
-  if (s->brp[j] == y) {  fsw = 1;  break;  }
- for (j = NUM_COLS_OFF_SCREEN_LEFT; i < b->bf[y].len && j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
- {
-  if (y == s->da.y && i >= s->da.x && i < s->de.x )
-   frb = s->fb->dy.fb;
-  else if (fsw) frb = s->fb->db.fb;
+  for (j = 1; j <= s->brp[0]; j++)
+    if (s->brp[j] == y)
+      {
+	fsw = 1;
+	break;
+      }
+  for (j = NUM_COLS_OFF_SCREEN_LEFT;
+       i < b->bf[y].len && j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
+    {
+      if (y == s->da.y && i >= s->da.x && i < s->de.x)
+	frb = s->fb->dy.fb;
+      else if (fsw)
+	frb = s->fb->db.fb;
 /*	else if( (i == s->pt[0].x && y == s->pt[0].y) || (i == s->pt[1].x && y == s->pt[1].y)  */
-  else if (y == s->fa.y && i >= s->fa.x && i < s->fe.x )
-   frb = s->fb->ek.fb;
+      else if (y == s->fa.y && i >= s->fa.x && i < s->fe.x)
+	frb = s->fb->ek.fb;
 #else
- for (j = NUM_COLS_OFF_SCREEN_LEFT; i < b->bf[y].len && j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
- {
-  if (y == s->fa.y && i >= s->fa.x && i < s->fe.x )
-   frb = s->fb->ek.fb;
+  for (j = NUM_COLS_OFF_SCREEN_LEFT;
+       i < b->bf[y].len && j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
+    {
+      if (y == s->fa.y && i >= s->fa.x && i < s->fe.x)
+	frb = s->fb->ek.fb;
 #endif
 /*	if( (i == s->pt[0].x && y == s->pt[0].y) || (i == s->pt[1].x && y == s->pt[1].y)  
          || (i == s->pt[2].x && y == s->pt[2].y) || (i == s->pt[3].x && y == s->pt[3].y)  
@@ -1081,203 +1247,252 @@ void e_pr_line(int y, FENSTER *f)
          || (i == s->pt[8].x && y == s->pt[8].y) || (i == s->pt[9].x && y == s->pt[9].y))
             frb = s->fb->ek.fb;
 */
-  else if ((y < s->mark_end.y && ( y > s->mark_begin.y ||
-    (y == s->mark_begin.y && i >= s->mark_begin.x) ) ) ||
-    (y == s->mark_end.y && i < s->mark_end.x && ( y > s->mark_begin.y ||
-    (y == s->mark_begin.y && i >= s->mark_begin.x) ) ) )
-   frb = s->fb->ez.fb;
-  else
-   frb = s->fb->et.fb;
+      else if ((y < s->mark_end.y && (y > s->mark_begin.y ||
+				      (y == s->mark_begin.y
+				       && i >= s->mark_begin.x)))
+	       || (y == s->mark_end.y && i < s->mark_end.x
+		   && (y > s->mark_begin.y
+		       || (y == s->mark_begin.y && i >= s->mark_begin.x))))
+	frb = s->fb->ez.fb;
+      else
+	frb = s->fb->et.fb;
 
-  if (f->dtmd == DTMD_HELP)
-  {
-   if (*(b->bf[y].s + i) == HBG || *(b->bf[y].s + i) == HFB ||
-     *(b->bf[y].s + i) == HHD || *(b->bf[y].s + i) == HBB)
-   {
-    if (*(b->bf[y].s + i) == HHD) frb = s->fb->hh.fb;
-    else if(*(b->bf[y].s + i) == HBB) frb = s->fb->hm.fb;
-    else frb = s->fb->hb.fb;
+      if (f->dtmd == DTMD_HELP)
+	{
+	  if (*(b->bf[y].s + i) == HBG || *(b->bf[y].s + i) == HFB ||
+	      *(b->bf[y].s + i) == HHD || *(b->bf[y].s + i) == HBB)
+	    {
+	      if (*(b->bf[y].s + i) == HHD)
+		frb = s->fb->hh.fb;
+	      else if (*(b->bf[y].s + i) == HBB)
+		frb = s->fb->hm.fb;
+	      else
+		frb = s->fb->hb.fb;
 #ifdef NEWSTYLE
-    if (*(b->bf[y].s + i) != HBB) k = j;
-    else k = -1;
+	      if (*(b->bf[y].s + i) != HBB)
+		k = j;
+	      else
+		k = -1;
 #endif
-    for (i++; b->bf[y].s[i] != HED && i < b->bf[y].len &&
-      j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
-     e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
-       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, *(b->bf[y].s + i), frb);
-    j--;
+	      for (i++; b->bf[y].s[i] != HED && i < b->bf[y].len &&
+		   j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
+		e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+			   *(b->bf[y].s + i), frb);
+	      j--;
 #ifdef NEWSTYLE
-    if (WpeIsXwin() && k >= 0)
-     e_make_xrect(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + k + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-       f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, 0);
+	      if (WpeIsXwin () && k >= 0)
+		e_make_xrect (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + k + 1,
+			      y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+			      f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			      y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, 0);
 #endif
-    continue;
-   }
-   else if (*(b->bf[y].s + i) == HFE)
-   {
-    for (; j < COL_NUM_ON_SCREEN_RIGHT; j++)
-     e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-       ' ', s->fb->hh.fb);
-    return;
-   }
-   else if (*(b->bf[y].s + i) == HNF)
-   {
-    for (k = j, i++; b->bf[y].s[i] != ':' && i < b->bf[y].len &&
-      j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
-     e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
-       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, *(b->bf[y].s + i), s->fb->hb.fb);
+	      continue;
+	    }
+	  else if (*(b->bf[y].s + i) == HFE)
+	    {
+	      for (; j < COL_NUM_ON_SCREEN_RIGHT; j++)
+		e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ',
+			   s->fb->hh.fb);
+	      return;
+	    }
+	  else if (*(b->bf[y].s + i) == HNF)
+	    {
+	      for (k = j, i++; b->bf[y].s[i] != ':' && i < b->bf[y].len &&
+		   j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
+		e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+			   *(b->bf[y].s + i), s->fb->hb.fb);
 #ifdef NEWSTYLE
-    if (WpeIsXwin())
-     e_make_xrect(f->a.x-NUM_COLS_OFF_SCREEN_LEFT+k+1, y-NUM_LINES_OFF_SCREEN_TOP+f->a.y+1,
-       f->a.x-NUM_COLS_OFF_SCREEN_LEFT+j, y-NUM_LINES_OFF_SCREEN_TOP+f->a.y+1, 0);
+	      if (WpeIsXwin ())
+		e_make_xrect (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + k + 1,
+			      y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+			      f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j,
+			      y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, 0);
 #endif
-    for (; b->bf[y].s[i] != HED && i < b->bf[y].len &&
-      j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
-     e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
-       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, *(b->bf[y].s + i), frb);
-    for (i++; b->bf[y].s[i] != HED && i < b->bf[y].len &&
-      j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
-     e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
-       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ', frb);
-    for (; b->bf[y].s[i] != '.' && i < b->bf[y].len &&
-      j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
-     e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
-       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ', frb);
-    j--;
-    continue;
-   }
-   else if (*(b->bf[y].s + i) == HED) {  j--;  continue;  }
-  }
-  if (*(b->bf[y].s + i) == WPE_TAB)
-   for (k = f->ed->tabn - j % f->ed->tabn; k > 1 &&
-     j < NUM_COLS_ON_SCREEN + NUM_COLS_OFF_SCREEN_LEFT - 2; k--, j++)
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      ' ', frb);
-  else if (!WpeIsXwin() && ((unsigned char)*(b->bf[y].s + i)) > 126)
-  {
-   e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j +1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-     '@', frb);
-   if (++j >= COL_NUM_ON_SCREEN_RIGHT) return;
-   if (((unsigned char)*(b->bf[y].s + i)) < 128 + ' ' &&
-     j < COL_NUM_ON_SCREEN_RIGHT)
-   {
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j +1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      '^', frb);
-    if (++j >= COL_NUM_ON_SCREEN_RIGHT) return;
-   }
-  }
-  else if (*(b->bf[y].s + i) < ' ')
-  {
-   e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j +1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-     '^', frb);
-   if (++j >= COL_NUM_ON_SCREEN_RIGHT) return;
-  }
-  if (*(b->bf[y].s + i) == WPE_TAB)
-   e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,                  ' ', frb);
-  else if (!WpeIsXwin() && ((unsigned char)*(b->bf[y].s + i)) > 126 &&
-    j < COL_NUM_ON_SCREEN_RIGHT)
-  {
-   if (((unsigned char)*(b->bf[y].s + i)) < 128 + ' ')
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      ((unsigned char) *(b->bf[y].s + i)) + 'A' - 129, frb);
-   else
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      ((unsigned char) *(b->bf[y].s + i)) - 128, frb);
-  }
-  else if (*(b->bf[y].s + i) < ' ' && j < COL_NUM_ON_SCREEN_RIGHT)
-   e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-     *(b->bf[y].s + i) + 'A' - 1, frb);
-  else
-   e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-     *(b->bf[y].s + i), frb);
- }
+	      for (; b->bf[y].s[i] != HED && i < b->bf[y].len &&
+		   j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
+		e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+			   *(b->bf[y].s + i), frb);
+	      for (i++;
+		   b->bf[y].s[i] != HED && i < b->bf[y].len
+		   && j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
+		e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ',
+			   frb);
+	      for (;
+		   b->bf[y].s[i] != '.' && i < b->bf[y].len
+		   && j < COL_NUM_ON_SCREEN_RIGHT; i++, j++)
+		e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ',
+			   frb);
+	      j--;
+	      continue;
+	    }
+	  else if (*(b->bf[y].s + i) == HED)
+	    {
+	      j--;
+	      continue;
+	    }
+	}
+      if (*(b->bf[y].s + i) == WPE_TAB)
+	for (k = f->ed->tabn - j % f->ed->tabn; k > 1 &&
+	     j < NUM_COLS_ON_SCREEN + NUM_COLS_OFF_SCREEN_LEFT - 2; k--, j++)
+	  e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		     y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ', frb);
+      else if (!WpeIsXwin () && ((unsigned char) *(b->bf[y].s + i)) > 126)
+	{
+	  e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		     y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, '@', frb);
+	  if (++j >= COL_NUM_ON_SCREEN_RIGHT)
+	    return;
+	  if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' ' &&
+	      j < COL_NUM_ON_SCREEN_RIGHT)
+	    {
+	      e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+			 y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, '^', frb);
+	      if (++j >= COL_NUM_ON_SCREEN_RIGHT)
+		return;
+	    }
+	}
+      else if (*(b->bf[y].s + i) < ' ')
+	{
+	  e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		     y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, '^', frb);
+	  if (++j >= COL_NUM_ON_SCREEN_RIGHT)
+	    return;
+	}
+      if (*(b->bf[y].s + i) == WPE_TAB)
+	e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ', frb);
+      else if (!WpeIsXwin () && ((unsigned char) *(b->bf[y].s + i)) > 126
+	       && j < COL_NUM_ON_SCREEN_RIGHT)
+	{
+	  if (((unsigned char) *(b->bf[y].s + i)) < 128 + ' ')
+	    e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+		       ((unsigned char) *(b->bf[y].s + i)) + 'A' - 129, frb);
+	  else
+	    e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+		       ((unsigned char) *(b->bf[y].s + i)) - 128, frb);
+	}
+      else if (*(b->bf[y].s + i) < ' ' && j < COL_NUM_ON_SCREEN_RIGHT)
+	e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+		   *(b->bf[y].s + i) + 'A' - 1, frb);
+      else
+	e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		   y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
+		   *(b->bf[y].s + i), frb);
+    }
 
- if ((i == b->bf[y].len) && (f->ed->edopt & ED_SHOW_ENDMARKS) &&
-   (DTMD_ISMARKABLE(f->dtmd)) && (j < COL_NUM_ON_SCREEN_RIGHT))
- {
-  if ((y < s->mark_end.y && ( y > s->mark_begin.y ||
-    (y == s->mark_begin.y && i >= s->mark_begin.x) ) ) ||
-    (y == s->mark_end.y && i < s->mark_end.x && ( y > s->mark_begin.y ||
-    (y == s->mark_begin.y && i >= s->mark_begin.x) ) ) )
-  {
-   if (*(b->bf[y].s + i) == WPE_WR)
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      PWR, s->fb->ez.fb);
-   else
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      PNL, s->fb->ez.fb);
-  }
-  else
-  {
-   if (*(b->bf[y].s + i) == WPE_WR)
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      PWR, s->fb->et.fb);
-   else
-    e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-      PNL, s->fb->et.fb);
-  }
-  j++;
- }
+  if ((i == b->bf[y].len) && (f->ed->edopt & ED_SHOW_ENDMARKS) &&
+      (DTMD_ISMARKABLE (f->dtmd)) && (j < COL_NUM_ON_SCREEN_RIGHT))
+    {
+      if ((y < s->mark_end.y && (y > s->mark_begin.y ||
+				 (y == s->mark_begin.y
+				  && i >= s->mark_begin.x)))
+	  || (y == s->mark_end.y && i < s->mark_end.x
+	      && (y > s->mark_begin.y
+		  || (y == s->mark_begin.y && i >= s->mark_begin.x))))
+	{
+	  if (*(b->bf[y].s + i) == WPE_WR)
+	    e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, PWR,
+		       s->fb->ez.fb);
+	  else
+	    e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, PNL,
+		       s->fb->ez.fb);
+	}
+      else
+	{
+	  if (*(b->bf[y].s + i) == WPE_WR)
+	    e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, PWR,
+		       s->fb->et.fb);
+	  else
+	    e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+		       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, PNL,
+		       s->fb->et.fb);
+	}
+      j++;
+    }
 
- for (; j < COL_NUM_ON_SCREEN_RIGHT; j++)
-  e_pr_char(f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1, y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1,
-    ' ', s->fb->et.fb);
+  for (; j < COL_NUM_ON_SCREEN_RIGHT; j++)
+    e_pr_char (f->a.x - NUM_COLS_OFF_SCREEN_LEFT + j + 1,
+	       y - NUM_LINES_OFF_SCREEN_TOP + f->a.y + 1, ' ', s->fb->et.fb);
 }
 
 /*   draw standard-box frame  */
-void e_std_rahmen(int xa, int ya, int xe, int ye, char *name, int sw, int frb,
-  int fes)
+void
+e_std_rahmen (int xa, int ya, int xe, int ye, char *name, int sw, int frb,
+	      int fes)
 {
- int i;
- char rhm[2][6];
- char *short_name;
-   
- rhm[0][0] = RE1; rhm[0][1] = RE2; rhm[0][2] = RE3; rhm[0][3] = RE4;
- rhm[0][4] = RE5; rhm[0][5] = RE6; rhm[1][0] = RD1; rhm[1][1] = RD2;
- rhm[1][2] = RD3; rhm[1][3] = RD4; rhm[1][4] = RD5; rhm[1][5] = RD6;
- for (i = xa + 1; i < xe; i++)
- {
-  e_pr_char(i, ya, rhm[sw][4], frb);
-  e_pr_char(i, ye, rhm[sw][4], frb);
- }
- for (i = ya + 1; i < ye; i++)
- {
-  e_pr_char(xa, i, rhm[sw][5], frb);
-  e_pr_char(xe, i, rhm[sw][5], frb);
- }
- e_pr_char(xa, ya, rhm[sw][0], frb);
- e_pr_char(xa, ye, rhm[sw][2], frb);
- e_pr_char(xe, ya, rhm[sw][1], frb);
- e_pr_char(xe, ye, rhm[sw][3], frb);
+  int i;
+  char rhm[2][6];
+  char *short_name;
 
- if (name)
- {
-  if (strlen(name) < (unsigned int)(xe - xa - 14))
-   e_pr_str((xa+xe-strlen(name))/2, ya, name, frb, 0, 0, 0, 0);
-  else
-  {
-   short_name = strdup(name);
-   strcpy(short_name + xe - xa - 17, "...");
-   e_pr_str(xa + 7, ya, short_name, frb, 0, 0, 0, 0);
-   free(short_name);
-  }
- }
- if (sw != 0)
- {
-  e_pr_char(xa+3, ya, WBT, fes);
+  rhm[0][0] = RE1;
+  rhm[0][1] = RE2;
+  rhm[0][2] = RE3;
+  rhm[0][3] = RE4;
+  rhm[0][4] = RE5;
+  rhm[0][5] = RE6;
+  rhm[1][0] = RD1;
+  rhm[1][1] = RD2;
+  rhm[1][2] = RD3;
+  rhm[1][3] = RD4;
+  rhm[1][4] = RD5;
+  rhm[1][5] = RD6;
+  for (i = xa + 1; i < xe; i++)
+    {
+      e_pr_char (i, ya, rhm[sw][4], frb);
+      e_pr_char (i, ye, rhm[sw][4], frb);
+    }
+  for (i = ya + 1; i < ye; i++)
+    {
+      e_pr_char (xa, i, rhm[sw][5], frb);
+      e_pr_char (xe, i, rhm[sw][5], frb);
+    }
+  e_pr_char (xa, ya, rhm[sw][0], frb);
+  e_pr_char (xa, ye, rhm[sw][2], frb);
+  e_pr_char (xe, ya, rhm[sw][1], frb);
+  e_pr_char (xe, ye, rhm[sw][3], frb);
+
+  if (name)
+    {
+      if (strlen (name) < (unsigned int) (xe - xa - 14))
+	e_pr_str ((xa + xe - strlen (name)) / 2, ya, name, frb, 0, 0, 0, 0);
+      else
+	{
+	  short_name = strdup (name);
+	  strcpy (short_name + xe - xa - 17, "...");
+	  e_pr_str (xa + 7, ya, short_name, frb, 0, 0, 0, 0);
+	  free (short_name);
+	}
+    }
+  if (sw != 0)
+    {
+      e_pr_char (xa + 3, ya, WBT, fes);
 #ifdef NEWSTYLE
-  if (!WpeIsXwin())
+      if (!WpeIsXwin ())
 #endif
-  {
-   e_pr_char(xa+2, ya, '[', frb);
-   e_pr_char(xa+4, ya, ']', frb);
-  }
+	{
+	  e_pr_char (xa + 2, ya, '[', frb);
+	  e_pr_char (xa + 4, ya, ']', frb);
+	}
 #ifdef NEWSTYLE
-  else e_make_xrect(xa+2, ya, xa+4, ya, 0);
- }
- if (WpeIsXwin()) e_make_xr_rahmen(xa, ya, xe, ye, sw);
+      else
+	e_make_xrect (xa + 2, ya, xa + 4, ya, 0);
+    }
+  if (WpeIsXwin ())
+    e_make_xr_rahmen (xa, ya, xe, ye, sw);
 #else
- }
+    }
 /*
    if(xe < MAXSCOL-1) for(i = ya+1; i <= ye; i++) e_pt_col(xe+1, i, SHDCOL);
    if(ye < MAXSLNS-2) for(i = xa+1; i <= xe+1 && i < MAXSCOL; i++) 
@@ -1286,393 +1501,467 @@ void e_std_rahmen(int xa, int ya, int xe, int ye, char *name, int sw, int frb,
 #endif
 }
 
-struct dirfile *e_add_df(char *str, struct dirfile *df)
+struct dirfile *
+e_add_df (char *str, struct dirfile *df)
 {
-   int i, n;
-   char *tmp;
+  int i, n;
+  char *tmp;
 
-   if (df == NULL)
-   {  df = malloc(sizeof(struct dirfile));
+  if (df == NULL)
+    {
+      df = malloc (sizeof (struct dirfile));
       df->anz = 0;
-      df->name = malloc(sizeof(char*));
-   }
-   for(n = 0; n < df->anz && *df->name[n] && strcmp(df->name[n], str); n++);
-   if(n == df->anz)
-   {  if(df->anz == MAXSVSTR - 1) free(df->name[df->anz-1]);
+      df->name = malloc (sizeof (char *));
+    }
+  for (n = 0; n < df->anz && *df->name[n] && strcmp (df->name[n], str); n++);
+  if (n == df->anz)
+    {
+      if (df->anz == MAXSVSTR - 1)
+	free (df->name[df->anz - 1]);
       else
-      {  df->anz++;
-	 df->name = realloc(df->name, df->anz * sizeof(char*));
-      }
-      for(i = df->anz-1; i > 0; i--) df->name[i] = df->name[i-1];
-      df->name[0] = malloc((strlen(str)+1) * sizeof(char));
-      strcpy(df->name[0], str);
-   }
-   else
-   {  tmp = df->name[n];
-      for(i = n; i > 0; i--) df->name[i] = df->name[i-1];
-      if(!tmp[0])
-      {  free(tmp);
-	 df->name[0] = malloc((strlen(str) + 1) * sizeof(char));
-	 strcpy(df->name[0], str);
-      }
-      else df->name[0] = tmp;
-   }
-   return(df);
+	{
+	  df->anz++;
+	  df->name = realloc (df->name, df->anz * sizeof (char *));
+	}
+      for (i = df->anz - 1; i > 0; i--)
+	df->name[i] = df->name[i - 1];
+      df->name[0] = malloc ((strlen (str) + 1) * sizeof (char));
+      strcpy (df->name[0], str);
+    }
+  else
+    {
+      tmp = df->name[n];
+      for (i = n; i > 0; i--)
+	df->name[i] = df->name[i - 1];
+      if (!tmp[0])
+	{
+	  free (tmp);
+	  df->name[0] = malloc ((strlen (str) + 1) * sizeof (char));
+	  strcpy (df->name[0], str);
+	}
+      else
+	df->name[0] = tmp;
+    }
+  return (df);
 }
 
-int e_sv_window(int xa, int ya, int *n, struct dirfile *df, FENSTER *f)
+int
+e_sv_window (int xa, int ya, int *n, struct dirfile *df, FENSTER * f)
 {
- ECNT *cn = f->ed;
- int ret, ye = ya + 6;
- int xe = xa +21;
- FLWND *fw = malloc(sizeof(FLWND));
+  ECNT *cn = f->ed;
+  int ret, ye = ya + 6;
+  int xe = xa + 21;
+  FLWND *fw = malloc (sizeof (FLWND));
 
- if ((f = (FENSTER *) malloc(sizeof(FENSTER))) == NULL)
-  e_error(e_msg[ERR_LOWMEM], 1, cn->fb);
- if (xe > MAXSCOL-3) {  xe = MAXSCOL - 3;  xa = xe - 21;  }
- if (ye > MAXSLNS-3) {  ye = MAXSLNS - 3;  ya = ye - 6;  }
- f->fb = cn->fb;
- f->a = e_set_pnt(xa, ya);
- f->e = e_set_pnt(xe, ye);
- f->dtmd = DTMD_FILEDROPDOWN;
- f->zoom = 0;
- f->ed = cn;
- f->c_sw = NULL;
- f->c_st = NULL;
- f->fd.dirct = NULL;
- f->winnum = -1;
- f->datnam = "";
- if (!(f->pic = e_ed_kst(f, NULL, 1)))
- {  e_error(e_msg[ERR_LOWMEM], 0, f->fb);  return(0);  }
- f->b = (BUFFER *)fw;
- fw->mxa = xa; fw->mxe = xe; fw->mya = ya; fw->mye = ye;
- fw->xa = xa+1; fw->xe = xe; fw->ya = ya+1; fw->ye = ye;
- fw->df = df; fw->srcha = 0; fw->f = f;
- fw->nf = fw->ia = fw->ja = 0;
- do
- {
-  ret = e_file_window(0, fw, f->fb->er.fb, f->fb->ez.fb);
+  if ((f = (FENSTER *) malloc (sizeof (FENSTER))) == NULL)
+    e_error (e_msg[ERR_LOWMEM], 1, cn->fb);
+  if (xe > MAXSCOL - 3)
+    {
+      xe = MAXSCOL - 3;
+      xa = xe - 21;
+    }
+  if (ye > MAXSLNS - 3)
+    {
+      ye = MAXSLNS - 3;
+      ya = ye - 6;
+    }
+  f->fb = cn->fb;
+  f->a = e_set_pnt (xa, ya);
+  f->e = e_set_pnt (xe, ye);
+  f->dtmd = DTMD_FILEDROPDOWN;
+  f->zoom = 0;
+  f->ed = cn;
+  f->c_sw = NULL;
+  f->c_st = NULL;
+  f->fd.dirct = NULL;
+  f->winnum = -1;
+  f->datnam = "";
+  if (!(f->pic = e_ed_kst (f, NULL, 1)))
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+      return (0);
+    }
+  f->b = (BUFFER *) fw;
+  fw->mxa = xa;
+  fw->mxe = xe;
+  fw->mya = ya;
+  fw->mye = ye;
+  fw->xa = xa + 1;
+  fw->xe = xe;
+  fw->ya = ya + 1;
+  fw->ye = ye;
+  fw->df = df;
+  fw->srcha = 0;
+  fw->f = f;
+  fw->nf = fw->ia = fw->ja = 0;
+  do
+    {
+      ret = e_file_window (0, fw, f->fb->er.fb, f->fb->ez.fb);
 #if MOUSE
-  if (ret < 0) ret = e_rahmen_mouse(f);
+      if (ret < 0)
+	ret = e_rahmen_mouse (f);
 #endif
-  if ((ret == AF2 && !(f->ed->edopt & ED_CUA_STYLE)) ||
-    (f->ed->edopt & ED_CUA_STYLE && ret == CtrlL))
-   e_size_move(f);
- } while(ret != WPE_CR && ret != WPE_ESC);
- *n = fw->nf;
- e_close_view(f->pic, 1);
- free(fw);
- free(f);
- return(ret);
+      if ((ret == AF2 && !(f->ed->edopt & ED_CUA_STYLE)) ||
+	  (f->ed->edopt & ED_CUA_STYLE && ret == CtrlL))
+	e_size_move (f);
+    }
+  while (ret != WPE_CR && ret != WPE_ESC);
+  *n = fw->nf;
+  e_close_view (f->pic, 1);
+  free (fw);
+  free (f);
+  return (ret);
 }
 
-int e_schr_lst_wsv(char *str, int xa, int ya, int n, int len, int ft,
-  int fz, struct dirfile **df, FENSTER *f)
+int
+e_schr_lst_wsv (char *str, int xa, int ya, int n, int len, int ft,
+		int fz, struct dirfile **df, FENSTER * f)
 {
 #if MOUSE
-   extern struct mouse e_mouse;
+  extern struct mouse e_mouse;
 #endif
-   int ret, num;
-   do
-   {  *df = e_add_df(str, *df);
+  int ret, num;
+  do
+    {
+      *df = e_add_df (str, *df);
 #ifndef NEWSTYLE
-      ret = e_schreib_leiste(str, xa, ya, n-4, len, ft, fz);
+      ret = e_schreib_leiste (str, xa, ya, n - 4, len, ft, fz);
 #else
-      ret = e_schreib_leiste(str, xa, ya, n-3, len, ft, fz);
+      ret = e_schreib_leiste (str, xa, ya, n - 3, len, ft, fz);
 #endif
 #if MOUSE
-      if(ret < 0 && e_mouse.y == ya && e_mouse.x >= xa+n-3
-				&& e_mouse.x <= xa+n-1) ret = CDO;
+      if (ret < 0 && e_mouse.y == ya && e_mouse.x >= xa + n - 3
+	  && e_mouse.x <= xa + n - 1)
+	ret = CDO;
 #endif
-      if (ret == CDO && e_sv_window(xa+n, ya, &num, *df, f) == WPE_CR)
-          strcpy(str, (*df)->name[num]);
-   }  while(ret == CDO);
-   return(ret);
+      if (ret == CDO && e_sv_window (xa + n, ya, &num, *df, f) == WPE_CR)
+	strcpy (str, (*df)->name[num]);
+    }
+  while (ret == CDO);
+  return (ret);
 }
 
-int e_schr_nchar_wsv(char *str, int x, int y, int n, int max, int col,
-  int csw)
+int
+e_schr_nchar_wsv (char *str, int x, int y, int n, int max, int col, int csw)
 #ifdef NEWSTYLE
 {
- e_pr_char(x+max-3, y, ' ', csw);
- e_pr_char(x+max-2, y, WSW, csw);
- e_pr_char(x+max-1, y, ' ', csw);
- e_make_xrect(x+max-3, y, x+max-1, y, 0);
- return(e_schr_nchar(str, x, y, n, max-3, col));
+  e_pr_char (x + max - 3, y, ' ', csw);
+  e_pr_char (x + max - 2, y, WSW, csw);
+  e_pr_char (x + max - 1, y, ' ', csw);
+  e_make_xrect (x + max - 3, y, x + max - 1, y, 0);
+  return (e_schr_nchar (str, x, y, n, max - 3, col));
 }
 #else
 {
 #if !defined(NO_XWINDOWS)
- int swcol = (e_gt_col(x+max, y) / 16) * 16;
- if (WpeIsXwin())
- {
-  e_pr_char(x+max, y, SCR, swcol);
-  e_pr_char(x+max, y+1, SCD, swcol);
-  e_pr_char(x+max-1, y+1, SCD, swcol);
-  e_pr_char(x+max-2, y+1, SCD, swcol);
- }
+  int swcol = (e_gt_col (x + max, y) / 16) * 16;
+  if (WpeIsXwin ())
+    {
+      e_pr_char (x + max, y, SCR, swcol);
+      e_pr_char (x + max, y + 1, SCD, swcol);
+      e_pr_char (x + max - 1, y + 1, SCD, swcol);
+      e_pr_char (x + max - 2, y + 1, SCD, swcol);
+    }
 #endif
- e_pr_char(x+max-3, y, ' ', csw);
- e_pr_char(x+max-2, y, WSW, csw);
- e_pr_char(x+max-1, y, ' ', csw);
- return(e_schr_nchar(str, x, y, n, max-4, col));
+  e_pr_char (x + max - 3, y, ' ', csw);
+  e_pr_char (x + max - 2, y, WSW, csw);
+  e_pr_char (x + max - 1, y, ' ', csw);
+  return (e_schr_nchar (str, x, y, n, max - 4, col));
 }
 #endif
 
-int e_mess_win(char *header, char *str, view **pic, FENSTER *f)
+int
+e_mess_win (char *header, char *str, view ** pic, FENSTER * f)
 {
- ECNT *cn = f->ed;
- extern int (*e_u_kbhit)(void);
+  ECNT *cn = f->ed;
+  extern int (*e_u_kbhit) (void);
 #if MOUSE
- extern struct mouse e_mouse;
+  extern struct mouse e_mouse;
 #endif
- int xa, ya, xe, ye, num, anz = 0, mxlen = 0, i, j;
- char **s;
+  int xa, ya, xe, ye, num, anz = 0, mxlen = 0, i, j;
+  char **s;
 
- s = StringToStringArray(str, &mxlen, strlen(header) + 8, &anz);
+  s = StringToStringArray (str, &mxlen, strlen (header) + 8, &anz);
 
- ya = (MAXSLNS - anz - 6)/2;
- ye = ya + anz + 5;
- xa = (MAXSCOL - mxlen - 6)/2;
- xe = xa + mxlen + 6;
- if (ya < 2) ya = 2;
- if (ye > MAXSLNS-3) ye = MAXSLNS - 3;
- num = anz;
- if (num > ye - ya - 5)
- {
-  num = ye - ya - 5;
-  strcpy(s[num-1], "...");
- }
+  ya = (MAXSLNS - anz - 6) / 2;
+  ye = ya + anz + 5;
+  xa = (MAXSCOL - mxlen - 6) / 2;
+  xe = xa + mxlen + 6;
+  if (ya < 2)
+    ya = 2;
+  if (ye > MAXSLNS - 3)
+    ye = MAXSLNS - 3;
+  num = anz;
+  if (num > ye - ya - 5)
+    {
+      num = ye - ya - 5;
+      strcpy (s[num - 1], "...");
+    }
 
- if (!(*pic) || (*pic)->e.x != xe || (*pic)->a.x != xa || (*pic)->e.x < xe)
- {
-  *pic = e_change_pic(xa, ya, xe, ye, *pic, 1, cn->fb->nt.fb);
+  if (!(*pic) || (*pic)->e.x != xe || (*pic)->a.x != xa || (*pic)->e.x < xe)
+    {
+      *pic = e_change_pic (xa, ya, xe, ye, *pic, 1, cn->fb->nt.fb);
+      for (i = xa + 1; i < xe; i++)
+	{
+	  e_pr_char (i, ye - 2, ' ', f->fb->nt.fb);
+	  e_pr_char (i, ye - 1, ' ', f->fb->nt.fb);
+	}
+      e_pr_str ((xe + xa - 6) / 2, ye - 2, "Ctrl C", cn->fb->nz.fb, -1, -1,
+		cn->fb->ns.fb, cn->fb->nt.fb);
+    }
+  e_std_rahmen (xa, ya, xe, ye, header, 1, cn->fb->nr.fb, cn->fb->ne.fb);
   for (i = xa + 1; i < xe; i++)
-  {
-   e_pr_char(i, ye-2, ' ', f->fb->nt.fb);
-   e_pr_char(i, ye-1, ' ', f->fb->nt.fb);
-  }
-  e_pr_str((xe + xa - 6)/2, ye-2, "Ctrl C", cn->fb->nz.fb, -1, -1,
-    cn->fb->ns.fb, cn->fb->nt.fb);
- }
- e_std_rahmen(xa, ya, xe, ye, header, 1, cn->fb->nr.fb, cn->fb->ne.fb);
- for (i = xa + 1; i < xe; i++)
-  e_pr_char(i, ya+1, ' ', cn->fb->nr.fb);
- for (j = 0; j < num; j++)
- {
-  e_pr_char(xa+1, ya+2+j, ' ', cn->fb->nt.fb);
-  e_pr_char(xa+2, ya+2+j, ' ', cn->fb->nt.fb);
-  e_pr_str(xa+3, ya+2+j, s[j], cn->fb->nt.fb, 0, 0, 0, 0);
-  for (i = xa+strlen(s[j])+3; i < xe; i++)
-   e_pr_char(i, ya+2+j, ' ', cn->fb->nt.fb);
- }
- for (j += ya+2; j < ye-2; j++)
-  for (i = xa + 1; i < xe; i++)
-   e_pr_char(i, j, ' ', cn->fb->nt.fb);
- for (i = 0; i < anz; i++)
-  free(s[i]);
- free(s);
+    e_pr_char (i, ya + 1, ' ', cn->fb->nr.fb);
+  for (j = 0; j < num; j++)
+    {
+      e_pr_char (xa + 1, ya + 2 + j, ' ', cn->fb->nt.fb);
+      e_pr_char (xa + 2, ya + 2 + j, ' ', cn->fb->nt.fb);
+      e_pr_str (xa + 3, ya + 2 + j, s[j], cn->fb->nt.fb, 0, 0, 0, 0);
+      for (i = xa + strlen (s[j]) + 3; i < xe; i++)
+	e_pr_char (i, ya + 2 + j, ' ', cn->fb->nt.fb);
+    }
+  for (j += ya + 2; j < ye - 2; j++)
+    for (i = xa + 1; i < xe; i++)
+      e_pr_char (i, j, ' ', cn->fb->nt.fb);
+  for (i = 0; i < anz; i++)
+    free (s[i]);
+  free (s);
 #ifndef NO_XWINDOWS
- if (WpeIsXwin())
- {
-  while ((i = (*e_u_kbhit)()))
-  {
-   if (i == -1 && e_mouse.y == ye-2 && e_mouse.x > (xe + xa - 10)/2 &&
-     e_mouse.x < (xe + xa + 6)/2 )
-    i = CtrlC;
-   if (i == CtrlC) break;
-  }
- }
- else
+  if (WpeIsXwin ())
+    {
+      while ((i = (*e_u_kbhit) ()))
+	{
+	  if (i == -1 && e_mouse.y == ye - 2 && e_mouse.x > (xe + xa - 10) / 2
+	      && e_mouse.x < (xe + xa + 6) / 2)
+	    i = CtrlC;
+	  if (i == CtrlC)
+	    break;
+	}
+    }
+  else
 #endif
-  while ((i = (*e_u_kbhit)()) && i != CtrlC)
-   ;
- return(i == CtrlC ? 1 : 0);
+    while ((i = (*e_u_kbhit) ()) && i != CtrlC)
+      ;
+  return (i == CtrlC ? 1 : 0);
 }
 
-int e_opt_sec_box(int xa, int ya, int num, OPTK *opt, FENSTER *f, int sw)
+int
+e_opt_sec_box (int xa, int ya, int num, OPTK * opt, FENSTER * f, int sw)
 {
-   view *pic;
-   int n, nold, max = 0, i, c = 0, xe, ye = ya + num + 1;
-   for(i = 0; i < num; i++)
-   if((n = strlen(opt[i].t)) > max) max = n;
-   xe = xa + max + 3;
-   pic = e_std_kst(xa, ya, xe, ye, NULL, sw, f->fb->nr.fb, f->fb->nt.fb, f->fb->ne.fb);
-   if(pic == NULL)  {  e_error(e_msg[ERR_LOWMEM], 0, f->fb); return(-2);  }
-   for (i = 0; i < num; i++)
-   e_pr_str_wsd(xa+2, ya+i+1, opt[i].t, f->fb->mt.fb, opt[i].x,
-		1, f->fb->ms.fb, xa+1, xe-1);
+  view *pic;
+  int n, nold, max = 0, i, c = 0, xe, ye = ya + num + 1;
+  for (i = 0; i < num; i++)
+    if ((n = strlen (opt[i].t)) > max)
+      max = n;
+  xe = xa + max + 3;
+  pic =
+    e_std_kst (xa, ya, xe, ye, NULL, sw, f->fb->nr.fb, f->fb->nt.fb,
+	       f->fb->ne.fb);
+  if (pic == NULL)
+    {
+      e_error (e_msg[ERR_LOWMEM], 0, f->fb);
+      return (-2);
+    }
+  for (i = 0; i < num; i++)
+    e_pr_str_wsd (xa + 2, ya + i + 1, opt[i].t, f->fb->mt.fb, opt[i].x,
+		  1, f->fb->ms.fb, xa + 1, xe - 1);
 #if  MOUSE
-   while (e_mshit() != 0);
+  while (e_mshit () != 0);
 #endif
-   n = 0; nold = 1;
-   while (c != WPE_ESC && c != WPE_CR)
-   {  if (nold != n)
-      {  e_pr_str_wsd(xa+2, nold+ya+1, opt[nold].t, f->fb->mt.fb,
-				opt[nold].x, 1, f->fb->ms.fb, xa+1, xe-1);
-	 e_pr_str_wsd(xa+2, n+ya+1, opt[n].t, f->fb->mz.fb,
-				opt[n].x, 1, f->fb->mz.fb, xa+1, xe-1);
-	 nold = n;
-      }
+  n = 0;
+  nold = 1;
+  while (c != WPE_ESC && c != WPE_CR)
+    {
+      if (nold != n)
+	{
+	  e_pr_str_wsd (xa + 2, nold + ya + 1, opt[nold].t, f->fb->mt.fb,
+			opt[nold].x, 1, f->fb->ms.fb, xa + 1, xe - 1);
+	  e_pr_str_wsd (xa + 2, n + ya + 1, opt[n].t, f->fb->mz.fb,
+			opt[n].x, 1, f->fb->mz.fb, xa + 1, xe - 1);
+	  nold = n;
+	}
 #if  MOUSE
-      if( (c = toupper(e_getch())) == -1)
-      c = e_m2_mouse(xa, ya, xe, ye, opt);
+      if ((c = toupper (e_getch ())) == -1)
+	c = e_m2_mouse (xa, ya, xe, ye, opt);
 #else
-      c = toupper(e_getch());
+      c = toupper (e_getch ());
 #endif
       for (i = 0; i < ye - ya - 1; i++)
-      if( c == opt[i].o) {  c = WPE_CR;  n = i;  break;  }
-      if (i > ye - ya) c = WPE_ESC;
-      else if ( c == CUP || c == CtrlP ) n = n > 0 ? n-1 : ye - ya - 2 ;
-      else if ( c == CDO || c == CtrlN ) n = n < ye-ya-2 ? n+1 : 0 ;
-      else if ( c == POS1 || c == CtrlA ) n = 0;
-      else if ( c == ENDE || c == CtrlE ) n = ye-ya-2;
-   }
-   if(sw == 1) e_close_view(pic, 1);
-   return(c == WPE_ESC ? -1 : n);
+	if (c == opt[i].o)
+	  {
+	    c = WPE_CR;
+	    n = i;
+	    break;
+	  }
+      if (i > ye - ya)
+	c = WPE_ESC;
+      else if (c == CUP || c == CtrlP)
+	n = n > 0 ? n - 1 : ye - ya - 2;
+      else if (c == CDO || c == CtrlN)
+	n = n < ye - ya - 2 ? n + 1 : 0;
+      else if (c == POS1 || c == CtrlA)
+	n = 0;
+      else if (c == ENDE || c == CtrlE)
+	n = ye - ya - 2;
+    }
+  if (sw == 1)
+    e_close_view (pic, 1);
+  return (c == WPE_ESC ? -1 : n);
 }
 
-struct dirfile *e_make_win_list(FENSTER *f)
+struct dirfile *
+e_make_win_list (FENSTER * f)
 {
- int i;
- struct dirfile *df;
+  int i;
+  struct dirfile *df;
 
- if (!(df = malloc(sizeof(struct dirfile)))) return(NULL);
- df->anz = f->ed->mxedt;
- if (!(df->name = malloc(df->anz * sizeof(char *))))
- {
-  free(df);
-  return(NULL);
- }
- for (i = 0; i < df->anz; i++)
- {
-  if (f->ed->f[df->anz-i]->datnam)
-  {
-   if (!(df->name[i] =
-     malloc((strlen(f->ed->f[df->anz-i]->datnam)+1) * sizeof(char))))
-   {
-    df->anz = i;
-    freedf(df);
-    return(NULL);
-   }
-   else strcpy(df->name[i], f->ed->f[df->anz-i]->datnam);
-  }
-  else
-  {
-   if (!(df->name[i] = malloc(sizeof(char))))
-   {
-    df->anz = i;
-    freedf(df);
-    return(NULL);
-   }
-   else *df->name[i] = '\0';
-  }
- }
- return(df);
+  if (!(df = malloc (sizeof (struct dirfile))))
+    return (NULL);
+  df->anz = f->ed->mxedt;
+  if (!(df->name = malloc (df->anz * sizeof (char *))))
+    {
+      free (df);
+      return (NULL);
+    }
+  for (i = 0; i < df->anz; i++)
+    {
+      if (f->ed->f[df->anz - i]->datnam)
+	{
+	  if (!(df->name[i] =
+		malloc ((strlen (f->ed->f[df->anz - i]->datnam) +
+			 1) * sizeof (char))))
+	    {
+	      df->anz = i;
+	      freedf (df);
+	      return (NULL);
+	    }
+	  else
+	    strcpy (df->name[i], f->ed->f[df->anz - i]->datnam);
+	}
+      else
+	{
+	  if (!(df->name[i] = malloc (sizeof (char))))
+	    {
+	      df->anz = i;
+	      freedf (df);
+	      return (NULL);
+	    }
+	  else
+	    *df->name[i] = '\0';
+	}
+    }
+  return (df);
 }
 
-int e_list_all_win(FENSTER *f)
+int
+e_list_all_win (FENSTER * f)
 {
- int i;
+  int i;
 
- for (i = f->ed->mxedt; i > 0; i--)
-  if (f->ed->f[i]->dtmd == DTMD_DATA && f->ed->f[i]->ins == 7)
-  {
-   e_switch_window(f->ed->edt[i], f);
-   return(0);
-  }
- return(e_data_first(7, f->ed, NULL));
+  for (i = f->ed->mxedt; i > 0; i--)
+    if (f->ed->f[i]->dtmd == DTMD_DATA && f->ed->f[i]->ins == 7)
+      {
+	e_switch_window (f->ed->edt[i], f);
+	return (0);
+      }
+  return (e_data_first (7, f->ed, NULL));
 }
 
 #ifdef NEWSTYLE
-int e_get_pic_xrect(int xa, int ya, int xe, int ye, view *pic)
+int
+e_get_pic_xrect (int xa, int ya, int xe, int ye, view * pic)
 {
- int i = xa, j, ebbg;
+  int i = xa, j, ebbg;
 
- ebbg = (xe - xa + 1) * 2 * (ye - ya + 1);
- for (j = ya; j <= ye; ++j)
-  for (i = xa; i <= xe; ++i)
-   *( pic->p + ebbg + (j-ya)*(xe-xa+1) + (i-xa) ) = extbyte[j*MAXSCOL + i];
- return(i);
+  ebbg = (xe - xa + 1) * 2 * (ye - ya + 1);
+  for (j = ya; j <= ye; ++j)
+    for (i = xa; i <= xe; ++i)
+      *(pic->p + ebbg + (j - ya) * (xe - xa + 1) + (i - xa)) =
+	extbyte[j * MAXSCOL + i];
+  return (i);
 }
 
-int e_put_pic_xrect(view *pic)
+int
+e_put_pic_xrect (view * pic)
 {
- int i = 0, j;
- int ebbg = (pic->e.x - pic->a.x + 1) * 2 * (pic->e.y - pic->a.y + 1);
+  int i = 0, j;
+  int ebbg = (pic->e.x - pic->a.x + 1) * 2 * (pic->e.y - pic->a.y + 1);
 
- for (j = pic->a.y; j <= pic->e.y; ++j)
-  for (i = pic->a.x; i <= pic->e.x; ++i)
-   extbyte[j*MAXSCOL+i] =
-     *(pic->p + ebbg + (j-pic->a.y)*(pic->e.x-pic->a.x+1) + (i-pic->a.x));
- return(i);
+  for (j = pic->a.y; j <= pic->e.y; ++j)
+    for (i = pic->a.x; i <= pic->e.x; ++i)
+      extbyte[j * MAXSCOL + i] =
+	*(pic->p + ebbg + (j - pic->a.y) * (pic->e.x - pic->a.x + 1) +
+	  (i - pic->a.x));
+  return (i);
 }
 
-int e_make_xrect_abs(int xa, int ya, int xe, int ye, int sw)
+int
+e_make_xrect_abs (int xa, int ya, int xe, int ye, int sw)
 {
- int j;
+  int j;
 
- for (j = xa; j <= xe; j++)
-  *(extbyte+ya*MAXSCOL+j) = *(extbyte+ye*MAXSCOL+j) = 0;
- for (j = ya; j <= ye; j++)
-  *(extbyte+j*MAXSCOL+xa) = *(extbyte+j*MAXSCOL+xe) = 0;
- return(e_make_xrect(xa, ya, xe, ye, sw));
-}
-
-int e_make_xrect(int xa, int ya, int xe, int ye, int sw)
-{
- int j;
-
- if (sw & 2)
- {
-  sw = (sw & 1) ? 16 : 0;
-  for (j = xa+1; j < xe; j++)
-  {
-   *(extbyte+ya*MAXSCOL+j) |= (sw | 4);
-   *(extbyte+ye*MAXSCOL+j) |= (sw | 1);
-  }
-  for (j = ya+1; j < ye; j++)
-  {
-   *(extbyte+j*MAXSCOL+xa) |= (sw | 2);
-   *(extbyte+j*MAXSCOL+xe) |= (sw | 8);
-  }
- }
- else
- {
-  sw = (sw & 1) ? 16 : 0;
   for (j = xa; j <= xe; j++)
-  {
-   *(extbyte+ya*MAXSCOL+j) |= (sw | 1);
-   *(extbyte+ye*MAXSCOL+j) |= (sw | 4);
-  }
+    *(extbyte + ya * MAXSCOL + j) = *(extbyte + ye * MAXSCOL + j) = 0;
   for (j = ya; j <= ye; j++)
-  {
-   *(extbyte+j*MAXSCOL+xa) |= (sw | 8);
-   *(extbyte+j*MAXSCOL+xe) |= (sw | 2);
-  }
- }
- return(j);
+    *(extbyte + j * MAXSCOL + xa) = *(extbyte + j * MAXSCOL + xe) = 0;
+  return (e_make_xrect (xa, ya, xe, ye, sw));
 }
 
-int e_make_xr_rahmen(int xa, int ya, int xe, int ye, int sw)
+int
+e_make_xrect (int xa, int ya, int xe, int ye, int sw)
 {
- if (!sw)
- {
-  e_make_xrect(xa, ya, xe, ye, 0);
-  e_make_xrect(xa, ya, xe, ye, 2);
- }
- else
- {
-  e_make_xrect(xa+1, ya, xe-1, ya, 0);
-  e_make_xrect(xa+1, ye, xe-1, ye, 0);
-  e_make_xrect(xa, ya+1, xa, ye-1, 0);
-  e_make_xrect(xe, ya+1, xe, ye-1, 0);
-  e_make_xrect(xa, ya, xa, ya, 0);
-  e_make_xrect(xe, ya, xe, ya, 0);
-  e_make_xrect(xe, ye, xe, ye, 0);
-  e_make_xrect(xa, ye, xa, ye, 0);
- }
- return(sw);
+  int j;
+
+  if (sw & 2)
+    {
+      sw = (sw & 1) ? 16 : 0;
+      for (j = xa + 1; j < xe; j++)
+	{
+	  *(extbyte + ya * MAXSCOL + j) |= (sw | 4);
+	  *(extbyte + ye * MAXSCOL + j) |= (sw | 1);
+	}
+      for (j = ya + 1; j < ye; j++)
+	{
+	  *(extbyte + j * MAXSCOL + xa) |= (sw | 2);
+	  *(extbyte + j * MAXSCOL + xe) |= (sw | 8);
+	}
+    }
+  else
+    {
+      sw = (sw & 1) ? 16 : 0;
+      for (j = xa; j <= xe; j++)
+	{
+	  *(extbyte + ya * MAXSCOL + j) |= (sw | 1);
+	  *(extbyte + ye * MAXSCOL + j) |= (sw | 4);
+	}
+      for (j = ya; j <= ye; j++)
+	{
+	  *(extbyte + j * MAXSCOL + xa) |= (sw | 8);
+	  *(extbyte + j * MAXSCOL + xe) |= (sw | 2);
+	}
+    }
+  return (j);
+}
+
+int
+e_make_xr_rahmen (int xa, int ya, int xe, int ye, int sw)
+{
+  if (!sw)
+    {
+      e_make_xrect (xa, ya, xe, ye, 0);
+      e_make_xrect (xa, ya, xe, ye, 2);
+    }
+  else
+    {
+      e_make_xrect (xa + 1, ya, xe - 1, ya, 0);
+      e_make_xrect (xa + 1, ye, xe - 1, ye, 0);
+      e_make_xrect (xa, ya + 1, xa, ye - 1, 0);
+      e_make_xrect (xe, ya + 1, xe, ye - 1, 0);
+      e_make_xrect (xa, ya, xa, ya, 0);
+      e_make_xrect (xe, ya, xe, ya, 0);
+      e_make_xrect (xe, ye, xe, ye, 0);
+      e_make_xrect (xa, ye, xa, ye, 0);
+    }
+  return (sw);
 }
 #endif
-

--- a/src/we_wind.h
+++ b/src/we_wind.h
@@ -23,12 +23,12 @@
 #define NUM_LINES_OFF_SCREEN_TOP	(f->s->c.y)
 #define NUM_LINES_ON_SCREEN	(f->e.y - f->a.y)
 #define LINE_NUM_ON_SCREEN_BOTTOM	(NUM_LINES_ON_SCREEN + NUM_LINES_OFF_SCREEN_TOP - 1)
-      
+
 /*this seems to include the scroll bar to the right*/
 /*it's values is always +1 to the actual visible columns*/
 #define NUM_COLS_ON_SCREEN_SAFE (((f->e.x - f->a.x) < (f->b->mx.x+1)) ? (f->e.x - f->a.x) : (f->b->mx.x+1))
 #define NUM_COLS_ON_SCREEN	(f->e.x - f->a.x)
-      
+
 #define NUM_COLS_OFF_SCREEN_LEFT	(f->s->c.x)
 #define COL_NUM_ON_SCREEN_RIGHT	(NUM_COLS_ON_SCREEN + NUM_COLS_OFF_SCREEN_LEFT - 1)
 
@@ -38,37 +38,38 @@
 
 
 /*   we_wind.c   */
-int e_error(char *text, int sw, FARBE *f);
-int e_message(int sw, char *str, FENSTER *f);
-void e_firstl(FENSTER *f, int sw);
-int e_pr_filetype(FENSTER *f);
-view *e_open_view(int xa, int ya, int xe, int ye, int col, int sw);
-int e_close_view(view *pic, int sw);
-void e_pr_line(int y, FENSTER *f);
-void e_std_rahmen(int xa, int ya, int xe, int ye, char *name, int sw,
-  int frb, int fes);
-void e_ed_rahmen(FENSTER *f, int sw);
-int e_schirm(FENSTER *f, int sw);
-int e_size_move(FENSTER *f);
-view *e_std_kst(int xa, int ya, int xe, int ye, char *name, int sw, int fr,
-  int ft, int fes);
-view *e_ed_kst(FENSTER *f, view *pic, int sw);
-int e_close_window(FENSTER *f);
-void e_switch_window(int num, FENSTER *f);
-int e_ed_zoom(FENSTER *f);
-int e_ed_cascade(FENSTER *f);
-int e_ed_tile(FENSTER *f);
-int e_ed_next(FENSTER *f);
-int e_mess_win(char *header, char *str, view **pic, FENSTER *f);
-view *e_change_pic(int xa, int ya, int xe, int ye, view *pic, int sw, int frb);
-struct dirfile *e_add_df(char *str, struct dirfile *df);
-int e_schr_nchar_wsv(char *str, int x, int y, int n, int max, int col,
-  int csw);
-int e_schr_lst_wsv(char *str, int xa, int ya, int n, int strlen, int ft,
-  int fz, struct dirfile **df, FENSTER *f);
-int e_rep_win_tree(ECNT *cn);
-int e_opt_sec_box(int xa, int ya, int num, OPTK *opt, FENSTER *f, int sw);
-int e_close_buffer(BUFFER *b);
-int e_list_all_win(FENSTER *f);
+int e_error (char *text, int sw, FARBE * f);
+int e_message (int sw, char *str, FENSTER * f);
+void e_firstl (FENSTER * f, int sw);
+int e_pr_filetype (FENSTER * f);
+view *e_open_view (int xa, int ya, int xe, int ye, int col, int sw);
+int e_close_view (view * pic, int sw);
+void e_pr_line (int y, FENSTER * f);
+void e_std_rahmen (int xa, int ya, int xe, int ye, char *name, int sw,
+		   int frb, int fes);
+void e_ed_rahmen (FENSTER * f, int sw);
+int e_schirm (FENSTER * f, int sw);
+int e_size_move (FENSTER * f);
+view *e_std_kst (int xa, int ya, int xe, int ye, char *name, int sw, int fr,
+		 int ft, int fes);
+view *e_ed_kst (FENSTER * f, view * pic, int sw);
+int e_close_window (FENSTER * f);
+void e_switch_window (int num, FENSTER * f);
+int e_ed_zoom (FENSTER * f);
+int e_ed_cascade (FENSTER * f);
+int e_ed_tile (FENSTER * f);
+int e_ed_next (FENSTER * f);
+int e_mess_win (char *header, char *str, view ** pic, FENSTER * f);
+view *e_change_pic (int xa, int ya, int xe, int ye, view * pic, int sw,
+		    int frb);
+struct dirfile *e_add_df (char *str, struct dirfile *df);
+int e_schr_nchar_wsv (char *str, int x, int y, int n, int max, int col,
+		      int csw);
+int e_schr_lst_wsv (char *str, int xa, int ya, int n, int strlen, int ft,
+		    int fz, struct dirfile **df, FENSTER * f);
+int e_rep_win_tree (ECNT * cn);
+int e_opt_sec_box (int xa, int ya, int num, OPTK * opt, FENSTER * f, int sw);
+int e_close_buffer (BUFFER * b);
+int e_list_all_win (FENSTER * f);
 
 #endif

--- a/src/we_xterm.c
+++ b/src/we_xterm.c
@@ -20,33 +20,33 @@
 
 //#ifndef TERMCAP
 #if defined HAVE_LIBNCURSES || defined HAVE_LIBCURSES
-# include <curses.h>
+#include <curses.h>
 #endif
 
 #ifndef XWPE_DLL
 #define WpeDllInit WpeXtermInit
 #endif
 
-int fk_show_cursor(void);
-int e_ini_size(void);
-int e_x_getch(void);
-int fk_x_mouse(int *g);
-int e_x_refresh(void);
-int fk_x_locate(int x, int y);
-int fk_x_cursor(int x);
-int e_x_sys_ini(void);
-int e_x_sys_end(void);
-int fk_x_putchar(int c);
-int x_bioskey(void);
-int e_x_system(const char *exe);
-int e_x_cp_X_to_buffer(FENSTER *f);
-int e_x_copy_X_buffer(FENSTER *f);
-int e_x_paste_X_buffer(FENSTER *f);
-int e_x_change(view *pic);
-int e_x_repaint_desk(FENSTER *f);
-void e_setlastpic(view *pic);
-int e_make_xr_rahmen(int xa, int ya, int xe, int ye, int sw);
-int e_x_kbhit(void);
+int fk_show_cursor (void);
+int e_ini_size (void);
+int e_x_getch (void);
+int fk_x_mouse (int *g);
+int e_x_refresh (void);
+int fk_x_locate (int x, int y);
+int fk_x_cursor (int x);
+int e_x_sys_ini (void);
+int e_x_sys_end (void);
+int fk_x_putchar (int c);
+int x_bioskey (void);
+int e_x_system (const char *exe);
+int e_x_cp_X_to_buffer (FENSTER * f);
+int e_x_copy_X_buffer (FENSTER * f);
+int e_x_paste_X_buffer (FENSTER * f);
+int e_x_change (view * pic);
+int e_x_repaint_desk (FENSTER * f);
+void e_setlastpic (view * pic);
+int e_make_xr_rahmen (int xa, int ya, int xe, int ye, int sw);
+int e_x_kbhit (void);
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -82,73 +82,74 @@ extern view *e_X_l_pic;
 
 extern struct mouse e_mouse;
 
-int WpeDllInit(int *argc, char **argv)
+int
+WpeDllInit (int *argc, char **argv)
 {
- e_s_u_clr = e_s_x_clr;
- e_n_u_clr = e_n_x_clr;
- e_frb_u_menue = e_frb_x_menue;
- e_pr_u_col_kasten = e_pr_x_col_kasten;
- fk_u_cursor = fk_x_cursor;
- fk_u_locate = fk_x_locate;
- e_u_refresh = e_x_refresh;
- e_u_getch = e_x_getch;
- u_bioskey = x_bioskey;
- e_u_sys_ini = e_x_sys_ini;
- e_u_sys_end = e_x_sys_end;
- e_u_system = e_x_system;
- fk_u_putchar = fk_x_putchar;
- fk_mouse = fk_x_mouse;
- e_u_cp_X_to_buffer = e_x_cp_X_to_buffer;
- e_u_copy_X_buffer = e_x_copy_X_buffer;
- e_u_paste_X_buffer = e_x_paste_X_buffer;
- e_u_kbhit = e_x_kbhit;
- e_u_change = e_x_change;
- e_u_ini_size = e_ini_size;
- e_u_setlastpic = e_setlastpic;
- WpeMouseChangeShape = (void (*)(WpeMouseShape))WpeNullFunction;
- WpeMouseRestoreShape = (void (*)(void))WpeNullFunction;
+  e_s_u_clr = e_s_x_clr;
+  e_n_u_clr = e_n_x_clr;
+  e_frb_u_menue = e_frb_x_menue;
+  e_pr_u_col_kasten = e_pr_x_col_kasten;
+  fk_u_cursor = fk_x_cursor;
+  fk_u_locate = fk_x_locate;
+  e_u_refresh = e_x_refresh;
+  e_u_getch = e_x_getch;
+  u_bioskey = x_bioskey;
+  e_u_sys_ini = e_x_sys_ini;
+  e_u_sys_end = e_x_sys_end;
+  e_u_system = e_x_system;
+  fk_u_putchar = fk_x_putchar;
+  fk_mouse = fk_x_mouse;
+  e_u_cp_X_to_buffer = e_x_cp_X_to_buffer;
+  e_u_copy_X_buffer = e_x_copy_X_buffer;
+  e_u_paste_X_buffer = e_x_paste_X_buffer;
+  e_u_kbhit = e_x_kbhit;
+  e_u_change = e_x_change;
+  e_u_ini_size = e_ini_size;
+  e_u_setlastpic = e_setlastpic;
+  WpeMouseChangeShape = (void (*)(WpeMouseShape)) WpeNullFunction;
+  WpeMouseRestoreShape = (void (*)(void)) WpeNullFunction;
 /* WpeMouseChangeShape = WpeXMouseChangeShape;
  WpeMouseRestoreShape = WpeXMouseRestoreShape;*/
- WpeDisplayEnd = WpeNullFunction;
- e_u_switch_screen = WpeZeroFunction;
- e_u_d_switch_out = (int (*)(int sw))WpeZeroFunction;
- MCI = 2;
- MCA = 1;
+  WpeDisplayEnd = WpeNullFunction;
+  e_u_switch_screen = WpeZeroFunction;
+  e_u_d_switch_out = (int (*)(int sw)) WpeZeroFunction;
+  MCI = 2;
+  MCA = 1;
 #ifdef NEWSTYLE
- RD1 = ' ';
- RD2 = ' ';
- RD3 = ' ';
- RD4 = ' ';
- RD5 = ' ';
- RD6 = ' ';
- RE1 = ' ';
- RE2 = ' ';
- RE3 = ' ';
- RE4 = ' ';
- RE5 = ' ';
- RE6 = ' ';
+  RD1 = ' ';
+  RD2 = ' ';
+  RD3 = ' ';
+  RD4 = ' ';
+  RD5 = ' ';
+  RD6 = ' ';
+  RE1 = ' ';
+  RE2 = ' ';
+  RE3 = ' ';
+  RE4 = ' ';
+  RE5 = ' ';
+  RE6 = ' ';
 #else
- RD1 = 13;
- RD2 = 12;
- RD3 = 14;
- RD4 = 11;
- RD5 = 18;
- RD6 = 25;
- RE1 = '.';
- RE2 = '.';
- RE3 = '.';
- RE4 = '.';
- RE5 = '.';
- RE6 = ':';
+  RD1 = 13;
+  RD2 = 12;
+  RD3 = 14;
+  RD4 = 11;
+  RD5 = 18;
+  RD6 = 25;
+  RE1 = '.';
+  RE2 = '.';
+  RE3 = '.';
+  RE4 = '.';
+  RE5 = '.';
+  RE6 = ':';
 #endif
- WBT = 1;
- ctree[0] = "\016\022\030";
- ctree[1] = "\016\022\022";
- ctree[2] = "\016\030\022";
- ctree[3] = "\025\022\022";
- ctree[4] = "\016\022\022";
- WpeXInit(argc, argv);
- return 0;
+  WBT = 1;
+  ctree[0] = "\016\022\030";
+  ctree[1] = "\016\022\022";
+  ctree[2] = "\016\030\022";
+  ctree[3] = "\025\022\022";
+  ctree[4] = "\016\022\022";
+  WpeXInit (argc, argv);
+  return 0;
 }
 
 #ifdef NEWSTYLE
@@ -181,166 +182,177 @@ int WpeDllInit(int *argc, char **argv)
   }
 
 
-#else				/* cached  a.r. */
+#else /* cached  a.r. */
 
 #define WPE_MAXSEG 1000
 int nseg[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+
 XSegment seg[8][WPE_MAXSEG];
 int scol[8] = { 0, 0, 15, 15, 15, 15, 0, 0 };
 
-int e_XLookupString(XKeyEvent *event, char *buffer_return, int buffer_size,
-		    KeySym *keysym_return, XComposeStatus *status)
+int
+e_XLookupString (XKeyEvent * event, char *buffer_return, int buffer_size,
+		 KeySym * keysym_return, XComposeStatus * status)
 {
-    static int first = 1;
-    static XIC xic;
-    static XIM xim;
+  static int first = 1;
+  static XIC xic;
+  static XIM xim;
 
-    if (first) {
-	if (!XSetLocaleModifiers(""))
-	    XSetLocaleModifiers("@im=none");
-	xim = XOpenIM(event->display, NULL, NULL, NULL);
-	xic = XCreateIC(xim,
-			XNInputStyle, XIMPreeditNothing | XIMStatusNothing,
-			XNClientWindow, WpeXInfo.window, NULL);
-	first = 0;
+  if (first)
+    {
+      if (!XSetLocaleModifiers (""))
+	XSetLocaleModifiers ("@im=none");
+      xim = XOpenIM (event->display, NULL, NULL, NULL);
+      xic = XCreateIC (xim,
+		       XNInputStyle, XIMPreeditNothing | XIMStatusNothing,
+		       XNClientWindow, WpeXInfo.window, NULL);
+      first = 0;
     }
-    if (xic) {
-	if (XFilterEvent((XEvent*)event, WpeXInfo.window))
-	    return (0);
+  if (xic)
+    {
+      if (XFilterEvent ((XEvent *) event, WpeXInfo.window))
+	return (0);
 
-	return (XmbLookupString(xic, event, buffer_return, buffer_size,
-				keysym_return, NULL));
+      return (XmbLookupString (xic, event, buffer_return, buffer_size,
+			       keysym_return, NULL));
     }
 
-    return (XLookupString(event, buffer_return, buffer_size,
-			  keysym_return, status));
+  return (XLookupString (event, buffer_return, buffer_size,
+			 keysym_return, status));
 }
 
-void e_flush_xrect()
+void
+e_flush_xrect ()
 {
- int i;
+  int i;
 
- for (i = 0; i < 8; i++)
-  if (nseg[i])
-  {
-   XSetForeground(WpeXInfo.display, WpeXInfo.gc, WpeXInfo.colors[scol[i]]);
-   XDrawSegments(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc, seg[i], nseg[i]);
-   nseg[i] = 0;
-  }
+  for (i = 0; i < 8; i++)
+    if (nseg[i])
+      {
+	XSetForeground (WpeXInfo.display, WpeXInfo.gc,
+			WpeXInfo.colors[scol[i]]);
+	XDrawSegments (WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc, seg[i],
+		       nseg[i]);
+	nseg[i] = 0;
+      }
 }
 
-void e_print_xrect(int x, int y, int n)
+void
+e_print_xrect (int x, int y, int n)
 {
- int c = extbyte[n] & 16 ? 4 : 0;
+  int c = extbyte[n] & 16 ? 4 : 0;
 
- if (extbyte[n])
- {
-  if ((nseg[0] > WPE_MAXSEG) || (nseg[1] > WPE_MAXSEG) || (nseg[2] > WPE_MAXSEG) ||
-    (nseg[3] > WPE_MAXSEG) || (nseg[4] > WPE_MAXSEG) || (nseg[5] > WPE_MAXSEG) ||
-    (nseg[6] > WPE_MAXSEG) || (nseg[7] > WPE_MAXSEG))
-   e_flush_xrect();
-  if (extbyte[n] & 2)
-  {
-   seg[c][nseg[c]].x1 = WpeXInfo.font_width*((x)+1)-1;
-   seg[c][nseg[c]].y1 = WpeXInfo.font_height*(y);
-   seg[c][nseg[c]].x2 = WpeXInfo.font_width*((x)+1)-1;
-   seg[c][nseg[c]].y2 = WpeXInfo.font_height*((y)+1)-1;
-   nseg[c]++;
-  }
-  if (extbyte[n] & 4)
-  {
-   seg[c+1][nseg[c+1]].x1 = WpeXInfo.font_width*(x);
-   seg[c+1][nseg[c+1]].y1 = WpeXInfo.font_height*((y)+1)-1;
-   seg[c+1][nseg[c+1]].x2 = WpeXInfo.font_width*((x)+1)-1;
-   seg[c+1][nseg[c+1]].y2 = WpeXInfo.font_height*((y)+1)-1;
-   nseg[c+1]++;
-  }
-  if (extbyte[n] & 8)
-  {
-   seg[c+2][nseg[c+2]].x1 = WpeXInfo.font_width*(x);
-   seg[c+2][nseg[c+2]].y1 = WpeXInfo.font_height*(y);
-   seg[c+2][nseg[c+2]].x2 = WpeXInfo.font_width*(x);
-   seg[c+2][nseg[c+2]].y2 = WpeXInfo.font_height*((y)+1)-1;
-   nseg[c+2]++;
-  }
-  if (extbyte[n] & 1)
-  {
-   seg[c+3][nseg[c+3]].x1 = WpeXInfo.font_width*(x);
-   seg[c+3][nseg[c+3]].y1 = WpeXInfo.font_height*(y);
-   seg[c+3][nseg[c+3]].x2 = WpeXInfo.font_width*((x)+1)-1;
-   seg[c+3][nseg[c+3]].y2 = WpeXInfo.font_height*(y);
-   nseg[c+3]++;
-  }
- }
+  if (extbyte[n])
+    {
+      if ((nseg[0] > WPE_MAXSEG) || (nseg[1] > WPE_MAXSEG)
+	  || (nseg[2] > WPE_MAXSEG) || (nseg[3] > WPE_MAXSEG)
+	  || (nseg[4] > WPE_MAXSEG) || (nseg[5] > WPE_MAXSEG)
+	  || (nseg[6] > WPE_MAXSEG) || (nseg[7] > WPE_MAXSEG))
+	e_flush_xrect ();
+      if (extbyte[n] & 2)
+	{
+	  seg[c][nseg[c]].x1 = WpeXInfo.font_width * ((x) + 1) - 1;
+	  seg[c][nseg[c]].y1 = WpeXInfo.font_height * (y);
+	  seg[c][nseg[c]].x2 = WpeXInfo.font_width * ((x) + 1) - 1;
+	  seg[c][nseg[c]].y2 = WpeXInfo.font_height * ((y) + 1) - 1;
+	  nseg[c]++;
+	}
+      if (extbyte[n] & 4)
+	{
+	  seg[c + 1][nseg[c + 1]].x1 = WpeXInfo.font_width * (x);
+	  seg[c + 1][nseg[c + 1]].y1 = WpeXInfo.font_height * ((y) + 1) - 1;
+	  seg[c + 1][nseg[c + 1]].x2 = WpeXInfo.font_width * ((x) + 1) - 1;
+	  seg[c + 1][nseg[c + 1]].y2 = WpeXInfo.font_height * ((y) + 1) - 1;
+	  nseg[c + 1]++;
+	}
+      if (extbyte[n] & 8)
+	{
+	  seg[c + 2][nseg[c + 2]].x1 = WpeXInfo.font_width * (x);
+	  seg[c + 2][nseg[c + 2]].y1 = WpeXInfo.font_height * (y);
+	  seg[c + 2][nseg[c + 2]].x2 = WpeXInfo.font_width * (x);
+	  seg[c + 2][nseg[c + 2]].y2 = WpeXInfo.font_height * ((y) + 1) - 1;
+	  nseg[c + 2]++;
+	}
+      if (extbyte[n] & 1)
+	{
+	  seg[c + 3][nseg[c + 3]].x1 = WpeXInfo.font_width * (x);
+	  seg[c + 3][nseg[c + 3]].y1 = WpeXInfo.font_height * (y);
+	  seg[c + 3][nseg[c + 3]].x2 = WpeXInfo.font_width * ((x) + 1) - 1;
+	  seg[c + 3][nseg[c + 3]].y2 = WpeXInfo.font_height * (y);
+	  nseg[c + 3]++;
+	}
+    }
 }
 #endif
 
 #endif
 
-int fk_show_cursor()
+int
+fk_show_cursor ()
 {
- int x;
+  int x;
 
- if (!cur_on)
-  return(0);
- x = 2 * old_cursor_x + 2 * MAXSCOL * old_cursor_y;
- if (x > 0)
- {
-  XSetForeground(WpeXInfo.display, WpeXInfo.gc,
-    WpeXInfo.colors[schirm[x + 1] % 16]);
-  XSetBackground(WpeXInfo.display, WpeXInfo.gc,
-    WpeXInfo.colors[schirm[x + 1] / 16]);
-  XDrawImageString(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
-    WpeXInfo.font_width*old_cursor_x,
-    WpeXInfo.font_height*(old_cursor_y+1) - WpeXInfo.font->max_bounds.descent,
-    schirm + x, 1);
+  if (!cur_on)
+    return (0);
+  x = 2 * old_cursor_x + 2 * MAXSCOL * old_cursor_y;
+  if (x > 0)
+    {
+      XSetForeground (WpeXInfo.display, WpeXInfo.gc,
+		      WpeXInfo.colors[schirm[x + 1] % 16]);
+      XSetBackground (WpeXInfo.display, WpeXInfo.gc,
+		      WpeXInfo.colors[schirm[x + 1] / 16]);
+      XDrawImageString (WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
+			WpeXInfo.font_width * old_cursor_x,
+			WpeXInfo.font_height * (old_cursor_y + 1) -
+			WpeXInfo.font->max_bounds.descent, schirm + x, 1);
 #ifdef NEWSTYLE
-  e_print_xrect(old_cursor_x, old_cursor_y, x/2);
+      e_print_xrect (old_cursor_x, old_cursor_y, x / 2);
 #ifndef NOXCACHE
-  e_flush_xrect();
+      e_flush_xrect ();
 #endif
 #endif
- }
- x = 2 * cur_x + 2 * MAXSCOL * cur_y;
+    }
+  x = 2 * cur_x + 2 * MAXSCOL * cur_y;
 
- XSetForeground(WpeXInfo.display, WpeXInfo.gc,
-   WpeXInfo.colors[schirm[x + 1] / 16]);
- XSetBackground(WpeXInfo.display, WpeXInfo.gc,
-   WpeXInfo.colors[schirm[x + 1] % 16]);
- XDrawImageString(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
-   WpeXInfo.font_width * cur_x,
-   WpeXInfo.font_height * (cur_y + 1) - WpeXInfo.font->max_bounds.descent,
-   schirm + x, 1);
- old_cursor_x = cur_x;
- old_cursor_y = cur_y;
- return(cur_on);
+  XSetForeground (WpeXInfo.display, WpeXInfo.gc,
+		  WpeXInfo.colors[schirm[x + 1] / 16]);
+  XSetBackground (WpeXInfo.display, WpeXInfo.gc,
+		  WpeXInfo.colors[schirm[x + 1] % 16]);
+  XDrawImageString (WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
+		    WpeXInfo.font_width * cur_x,
+		    WpeXInfo.font_height * (cur_y + 1) -
+		    WpeXInfo.font->max_bounds.descent, schirm + x, 1);
+  old_cursor_x = cur_x;
+  old_cursor_y = cur_y;
+  return (cur_on);
 }
 
-int e_ini_size()
+int
+e_ini_size ()
 {
- old_cursor_x = cur_x;
- old_cursor_y = cur_y;
+  old_cursor_x = cur_x;
+  old_cursor_y = cur_y;
 
- if (schirm)
-  free(schirm);
- if(altschirm)
-  free(altschirm);
- schirm = malloc(2 * MAXSCOL * MAXSLNS);
- altschirm = malloc(2 * MAXSCOL * MAXSLNS);
+  if (schirm)
+    free (schirm);
+  if (altschirm)
+    free (altschirm);
+  schirm = malloc (2 * MAXSCOL * MAXSLNS);
+  altschirm = malloc (2 * MAXSCOL * MAXSLNS);
 #ifdef NEWSTYLE
- if (extbyte)
-  free(extbyte);
- if (altextbyte)
-  free(altextbyte);
- extbyte = malloc(MAXSCOL * MAXSLNS);
- altextbyte = malloc(MAXSCOL * MAXSLNS);
- if (!schirm || !altschirm || !extbyte || !altextbyte)
-  return(-1);
+  if (extbyte)
+    free (extbyte);
+  if (altextbyte)
+    free (altextbyte);
+  extbyte = malloc (MAXSCOL * MAXSLNS);
+  altextbyte = malloc (MAXSCOL * MAXSLNS);
+  if (!schirm || !altschirm || !extbyte || !altextbyte)
+    return (-1);
 #else
- if(!schirm || !altschirm)
-  return(-1);
+  if (!schirm || !altschirm)
+    return (-1);
 #endif
- return(0);
+  return (0);
 }
 
 #define A_Normal 	16
@@ -349,758 +361,893 @@ int e_ini_size()
 #define A_Underline	1
 #define A_Bold		16
 
-int e_X_sw_color()
+int
+e_X_sw_color ()
 {
- FARBE *fb = WpeEditor->fb;
- fb->er = e_n_clr(A_Normal);
- fb->et = e_n_clr(A_Normal);
- fb->ez = e_n_clr(A_Reverse);
- fb->es = e_n_clr(A_Normal);
- fb->em = e_n_clr(A_Standout);
- fb->ek = e_n_clr(A_Underline);
- fb->nr = e_n_clr(A_Standout);
- fb->nt = e_n_clr(A_Reverse);
- fb->nz = e_n_clr(A_Normal);
- fb->ns = e_n_clr(A_Bold);
- fb->mr = e_n_clr(A_Standout);
- fb->mt = e_n_clr(A_Standout);
- fb->mz = e_n_clr(A_Normal);
- fb->ms = e_n_clr(A_Normal);
- fb->fr = e_n_clr(A_Normal);
- fb->ft = e_n_clr(A_Normal);
- fb->fz = e_n_clr(A_Standout);
- fb->fs = e_n_clr(A_Standout);
- fb->of = e_n_clr(A_Standout);
- fb->df = e_n_clr(A_Normal);
- fb->dc = 0x02;
+  FARBE *fb = WpeEditor->fb;
+  fb->er = e_n_clr (A_Normal);
+  fb->et = e_n_clr (A_Normal);
+  fb->ez = e_n_clr (A_Reverse);
+  fb->es = e_n_clr (A_Normal);
+  fb->em = e_n_clr (A_Standout);
+  fb->ek = e_n_clr (A_Underline);
+  fb->nr = e_n_clr (A_Standout);
+  fb->nt = e_n_clr (A_Reverse);
+  fb->nz = e_n_clr (A_Normal);
+  fb->ns = e_n_clr (A_Bold);
+  fb->mr = e_n_clr (A_Standout);
+  fb->mt = e_n_clr (A_Standout);
+  fb->mz = e_n_clr (A_Normal);
+  fb->ms = e_n_clr (A_Normal);
+  fb->fr = e_n_clr (A_Normal);
+  fb->ft = e_n_clr (A_Normal);
+  fb->fz = e_n_clr (A_Standout);
+  fb->fs = e_n_clr (A_Standout);
+  fb->of = e_n_clr (A_Standout);
+  fb->df = e_n_clr (A_Normal);
+  fb->dc = 0x02;
 #ifdef DEBUGGER
- fb->db = e_n_clr(A_Standout);
- fb->dy = e_n_clr(A_Standout);
+  fb->db = e_n_clr (A_Standout);
+  fb->dy = e_n_clr (A_Standout);
 #endif
- return(0);
+  return (0);
 }
 
-int e_x_refresh()
+int
+e_x_refresh ()
 {
-#ifndef NOXCACHE				/* a.r. */
+#ifndef NOXCACHE		/* a.r. */
 #define STRBUFSIZE 1024
-   unsigned long oldback = 0, oldfore = 0;
-   static char stringbuf[STRBUFSIZE];
-   int stringcount = 0, oldI = 0, oldX = 0, oldY = 0, oldJ = 0;
+  unsigned long oldback = 0, oldfore = 0;
+  static char stringbuf[STRBUFSIZE];
+  int stringcount = 0, oldI = 0, oldX = 0, oldY = 0, oldJ = 0;
 #endif
-   int i, j, x, y, cur_tmp = cur_on;
-   fk_cursor(0);
-   for(i = 0; i < MAXSLNS; i++)
-   for(j = 0; j < MAXSCOL; j++)
-   {  y = j + MAXSCOL*i;
-      x = 2*y;
-#ifdef NEWSTYLE
-      if(schirm[x] != altschirm[x] || schirm[x+1] != altschirm[x+1]
-		|| extbyte[y] != altextbyte[y])
-#else
-      if(schirm[x] != altschirm[x] || schirm[x+1] != altschirm[x+1])
-#endif
+  int i, j, x, y, cur_tmp = cur_on;
+  fk_cursor (0);
+  for (i = 0; i < MAXSLNS; i++)
+    for (j = 0; j < MAXSCOL; j++)
       {
-#ifdef NOXCACHE
-	 XSetForeground(WpeXInfo.display, WpeXInfo.gc, WpeXInfo.colors[schirm[x+1] % 16]);
-	 XSetBackground(WpeXInfo.display, WpeXInfo.gc, WpeXInfo.colors[schirm[x+1] / 16]);
-	 XDrawImageString(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc, WpeXInfo.font_width*j,
-    		WpeXInfo.font_height*(i+1) - WpeXInfo.font->max_bounds.descent,
-							schirm + x, 1);
+	y = j + MAXSCOL * i;
+	x = 2 * y;
+#ifdef NEWSTYLE
+	if (schirm[x] != altschirm[x] || schirm[x + 1] != altschirm[x + 1]
+	    || extbyte[y] != altextbyte[y])
 #else
-	 if (   oldback != (unsigned) WpeXInfo.colors[schirm[x+1] / 16]  	/* a.r. */
-	     || oldfore != (unsigned) WpeXInfo.colors[schirm[x+1] % 16]
-	     || i != oldI
-	     || j > oldJ+1	/* is there a more elegant solution? */
-	     || stringcount >= STRBUFSIZE
-            )
-	   {
-	        XDrawImageString(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
-		    		 oldX, oldY, stringbuf, stringcount);
-	        oldback = WpeXInfo.colors[schirm[x+1] / 16];
-	        oldfore = WpeXInfo.colors[schirm[x+1] % 16];
-	 	XSetForeground(WpeXInfo.display, WpeXInfo.gc, oldfore );
-	 	XSetBackground(WpeXInfo.display, WpeXInfo.gc, oldback );
-		oldX = WpeXInfo.font_width*j;
-    		oldY = WpeXInfo.font_height*(i+1) - WpeXInfo.font->max_bounds.descent;
+	if (schirm[x] != altschirm[x] || schirm[x + 1] != altschirm[x + 1])
+#endif
+	  {
+#ifdef NOXCACHE
+	    XSetForeground (WpeXInfo.display, WpeXInfo.gc,
+			    WpeXInfo.colors[schirm[x + 1] % 16]);
+	    XSetBackground (WpeXInfo.display, WpeXInfo.gc,
+			    WpeXInfo.colors[schirm[x + 1] / 16]);
+	    XDrawImageString (WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
+			      WpeXInfo.font_width * j,
+			      WpeXInfo.font_height * (i + 1) -
+			      WpeXInfo.font->max_bounds.descent, schirm + x,
+			      1);
+#else
+	    if (oldback != (unsigned) WpeXInfo.colors[schirm[x + 1] / 16]	/* a.r. */
+		|| oldfore != (unsigned) WpeXInfo.colors[schirm[x + 1] % 16] || i != oldI || j > oldJ + 1	/* is there a more elegant solution? */
+		|| stringcount >= STRBUFSIZE)
+	      {
+		XDrawImageString (WpeXInfo.display, WpeXInfo.window,
+				  WpeXInfo.gc, oldX, oldY, stringbuf,
+				  stringcount);
+		oldback = WpeXInfo.colors[schirm[x + 1] / 16];
+		oldfore = WpeXInfo.colors[schirm[x + 1] % 16];
+		XSetForeground (WpeXInfo.display, WpeXInfo.gc, oldfore);
+		XSetBackground (WpeXInfo.display, WpeXInfo.gc, oldback);
+		oldX = WpeXInfo.font_width * j;
+		oldY =
+		  WpeXInfo.font_height * (i + 1) -
+		  WpeXInfo.font->max_bounds.descent;
 		oldI = i;
 		stringcount = 0;
 		stringbuf[stringcount++] = schirm[x];
-	   }
-	 else
-		stringbuf[stringcount++] = schirm[x];
+	      }
+	    else
+	      stringbuf[stringcount++] = schirm[x];
 #endif
 #ifndef NEWSTYLE
-	 if(schirm[x] == 16)
-	 {  XFillRectangle(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc, WpeXInfo.font_width*j,
-    		WpeXInfo.font_height*(i), WpeXInfo.font_width,
-			(WpeXInfo.font_height + WpeXInfo.font->max_bounds.descent)/2);
-	 }
-	 else if(schirm[x] == 20)
-	 {  XFillRectangle(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc, WpeXInfo.font_width*j,
-    		(int)(WpeXInfo.font_height*(i+1./2)), WpeXInfo.font_width,
-			(WpeXInfo.font_height + WpeXInfo.font->max_bounds.descent)/2);
-	 }
+	    if (schirm[x] == 16)
+	      {
+		XFillRectangle (WpeXInfo.display, WpeXInfo.window,
+				WpeXInfo.gc, WpeXInfo.font_width * j,
+				WpeXInfo.font_height * (i),
+				WpeXInfo.font_width,
+				(WpeXInfo.font_height +
+				 WpeXInfo.font->max_bounds.descent) / 2);
+	      }
+	    else if (schirm[x] == 20)
+	      {
+		XFillRectangle (WpeXInfo.display, WpeXInfo.window,
+				WpeXInfo.gc, WpeXInfo.font_width * j,
+				(int) (WpeXInfo.font_height * (i + 1. / 2)),
+				WpeXInfo.font_width,
+				(WpeXInfo.font_height +
+				 WpeXInfo.font->max_bounds.descent) / 2);
+	      }
 #endif
-	 altschirm[x] = schirm[x];
-	 altschirm[x+1] = schirm[x+1];
+	    altschirm[x] = schirm[x];
+	    altschirm[x + 1] = schirm[x + 1];
 #ifdef NEWSTYLE
-	 e_print_xrect(j, i, y);
-	 altextbyte[y] = extbyte[y];
+	    e_print_xrect (j, i, y);
+	    altextbyte[y] = extbyte[y];
 #endif
 #ifndef NOXCACHE
-	 oldJ = j;
+	    oldJ = j;
 #endif
+	  }
       }
-   }
 #ifndef NOXCACHE
-   XDrawImageString(WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
-		    oldX,
-    		    oldY,
-		    stringbuf,
-		    stringcount);
+  XDrawImageString (WpeXInfo.display, WpeXInfo.window, WpeXInfo.gc,
+		    oldX, oldY, stringbuf, stringcount);
 #ifdef NEWSTYLE
-   e_flush_xrect();
+  e_flush_xrect ();
 #endif
 #endif
-   fk_cursor(cur_tmp);
-   fk_show_cursor();
-   XFlush(WpeXInfo.display);
-   return(0);
+  fk_cursor (cur_tmp);
+  fk_show_cursor ();
+  XFlush (WpeXInfo.display);
+  return (0);
 }
 
-int e_x_change(view *pic)
+int
+e_x_change (view * pic)
 {
- XEvent report;
- XExposeEvent *expose_report;
- KeySym keysym;
- char buffer[BUFSIZE];
- int charcount;
- unsigned int key_b;
- XSizeHints size_hints;
+  XEvent report;
+  XExposeEvent *expose_report;
+  KeySym keysym;
+  char buffer[BUFSIZE];
+  int charcount;
+  unsigned int key_b;
+  XSizeHints size_hints;
 
- expose_report = (XExposeEvent *)&report;
- while (XCheckMaskEvent(WpeXInfo.display, KeyPressMask | ButtonPressMask |
-		ExposureMask | StructureNotifyMask, &report) == True)
- {
-  switch(report.type)
-  {
-   case Expose:
-    /* Reason for +2 : Assumes extra character on either side. */
-    e_refresh_area(expose_report->x/WpeXInfo.font_width,
-                           expose_report->y/WpeXInfo.font_height,
-                           expose_report->width/WpeXInfo.font_width+2,
-                           expose_report->height/WpeXInfo.font_height+2);
+  expose_report = (XExposeEvent *) & report;
+  while (XCheckMaskEvent (WpeXInfo.display, KeyPressMask | ButtonPressMask |
+			  ExposureMask | StructureNotifyMask,
+			  &report) == True)
+    {
+      switch (report.type)
+	{
+	case Expose:
+	  /* Reason for +2 : Assumes extra character on either side. */
+	  e_refresh_area (expose_report->x / WpeXInfo.font_width,
+			  expose_report->y / WpeXInfo.font_height,
+			  expose_report->width / WpeXInfo.font_width + 2,
+			  expose_report->height / WpeXInfo.font_height + 2);
 /*	    e_abs_refr();*/
-    e_refresh();
-    break;
-   case ConfigureNotify:
-    size_hints.width = (report.xconfigure.width / WpeXInfo.font_width) * WpeXInfo.font_width;
-    size_hints.height = (report.xconfigure.height / WpeXInfo.font_height) * WpeXInfo.font_height;
-    if (size_hints.width != MAXSCOL * WpeXInfo.font_width ||
-      size_hints.height != MAXSLNS * WpeXInfo.font_height)
-    {
-     MAXSCOL = size_hints.width / WpeXInfo.font_width;
-     MAXSLNS = size_hints.height / WpeXInfo.font_height;
-     e_x_repaint_desk(WpeEditor->f[WpeEditor->mxedt]);
+	  e_refresh ();
+	  break;
+	case ConfigureNotify:
+	  size_hints.width =
+	    (report.xconfigure.width / WpeXInfo.font_width) *
+	    WpeXInfo.font_width;
+	  size_hints.height =
+	    (report.xconfigure.height / WpeXInfo.font_height) *
+	    WpeXInfo.font_height;
+	  if (size_hints.width != MAXSCOL * WpeXInfo.font_width
+	      || size_hints.height != MAXSLNS * WpeXInfo.font_height)
+	    {
+	      MAXSCOL = size_hints.width / WpeXInfo.font_width;
+	      MAXSLNS = size_hints.height / WpeXInfo.font_height;
+	      e_x_repaint_desk (WpeEditor->f[WpeEditor->mxedt]);
+	    }
+	  break;
+	case KeyPress:
+	  charcount =
+	    e_XLookupString (&report.xkey, buffer, BUFSIZE, &keysym, NULL);
+	  if (charcount == 1 && *buffer == CtrlC)
+	    return (CtrlC);
+	  break;
+	case ButtonPress:
+	  if (!pic)
+	    break;
+	  key_b = report.xbutton.state;
+	  if (report.xbutton.button == 1)
+	    {
+	      e_mouse.k = (key_b & ShiftMask) ? 3 : 0 +
+		(key_b & ControlMask) ? 4 : 0 +
+		(key_b & WpeXInfo.altmask) ? 8 : 0;
+	      e_mouse.x = report.xbutton.x / WpeXInfo.font_width;
+	      e_mouse.y = report.xbutton.y / WpeXInfo.font_height;
+	      if (e_mouse.x > (pic->e.x + pic->a.x - 10) / 2 &&
+		  e_mouse.x < (pic->e.x + pic->a.x + 6) / 2)
+		return (CtrlC);
+	    }
+	  break;
+	}
     }
-    break;
-   case KeyPress:
-    charcount = e_XLookupString(&report.xkey, buffer, BUFSIZE, &keysym, NULL);
-    if (charcount == 1 && *buffer == CtrlC) return(CtrlC);
-    break;
-   case ButtonPress:
-    if (!pic)
-     break;
-    key_b = report.xbutton.state;
-    if (report.xbutton.button == 1)
+  return (0);
+}
+
+int
+e_x_getch ()
+{
+  Window tmp_win, tmp_root;
+  XEvent report;
+  XSelectionEvent se;
+  KeySym keysym;
+  int charcount;
+  char buffer[BUFSIZE];
+  int c, root_x, root_y, x, y;
+  unsigned int key_b;
+  XSizeHints size_hints;
+
+  e_refresh ();
+
+  XQueryPointer (WpeXInfo.display, WpeXInfo.window, &tmp_root, &tmp_win,
+		 &root_x, &root_y, &x, &y, &key_b);
+  if (key_b & (Button1Mask | Button2Mask | Button3Mask))
     {
-     e_mouse.k = (key_b & ShiftMask) ? 3 : 0 +
-		         (key_b & ControlMask) ? 4 : 0 +
-		         (key_b & WpeXInfo.altmask) ? 8 : 0;
-     e_mouse.x = report.xbutton.x/WpeXInfo.font_width;
-     e_mouse.y = report.xbutton.y/WpeXInfo.font_height;
-     if (e_mouse.x > (pic->e.x + pic->a.x - 10)/2 &&
-       e_mouse.x < (pic->e.x + pic->a.x + 6)/2 )
-      return(CtrlC);
+      e_mouse.x = x / WpeXInfo.font_width;
+      e_mouse.y = y / WpeXInfo.font_height;
+      c = 0;
+      if (key_b & Button1Mask)
+	c |= 1;
+      if (key_b & Button2Mask)
+	c |= 4;
+      if (key_b & Button3Mask)
+	c |= 2;
+      return (-c);
     }
-    break;
-  }
- }
- return(0);
-}
 
-int e_x_getch()
-{
- Window tmp_win, tmp_root;
- XEvent report;
- XSelectionEvent se;
- KeySym keysym;
- int charcount;
- char buffer[BUFSIZE];
- int c, root_x, root_y, x, y;
- unsigned int key_b;
- XSizeHints size_hints;
-
- e_refresh();
-
- XQueryPointer(WpeXInfo.display, WpeXInfo.window, &tmp_root, &tmp_win,
-   &root_x, &root_y, &x, &y, &key_b);
- if (key_b & (Button1Mask | Button2Mask | Button3Mask))
- {
-  e_mouse.x = x / WpeXInfo.font_width;
-  e_mouse.y = y / WpeXInfo.font_height;
-  c = 0;
-  if (key_b & Button1Mask) c |= 1;
-  if (key_b & Button2Mask) c |= 4;
-  if (key_b & Button3Mask) c |= 2;
-  return(-c);
- }
-
- while (1)
- {
-  XNextEvent(WpeXInfo.display, &report);
-
-  switch (report.type)
-  {
-   case Expose:
-    do
+  while (1)
     {
-     /* Reason for +2 : Assumes extra character on either side. */
-     e_refresh_area(report.xexpose.x / WpeXInfo.font_width,
-       report.xexpose.y / WpeXInfo.font_height,
-       report.xexpose.width / WpeXInfo.font_width + 2,
-       report.xexpose.height / WpeXInfo.font_height + 2);
-    } while (XCheckMaskEvent(WpeXInfo.display, ExposureMask, &report) == True);
-    e_refresh();
-    break;
-   case ConfigureNotify:
-    size_hints.width = (report.xconfigure.width / WpeXInfo.font_width) * WpeXInfo.font_width;
-    size_hints.height = (report.xconfigure.height / WpeXInfo.font_height) * WpeXInfo.font_height;
-    if (size_hints.width != MAXSCOL * WpeXInfo.font_width ||
-      size_hints.height != MAXSLNS * WpeXInfo.font_height)
-    {
-     MAXSCOL = size_hints.width / WpeXInfo.font_width;
-     MAXSLNS = size_hints.height / WpeXInfo.font_height;
-     e_x_repaint_desk(WpeEditor->f[WpeEditor->mxedt]);
+      XNextEvent (WpeXInfo.display, &report);
+
+      switch (report.type)
+	{
+	case Expose:
+	  do
+	    {
+	      /* Reason for +2 : Assumes extra character on either side. */
+	      e_refresh_area (report.xexpose.x / WpeXInfo.font_width,
+			      report.xexpose.y / WpeXInfo.font_height,
+			      report.xexpose.width / WpeXInfo.font_width + 2,
+			      report.xexpose.height / WpeXInfo.font_height +
+			      2);
+	    }
+	  while (XCheckMaskEvent (WpeXInfo.display, ExposureMask, &report) ==
+		 True);
+	  e_refresh ();
+	  break;
+	case ConfigureNotify:
+	  size_hints.width =
+	    (report.xconfigure.width / WpeXInfo.font_width) *
+	    WpeXInfo.font_width;
+	  size_hints.height =
+	    (report.xconfigure.height / WpeXInfo.font_height) *
+	    WpeXInfo.font_height;
+	  if (size_hints.width != MAXSCOL * WpeXInfo.font_width
+	      || size_hints.height != MAXSLNS * WpeXInfo.font_height)
+	    {
+	      MAXSCOL = size_hints.width / WpeXInfo.font_width;
+	      MAXSLNS = size_hints.height / WpeXInfo.font_height;
+	      e_x_repaint_desk (WpeEditor->f[WpeEditor->mxedt]);
+	    }
+	  break;
+	case ClientMessage:
+	  // Atoms are defined as unsigned long, hence a cast to unsigned
+	  if (report.xclient.message_type == WpeXInfo.protocol_atom &&
+	      ((report.xclient.format == 8 &&
+		(unsigned) report.xclient.data.b[0] == WpeXInfo.delete_atom)
+	       || (report.xclient.format == 16
+		   && (unsigned) report.xclient.data.s[0] ==
+		   WpeXInfo.delete_atom) || (report.xclient.format == 32
+					     && (unsigned) report.xclient.
+					     data.l[0] ==
+					     WpeXInfo.delete_atom)))
+	    {
+	      e_quit (WpeEditor->f[WpeEditor->mxedt]);
+	    }
+	  break;
+	case KeyPress:
+	  charcount = e_XLookupString (&report.xkey, buffer, BUFSIZE, &keysym,
+				       NULL);
+	  key_b = report.xkey.state;
+	  if (charcount == 1)
+	    {
+	      if (*buffer == 127)
+		{
+		  if (key_b & ControlMask)
+		    return (CENTF);
+		  else if (key_b & ShiftMask)
+		    return (ShiftDel);
+		  else if (key_b & WpeXInfo.altmask)
+		    return (AltDel);
+		  else
+		    return (ENTF);
+		}
+	      if ((key_b & ShiftMask) && (*buffer == '\t'))
+		return (WPE_BTAB);
+
+	      if (key_b & WpeXInfo.altmask)
+		c =
+		  e_tast_sim (key_b & ShiftMask ? toupper (*buffer) :
+			      *buffer);
+	      else
+		return (*buffer);
+	    }
+	  else
+	    {
+	      c = 0;
+	      if (key_b & ControlMask)
+		{
+		  if (keysym == XK_Left)
+		    c = CCLE;
+		  else if (keysym == XK_Right)
+		    c = CCRI;
+		  else if (keysym == XK_Home)
+		    c = CPS1;
+		  else if (keysym == XK_End)
+		    c = CEND;
+		  else if (keysym == XK_Insert)
+		    c = CEINFG;
+		  else if (keysym == XK_Delete)
+		    c = CENTF;
+		  else if (keysym == XK_Prior)
+		    c = CBUP;
+		  else if (keysym == XK_Next)
+		    c = CBDO;
+		  else if (keysym == XK_F1)
+		    c = CF1;
+		  else if (keysym == XK_F2)
+		    c = CF2;
+		  else if (keysym == XK_F3)
+		    c = CF3;
+		  else if (keysym == XK_F4)
+		    c = CF4;
+		  else if (keysym == XK_F5)
+		    c = CF5;
+		  else if (keysym == XK_F6)
+		    c = CF6;
+		  else if (keysym == XK_F7)
+		    c = CF7;
+		  else if (keysym == XK_F8)
+		    c = CF8;
+		  else if (keysym == XK_F9)
+		    c = CF9;
+		  else if (keysym == XK_F10)
+		    c = CF10;
+		}
+	      else if (key_b & WpeXInfo.altmask)
+		{
+		  if (keysym == XK_F1)
+		    c = AF1;
+		  else if (keysym == XK_F2)
+		    c = AF2;
+		  else if (keysym == XK_F3)
+		    c = AF3;
+		  else if (keysym == XK_F4)
+		    c = AF4;
+		  else if (keysym == XK_F5)
+		    c = AF5;
+		  else if (keysym == XK_F6)
+		    c = AF6;
+		  else if (keysym == XK_F7)
+		    c = AF7;
+		  else if (keysym == XK_F8)
+		    c = AF8;
+		  else if (keysym == XK_F9)
+		    c = AF9;
+		  else if (keysym == XK_F10)
+		    c = AF10;
+		  else if (keysym == XK_Insert)
+		    c = AltEin;
+		  else if (keysym == XK_Delete)
+		    c = AltDel;
+		}
+	      else
+		{
+		  if (keysym == XK_Left)
+		    c = CLE;
+		  else if (keysym == XK_Right)
+		    c = CRI;
+		  else if (keysym == XK_Up)
+		    c = CUP;
+		  else if (keysym == XK_Down)
+		    c = CDO;
+		  else if (keysym == XK_Home)
+		    c = POS1;
+		  else if (keysym == XK_End)
+		    c = ENDE;
+		  else if (keysym == XK_Insert)
+		    c = EINFG;
+		  else if (keysym == XK_Delete)
+		    c = ENTF;
+		  else if (keysym == XK_BackSpace)
+		    c = CtrlH;
+		  else if (keysym == XK_Prior)
+		    c = BUP;
+		  else if (keysym == XK_Next)
+		    c = BDO;
+		  else if (keysym == XK_F1)
+		    c = F1;
+		  else if (keysym == XK_F2)
+		    c = F2;
+		  else if (keysym == XK_F3)
+		    c = F3;
+		  else if (keysym == XK_F4)
+		    c = F4;
+		  else if (keysym == XK_F5)
+		    c = F5;
+		  else if (keysym == XK_F6)
+		    c = F6;
+		  else if (keysym == XK_F7)
+		    c = F7;
+		  else if (keysym == XK_F8)
+		    c = F8;
+		  else if (keysym == XK_F9)
+		    c = F9;
+		  else if (keysym == XK_F10)
+		    c = F10;
+		  else if (keysym == XK_L1)
+		    c = STOP;
+		  else if (keysym == XK_L2)
+		    c = AGAIN;
+		  else if (keysym == XK_L3)
+		    c = PROPS;
+		  else if (keysym == XK_L4)
+		    c = UNDO;
+		  else if (keysym == XK_L5)
+		    c = FRONT;
+		  else if (keysym == XK_L6)
+		    c = COPY;
+		  else if (keysym == XK_L7)
+		    c = OPEN;
+		  else if (keysym == XK_L8)
+		    c = PASTE;
+		  else if (keysym == XK_L9)
+		    c = FID;
+		  else if (keysym == XK_L10)
+		    c = CUT;
+		  else if (keysym == XK_Help)
+		    c = HELP;
+		}
+	    }
+	  if (c != 0)
+	    {
+	      if (key_b & ShiftMask)
+		c = c + 512;
+	      return (c);
+	    }
+	  break;
+	case ButtonPress:
+	  key_b = report.xbutton.state;
+	  e_mouse.k = (key_b & ShiftMask) ? 3 : 0 +
+	    (key_b & ControlMask) ? 4 : 0 +
+	    (key_b & WpeXInfo.altmask) ? 8 : 0;
+	  e_mouse.x = report.xbutton.x / WpeXInfo.font_width;
+	  e_mouse.y = report.xbutton.y / WpeXInfo.font_height;
+	  c = 0;
+	  if (report.xbutton.button == 1)
+	    c |= 1;
+	  if (report.xbutton.button == 2)
+	    c |= 2;
+	  if (report.xbutton.button == 3)
+	    c |= 4;
+	  return (-c);
+	case SelectionRequest:
+	  if (WpeXInfo.selection)
+	    {
+	      se.type = SelectionNotify;
+	      se.display = report.xselectionrequest.display;
+	      se.requestor = report.xselectionrequest.requestor;
+	      se.selection = report.xselectionrequest.selection;
+	      se.time = report.xselectionrequest.time;
+	      se.target = report.xselectionrequest.target;
+	      if (report.xselectionrequest.property == None)
+		report.xselectionrequest.property =
+		  report.xselectionrequest.target;
+	      /* Xt asks for TARGETS.  Should probably support that. */
+	      if (report.xselectionrequest.target == WpeXInfo.text_atom)
+		{
+		  se.property = report.xselectionrequest.property;
+		  XChangeProperty (se.display, se.requestor, se.property,
+				   se.target, 8, PropModeReplace,
+				   WpeXInfo.selection,
+				   strlen ((const char *) WpeXInfo.
+					   selection));
+		}
+	      else
+		se.property = None;
+	      XSendEvent (WpeXInfo.display, se.requestor, False, 0,
+			  (XEvent *) & se);
+	    }
+	  break;
+	case SelectionClear:
+	  if (WpeXInfo.selection)
+	    {
+	      free (WpeXInfo.selection);
+	      WpeXInfo.selection = NULL;
+	    }
+	  break;
+	default:
+	  break;
+	}
     }
-    break;
-   case ClientMessage:
-    // Atoms are defined as unsigned long, hence a cast to unsigned
-    if (report.xclient.message_type == WpeXInfo.protocol_atom &&
-      ((report.xclient.format == 8 &&
-        (unsigned)report.xclient.data.b[0] == WpeXInfo.delete_atom) ||
-      (report.xclient.format == 16 &&
-        (unsigned)report.xclient.data.s[0] == WpeXInfo.delete_atom) ||
-      (report.xclient.format == 32 &&
-        (unsigned)report.xclient.data.l[0] == WpeXInfo.delete_atom)))
+  return (0);
+}
+
+int
+e_x_kbhit ()
+{
+  XEvent report;
+  KeySym keysym;
+  int charcount;
+  char buffer[BUFSIZE];
+  int c;
+  unsigned int key_b;
+
+  e_refresh ();
+
+  if (XCheckMaskEvent
+      (WpeXInfo.display, ButtonPressMask | KeyPressMask, &report) == False)
+    return (0);
+
+  if (report.type == ButtonPress)
     {
-     e_quit(WpeEditor->f[WpeEditor->mxedt]);
+      key_b = report.xbutton.state;
+      e_mouse.k = (key_b & ShiftMask) ? 3 : 0;
+      e_mouse.x = report.xbutton.x / WpeXInfo.font_width;
+      e_mouse.y = report.xbutton.y / WpeXInfo.font_height;
+      c = 0;
+      if (report.xbutton.button == 1)
+	c |= 1;
+      if (report.xbutton.button == 2)
+	c |= 2;
+      if (report.xbutton.button == 3)
+	c |= 4;
+      return (-c);
     }
-    break;
-   case KeyPress:
-    charcount = e_XLookupString(&report.xkey, buffer, BUFSIZE, &keysym,
-      NULL);
-    key_b = report.xkey.state;
-    if (charcount == 1)
-    {
-     if (*buffer == 127)
-     {
-      if (key_b & ControlMask)
-       return(CENTF);
-      else if (key_b & ShiftMask)
-       return(ShiftDel);
-      else if (key_b & WpeXInfo.altmask)
-       return(AltDel);
-      else
-       return(ENTF);
-     }
-     if ((key_b & ShiftMask) && (*buffer == '\t'))
-      return(WPE_BTAB);
-
-     if (key_b & WpeXInfo.altmask)
-      c = e_tast_sim(key_b & ShiftMask ? toupper(*buffer) : *buffer);
-     else
-      return(*buffer);
-    }
-    else
-    {
-     c = 0;
-     if (key_b & ControlMask)
-     {
-      if (keysym == XK_Left) c = CCLE;
-      else if (keysym == XK_Right) c = CCRI;
-      else if (keysym == XK_Home) c = CPS1;
-      else if (keysym == XK_End) c = CEND;
-      else if (keysym == XK_Insert) c = CEINFG;
-      else if (keysym == XK_Delete) c = CENTF;
-      else if (keysym == XK_Prior) c = CBUP;
-      else if (keysym == XK_Next) c = CBDO;
-      else if (keysym == XK_F1) c = CF1;
-      else if (keysym == XK_F2) c = CF2;
-      else if (keysym == XK_F3) c = CF3;
-      else if (keysym == XK_F4) c = CF4;
-      else if (keysym == XK_F5) c = CF5;
-      else if (keysym == XK_F6) c = CF6;
-      else if (keysym == XK_F7) c = CF7;
-      else if (keysym == XK_F8) c = CF8;
-      else if (keysym == XK_F9) c = CF9;
-      else if (keysym == XK_F10) c = CF10;
-     }
-     else if (key_b & WpeXInfo.altmask)
-     {
-      if (keysym == XK_F1) c = AF1;
-      else if (keysym == XK_F2) c = AF2;
-      else if (keysym == XK_F3) c = AF3;
-      else if (keysym == XK_F4) c = AF4;
-      else if (keysym == XK_F5) c = AF5;
-      else if (keysym == XK_F6) c = AF6;
-      else if (keysym == XK_F7) c = AF7;
-      else if (keysym == XK_F8) c = AF8;
-      else if (keysym == XK_F9) c = AF9;
-      else if (keysym == XK_F10) c = AF10;
-      else if (keysym == XK_Insert) c = AltEin;
-      else if (keysym == XK_Delete) c = AltDel;
-     }
-     else
-     {
-      if (keysym == XK_Left) c = CLE;
-      else if (keysym == XK_Right) c = CRI;
-      else if (keysym == XK_Up) c = CUP;
-      else if (keysym == XK_Down) c = CDO;
-      else if (keysym == XK_Home) c = POS1;
-      else if (keysym == XK_End) c = ENDE;
-      else if (keysym == XK_Insert) c = EINFG;
-      else if (keysym == XK_Delete) c = ENTF;
-      else if (keysym == XK_BackSpace) c = CtrlH;
-      else if (keysym == XK_Prior) c = BUP;
-      else if (keysym == XK_Next) c = BDO;
-      else if (keysym == XK_F1) c = F1;
-      else if (keysym == XK_F2) c = F2;
-      else if (keysym == XK_F3) c = F3;
-      else if (keysym == XK_F4) c = F4;
-      else if (keysym == XK_F5) c = F5;
-      else if (keysym == XK_F6) c = F6;
-      else if (keysym == XK_F7) c = F7;
-      else if (keysym == XK_F8) c = F8;
-      else if (keysym == XK_F9) c = F9;
-      else if (keysym == XK_F10) c = F10;
-      else if (keysym == XK_L1) c = STOP;
-      else if (keysym == XK_L2) c = AGAIN;
-      else if (keysym == XK_L3) c = PROPS;
-      else if (keysym == XK_L4) c = UNDO;
-      else if (keysym == XK_L5) c = FRONT;
-      else if (keysym == XK_L6) c = COPY;
-      else if (keysym == XK_L7) c = OPEN;
-      else if (keysym == XK_L8) c = PASTE;
-      else if (keysym == XK_L9) c = FID;
-      else if (keysym == XK_L10) c = CUT;
-      else if (keysym == XK_Help) c = HELP;
-     }
-    }
-    if (c != 0)
-    {
-     if (key_b & ShiftMask)
-      c = c + 512;
-     return(c);
-    }
-    break;
-   case ButtonPress:
-    key_b = report.xbutton.state;
-    e_mouse.k = (key_b & ShiftMask) ? 3 : 0 +
-      (key_b & ControlMask) ? 4 : 0 +
-      (key_b & WpeXInfo.altmask) ? 8 : 0;
-    e_mouse.x = report.xbutton.x/WpeXInfo.font_width;
-    e_mouse.y = report.xbutton.y/WpeXInfo.font_height;
-    c = 0;
-    if (report.xbutton.button == 1) c |= 1;
-    if (report.xbutton.button == 2) c |= 2;
-    if (report.xbutton.button == 3) c |= 4;
-    return(-c);
-   case SelectionRequest:
-    if (WpeXInfo.selection)
-    {
-     se.type = SelectionNotify;
-     se.display = report.xselectionrequest.display;
-     se.requestor = report.xselectionrequest.requestor;
-     se.selection = report.xselectionrequest.selection;
-     se.time = report.xselectionrequest.time;
-     se.target = report.xselectionrequest.target;
-     if (report.xselectionrequest.property == None)
-      report.xselectionrequest.property = report.xselectionrequest.target;
-     /* Xt asks for TARGETS.  Should probably support that. */
-     if (report.xselectionrequest.target == WpeXInfo.text_atom)
-     {
-      se.property = report.xselectionrequest.property;
-      XChangeProperty(se.display, se.requestor, se.property, se.target, 8,
-        PropModeReplace, WpeXInfo.selection, strlen((const char *)WpeXInfo.selection));
-     }
-     else
-      se.property = None;
-     XSendEvent(WpeXInfo.display, se.requestor, False, 0, (XEvent *)&se);
-    }
-    break;
-   case SelectionClear:
-    if (WpeXInfo.selection)
-    {
-     free(WpeXInfo.selection);
-     WpeXInfo.selection = NULL;
-    }
-    break;
-   default:
-    break;
-  }
- }
- return(0);
-}
-
-int e_x_kbhit()
-{
- XEvent report;
- KeySym keysym;
- int charcount;
- char buffer[BUFSIZE];
- int c;
- unsigned int key_b;
-
- e_refresh();
-
- if (XCheckMaskEvent(WpeXInfo.display, ButtonPressMask | KeyPressMask, &report) == False)
-  return(0);
-
- if (report.type == ButtonPress)
- {
-  key_b = report.xbutton.state;
-  e_mouse.k = (key_b & ShiftMask) ? 3 : 0;
-  e_mouse.x = report.xbutton.x/WpeXInfo.font_width;
-  e_mouse.y = report.xbutton.y/WpeXInfo.font_height;
-  c = 0;
-  if(report.xbutton.button == 1) c |= 1;
-  if(report.xbutton.button == 2) c |= 2;
-  if(report.xbutton.button == 3) c |= 4;
-  return(-c);
- }
- else
- {
-  charcount = e_XLookupString(&report.xkey, buffer, BUFSIZE,
-						&keysym, NULL);
-  if(charcount == 1) return(*buffer);
-  else return(0);
- }
-}
-
-void e_setlastpic(view *pic)
-{
- extern view *e_X_l_pic;
-
- e_X_l_pic = pic;
-}
-
-int fk_x_locate(int x, int y)
-{
- cur_x = x;
- return(cur_y = y);
-}
-
-int fk_x_cursor(int x)
-{
- return(cur_on = x);
-}
-
-int e_x_sys_ini()
-{
- return(0);
-}
-
-int e_x_sys_end()
-{
- return(0);
-}
-
-int fk_x_putchar(int c)
-{
- return(fputc(c, stdout));
-}
-
-int x_bioskey()
-{
- return(e_mouse.k);
-}
-
-int e_x_system(const char *exe)
-{
- FILE *fp;
- int ret;
- char file[80];
- char *string;
-
- sprintf(file, "%s/we_sys_tmp", e_tmp_dir);
- string = malloc(strlen(XTERM_CMD) + strlen(exe) + strlen(file) +
-   strlen(user_shell) + 40);
- if (!(fp = fopen(file, "w+")))
- {
-  free(string);
-  return(-1);
- }
- fputs("$*\necho type \\<Return\\> to continue\nread i\n", fp);
- fclose(fp);
- chmod(file, 0700);
- if (exe[0] == '/')
-  sprintf(string, "%s -geometry 80x25-0-0 +sb -e %s %s %s", XTERM_CMD,
-    user_shell, file, exe);
- else
-  sprintf(string, "%s -geometry 80x25-0-0 +sb -e %s %s ./%s", XTERM_CMD,
-    user_shell, file, exe);
- ret = system(string);
- remove(file);
- free(string);
- return(ret);
-}
-
-int e_x_repaint_desk(FENSTER *f)
-{
- ECNT *cn = f->ed;
- int i, g[4];
- extern view *e_X_l_pic;
- view *sv_pic = NULL, *nw_pic = NULL;
-
- if (e_X_l_pic && e_X_l_pic != cn->f[cn->mxedt]->pic)
- {
-  sv_pic = e_X_l_pic;
-  nw_pic = e_open_view(e_X_l_pic->a.x, e_X_l_pic->a.y, e_X_l_pic->e.x,
-    e_X_l_pic->e.y, 0, 2);
- }
- e_ini_size();
- if (cn->mxedt < 1)
- {
-  e_cls(f->fb->df.fb, f->fb->dc);
-  e_ini_desk(f->ed);
-  if (nw_pic)
-  {
-   e_close_view(nw_pic, 1);
-   e_X_l_pic = sv_pic;
-  }
-  return(0);
- }
- ini_repaint(cn);
- e_abs_refr();
- for (i = cn->mxedt; i >= 1; i--)
- {
-  free(cn->f[i]->pic->p);
-  free(cn->f[i]->pic);
- }
- for (i = 0; i <= cn->mxedt; i++)
- {
-  if (cn->f[i]->e.x >= MAXSCOL) cn->f[i]->e.x = MAXSCOL-1;
-  if (cn->f[i]->e.y >= MAXSLNS-1) cn->f[i]->e.y = MAXSLNS-2;
-  if (cn->f[i]->e.x - cn->f[i]->a.x < 26)
-   cn->f[i]->a.x = cn->f[i]->e.x - 26;
-  if (!DTMD_ISTEXT(cn->f[i]->dtmd) && cn->f[i]->e.y - cn->f[i]->a.y < 9)
-   cn->f[i]->a.y = cn->f[i]->e.y - 9;
-  else if (DTMD_ISTEXT(cn->f[i]->dtmd) && cn->f[i]->e.y - cn->f[i]->a.y < 3)
-   cn->f[i]->a.y = cn->f[i]->e.y - 3;
- }
- for (i = 1; i < cn->mxedt; i++)
- {
-  e_firstl(cn->f[i], 0);
-  e_schirm(cn->f[i], 0);
- }
- e_firstl(cn->f[i], 1);
- e_schirm(cn->f[i], 1);
- if (nw_pic)
- {
-  e_close_view(nw_pic, 1);
-  e_X_l_pic = sv_pic;
- }
- g[0] = 2; fk_mouse(g);
- end_repaint();
- e_cursor(cn->f[i], 1);
- g[0] = 0; fk_mouse(g);
- g[0] = 1; fk_mouse(g);
- return(0);
-}
-
-
-int fk_x_mouse(int *g)
-{
- Window tmp_win, tmp_root;
- int root_x, root_y, x, y;
- unsigned int key_b;
-
- if (!XQueryPointer(WpeXInfo.display, WpeXInfo.window, &tmp_root, &tmp_win,
-   &root_x, &root_y, &x, &y, &key_b))
- {
-  g[2] = e_mouse.x * 8;
-  g[3] = e_mouse.y * 8;
-  g[0] = g[1] = 0;
-  return(0);
- }
- g[0] = 0;
- if (key_b & Button1Mask)
-  g[0] |= 1;
- if(key_b & Button2Mask)
-  g[0] |= 4;
- if(key_b & Button3Mask)
-  g[0] |= 2;
- g[1] = g[0];
- g[2] = x/WpeXInfo.font_width * 8;
- g[3] = y/WpeXInfo.font_height * 8;
- return(g[1]);
-}
-
-int e_x_cp_X_to_buffer(FENSTER *f)
-{
- BUFFER *b0 = f->ed->f[0]->b;
- SCHIRM *s0 = f->ed->f[0]->s;
- int i, j, k, n;
- unsigned char *str;
- XEvent report;
- Atom type;
- int format;
- unsigned long nitems, bytes_left;
-
- for (i = 1; i < b0->mxlines; i++)
-  free(b0->bf[i].s);
- b0->mxlines = 1;
- *(b0->bf[0].s) = WPE_WR;
- *(b0->bf[0].s+1) = '\0';
- b0->bf[0].len = 0;
-#if defined SELECTION
- if (WpeXInfo.selection)
- {
-  str = (unsigned char *)WpeStrdup((const char *)WpeXInfo.selection);
-  n = strlen((const char *)str);
- }
- else
- {
-  /* Should check for errors especially failure to send SelectionNotify */
-  XConvertSelection(WpeXInfo.display, WpeXInfo.selection_atom,
-    WpeXInfo.text_atom, WpeXInfo.property_atom, WpeXInfo.window, CurrentTime);
-  n = 0;
-  while (!XCheckTypedEvent(WpeXInfo.display, SelectionNotify, &report))
-  {
-   /* Should probably have a better timeout period than this. */
-   sleep(0);
-   n++;
-   if (n > 1000)
-    return 0;
-  }
-  if (WpeXInfo.property_atom == None)
-   return 0;
-  XGetWindowProperty(WpeXInfo.display, WpeXInfo.window, WpeXInfo.property_atom,
-    0, 1000000, FALSE, WpeXInfo.text_atom, &type, &format, &nitems, &bytes_left,
-    &str);
-  if (type == None)
-  {
-   /* Specified property does not exit*/
-   return 0;
-  }
-  n = strlen((const char *)str);
- }
-#else
- str = XFetchBytes(WpeXInfo.display, &n);
-#endif
- for (i = k = 0; i < n; i++, k++)
- {
-  for (j = 0; i < n && str[i] != '\n' && j < b0->mx.x-1; j++, i++)
-   b0->bf[k].s[j] = str[i];
-  if (i < n)
-  {
-   e_new_line(k+1, b0);
-   if (str[i] == '\n')
-   {
-    b0->bf[k].s[j] = WPE_WR;
-    b0->bf[k].nrc = j+1;
-   }
-   else
-    b0->bf[k].nrc = j;
-   b0->bf[k].s[j+1] = '\0';
-   b0->bf[k].len = j;
-  }
   else
-  {
-   b0->bf[k].s[j] = '\0';
-   b0->bf[k].nrc = b0->bf[k].len = j;
-  }
- }
- s0->mark_begin.x = s0->mark_begin.y = 0;
- s0->mark_end.y = b0->mxlines-1;
- s0->mark_end.x = b0->bf[b0->mxlines-1].len;
-#if defined SELECTION
- if (WpeXInfo.selection)
-  free(str);
- else
-#endif
-  XFree(str);
- return 0;
+    {
+      charcount = e_XLookupString (&report.xkey, buffer, BUFSIZE,
+				   &keysym, NULL);
+      if (charcount == 1)
+	return (*buffer);
+      else
+	return (0);
+    }
 }
 
-int e_x_copy_X_buffer(FENSTER *f)
+void
+e_setlastpic (view * pic)
 {
- e_cp_X_to_buffer(f);
- e_edt_einf(f);
- return(0);
+  extern view *e_X_l_pic;
+
+  e_X_l_pic = pic;
 }
 
-int e_x_paste_X_buffer(FENSTER *f)
+int
+fk_x_locate (int x, int y)
 {
- BUFFER *b0 = f->ed->f[0]->b;
- SCHIRM *s0 = f->ed->f[0]->s;
- int i, n;
- unsigned int j;
+  cur_x = x;
+  return (cur_y = y);
+}
 
- e_edt_copy(f);
+int
+fk_x_cursor (int x)
+{
+  return (cur_on = x);
+}
+
+int
+e_x_sys_ini ()
+{
+  return (0);
+}
+
+int
+e_x_sys_end ()
+{
+  return (0);
+}
+
+int
+fk_x_putchar (int c)
+{
+  return (fputc (c, stdout));
+}
+
+int
+x_bioskey ()
+{
+  return (e_mouse.k);
+}
+
+int
+e_x_system (const char *exe)
+{
+  FILE *fp;
+  int ret;
+  char file[80];
+  char *string;
+
+  sprintf (file, "%s/we_sys_tmp", e_tmp_dir);
+  string = malloc (strlen (XTERM_CMD) + strlen (exe) + strlen (file) +
+		   strlen (user_shell) + 40);
+  if (!(fp = fopen (file, "w+")))
+    {
+      free (string);
+      return (-1);
+    }
+  fputs ("$*\necho type \\<Return\\> to continue\nread i\n", fp);
+  fclose (fp);
+  chmod (file, 0700);
+  if (exe[0] == '/')
+    sprintf (string, "%s -geometry 80x25-0-0 +sb -e %s %s %s", XTERM_CMD,
+	     user_shell, file, exe);
+  else
+    sprintf (string, "%s -geometry 80x25-0-0 +sb -e %s %s ./%s", XTERM_CMD,
+	     user_shell, file, exe);
+  ret = system (string);
+  remove (file);
+  free (string);
+  return (ret);
+}
+
+int
+e_x_repaint_desk (FENSTER * f)
+{
+  ECNT *cn = f->ed;
+  int i, g[4];
+  extern view *e_X_l_pic;
+  view *sv_pic = NULL, *nw_pic = NULL;
+
+  if (e_X_l_pic && e_X_l_pic != cn->f[cn->mxedt]->pic)
+    {
+      sv_pic = e_X_l_pic;
+      nw_pic = e_open_view (e_X_l_pic->a.x, e_X_l_pic->a.y, e_X_l_pic->e.x,
+			    e_X_l_pic->e.y, 0, 2);
+    }
+  e_ini_size ();
+  if (cn->mxedt < 1)
+    {
+      e_cls (f->fb->df.fb, f->fb->dc);
+      e_ini_desk (f->ed);
+      if (nw_pic)
+	{
+	  e_close_view (nw_pic, 1);
+	  e_X_l_pic = sv_pic;
+	}
+      return (0);
+    }
+  ini_repaint (cn);
+  e_abs_refr ();
+  for (i = cn->mxedt; i >= 1; i--)
+    {
+      free (cn->f[i]->pic->p);
+      free (cn->f[i]->pic);
+    }
+  for (i = 0; i <= cn->mxedt; i++)
+    {
+      if (cn->f[i]->e.x >= MAXSCOL)
+	cn->f[i]->e.x = MAXSCOL - 1;
+      if (cn->f[i]->e.y >= MAXSLNS - 1)
+	cn->f[i]->e.y = MAXSLNS - 2;
+      if (cn->f[i]->e.x - cn->f[i]->a.x < 26)
+	cn->f[i]->a.x = cn->f[i]->e.x - 26;
+      if (!DTMD_ISTEXT (cn->f[i]->dtmd) && cn->f[i]->e.y - cn->f[i]->a.y < 9)
+	cn->f[i]->a.y = cn->f[i]->e.y - 9;
+      else if (DTMD_ISTEXT (cn->f[i]->dtmd)
+	       && cn->f[i]->e.y - cn->f[i]->a.y < 3)
+	cn->f[i]->a.y = cn->f[i]->e.y - 3;
+    }
+  for (i = 1; i < cn->mxedt; i++)
+    {
+      e_firstl (cn->f[i], 0);
+      e_schirm (cn->f[i], 0);
+    }
+  e_firstl (cn->f[i], 1);
+  e_schirm (cn->f[i], 1);
+  if (nw_pic)
+    {
+      e_close_view (nw_pic, 1);
+      e_X_l_pic = sv_pic;
+    }
+  g[0] = 2;
+  fk_mouse (g);
+  end_repaint ();
+  e_cursor (cn->f[i], 1);
+  g[0] = 0;
+  fk_mouse (g);
+  g[0] = 1;
+  fk_mouse (g);
+  return (0);
+}
+
+
+int
+fk_x_mouse (int *g)
+{
+  Window tmp_win, tmp_root;
+  int root_x, root_y, x, y;
+  unsigned int key_b;
+
+  if (!XQueryPointer (WpeXInfo.display, WpeXInfo.window, &tmp_root, &tmp_win,
+		      &root_x, &root_y, &x, &y, &key_b))
+    {
+      g[2] = e_mouse.x * 8;
+      g[3] = e_mouse.y * 8;
+      g[0] = g[1] = 0;
+      return (0);
+    }
+  g[0] = 0;
+  if (key_b & Button1Mask)
+    g[0] |= 1;
+  if (key_b & Button2Mask)
+    g[0] |= 4;
+  if (key_b & Button3Mask)
+    g[0] |= 2;
+  g[1] = g[0];
+  g[2] = x / WpeXInfo.font_width * 8;
+  g[3] = y / WpeXInfo.font_height * 8;
+  return (g[1]);
+}
+
+int
+e_x_cp_X_to_buffer (FENSTER * f)
+{
+  BUFFER *b0 = f->ed->f[0]->b;
+  SCHIRM *s0 = f->ed->f[0]->s;
+  int i, j, k, n;
+  unsigned char *str;
+  XEvent report;
+  Atom type;
+  int format;
+  unsigned long nitems, bytes_left;
+
+  for (i = 1; i < b0->mxlines; i++)
+    free (b0->bf[i].s);
+  b0->mxlines = 1;
+  *(b0->bf[0].s) = WPE_WR;
+  *(b0->bf[0].s + 1) = '\0';
+  b0->bf[0].len = 0;
 #if defined SELECTION
- if (WpeXInfo.selection)
- {
-  free(WpeXInfo.selection);
-  WpeXInfo.selection = NULL;
- }
+  if (WpeXInfo.selection)
+    {
+      str = (unsigned char *) WpeStrdup ((const char *) WpeXInfo.selection);
+      n = strlen ((const char *) str);
+    }
+  else
+    {
+      /* Should check for errors especially failure to send SelectionNotify */
+      XConvertSelection (WpeXInfo.display, WpeXInfo.selection_atom,
+			 WpeXInfo.text_atom, WpeXInfo.property_atom,
+			 WpeXInfo.window, CurrentTime);
+      n = 0;
+      while (!XCheckTypedEvent (WpeXInfo.display, SelectionNotify, &report))
+	{
+	  /* Should probably have a better timeout period than this. */
+	  sleep (0);
+	  n++;
+	  if (n > 1000)
+	    return 0;
+	}
+      if (WpeXInfo.property_atom == None)
+	return 0;
+      XGetWindowProperty (WpeXInfo.display, WpeXInfo.window,
+			  WpeXInfo.property_atom, 0, 1000000, FALSE,
+			  WpeXInfo.text_atom, &type, &format, &nitems,
+			  &bytes_left, &str);
+      if (type == None)
+	{
+	  /* Specified property does not exit */
+	  return 0;
+	}
+      n = strlen ((const char *) str);
+    }
+#else
+  str = XFetchBytes (WpeXInfo.display, &n);
 #endif
- if ((s0->mark_end.y == 0 && s0->mark_end.x == 0) ||
-   s0->mark_end.y < s0->mark_begin.y)
-  return(0);
- if (s0->mark_end.y == s0->mark_begin.y)
- {
-  if (s0->mark_end.x < s0->mark_begin.x)
-   return(0);
-  n = s0->mark_end.x - s0->mark_begin.x;
+  for (i = k = 0; i < n; i++, k++)
+    {
+      for (j = 0; i < n && str[i] != '\n' && j < b0->mx.x - 1; j++, i++)
+	b0->bf[k].s[j] = str[i];
+      if (i < n)
+	{
+	  e_new_line (k + 1, b0);
+	  if (str[i] == '\n')
+	    {
+	      b0->bf[k].s[j] = WPE_WR;
+	      b0->bf[k].nrc = j + 1;
+	    }
+	  else
+	    b0->bf[k].nrc = j;
+	  b0->bf[k].s[j + 1] = '\0';
+	  b0->bf[k].len = j;
+	}
+      else
+	{
+	  b0->bf[k].s[j] = '\0';
+	  b0->bf[k].nrc = b0->bf[k].len = j;
+	}
+    }
+  s0->mark_begin.x = s0->mark_begin.y = 0;
+  s0->mark_end.y = b0->mxlines - 1;
+  s0->mark_end.x = b0->bf[b0->mxlines - 1].len;
 #if defined SELECTION
-  WpeXInfo.selection = malloc(n + 1);
-  strncpy((char *)WpeXInfo.selection, (char *)b0->bf[s0->mark_begin.y].s+s0->mark_begin.x,
-    n);
+  if (WpeXInfo.selection)
+    free (str);
+  else
+#endif
+    XFree (str);
+  return 0;
+}
+
+int
+e_x_copy_X_buffer (FENSTER * f)
+{
+  e_cp_X_to_buffer (f);
+  e_edt_einf (f);
+  return (0);
+}
+
+int
+e_x_paste_X_buffer (FENSTER * f)
+{
+  BUFFER *b0 = f->ed->f[0]->b;
+  SCHIRM *s0 = f->ed->f[0]->s;
+  int i, n;
+  unsigned int j;
+
+  e_edt_copy (f);
+#if defined SELECTION
+  if (WpeXInfo.selection)
+    {
+      free (WpeXInfo.selection);
+      WpeXInfo.selection = NULL;
+    }
+#endif
+  if ((s0->mark_end.y == 0 && s0->mark_end.x == 0) ||
+      s0->mark_end.y < s0->mark_begin.y)
+    return (0);
+  if (s0->mark_end.y == s0->mark_begin.y)
+    {
+      if (s0->mark_end.x < s0->mark_begin.x)
+	return (0);
+      n = s0->mark_end.x - s0->mark_begin.x;
+#if defined SELECTION
+      WpeXInfo.selection = malloc (n + 1);
+      strncpy ((char *) WpeXInfo.selection,
+	       (char *) b0->bf[s0->mark_begin.y].s + s0->mark_begin.x, n);
+      WpeXInfo.selection[n] = 0;
+      XSetSelectionOwner (WpeXInfo.display, WpeXInfo.selection_atom,
+			  WpeXInfo.window, CurrentTime);
+#else
+      XStoreBytes (WpeXInfo.display,
+		   b0->bf[s0->mark_begin.y].s + s0->mark_begin.x, n);
+#endif
+      return (0);
+    }
+  WpeXInfo.selection = malloc (b0->bf[s0->mark_begin.y].nrc * sizeof (char));
+  for (n = 0, j = s0->mark_begin.x; j < b0->bf[s0->mark_begin.y].nrc;
+       j++, n++)
+    WpeXInfo.selection[n] = b0->bf[s0->mark_begin.y].s[j];
+  for (i = s0->mark_begin.y + 1; i < s0->mark_end.y; i++)
+    {
+      WpeXInfo.selection =
+	realloc (WpeXInfo.selection, (n + b0->bf[i].nrc) * sizeof (char));
+      for (j = 0; j < b0->bf[i].nrc; j++, n++)
+	WpeXInfo.selection[n] = b0->bf[i].s[j];
+    }
+  WpeXInfo.selection =
+    realloc (WpeXInfo.selection, (n + s0->mark_end.x + 1) * sizeof (char));
+  for (j = 0; j < (unsigned) s0->mark_end.x; j++, n++)
+    WpeXInfo.selection[n] = b0->bf[i].s[j];
   WpeXInfo.selection[n] = 0;
-  XSetSelectionOwner(WpeXInfo.display, WpeXInfo.selection_atom,
-    WpeXInfo.window, CurrentTime);
-#else
-  XStoreBytes(WpeXInfo.display, b0->bf[s0->mark_begin.y].s+s0->mark_begin.x,
-    n);
-#endif
-  return(0);
- }
- WpeXInfo.selection = malloc(b0->bf[s0->mark_begin.y].nrc * sizeof(char));
- for (n = 0, j = s0->mark_begin.x; j < b0->bf[s0->mark_begin.y].nrc; j++, n++)
-  WpeXInfo.selection[n] = b0->bf[s0->mark_begin.y].s[j];
- for (i = s0->mark_begin.y+1; i < s0->mark_end.y; i++)
- {
-  WpeXInfo.selection = realloc(WpeXInfo.selection, (n + b0->bf[i].nrc)*sizeof(char));
-  for (j = 0; j < b0->bf[i].nrc; j++, n++)
-   WpeXInfo.selection[n] = b0->bf[i].s[j];
- }
- WpeXInfo.selection = realloc(WpeXInfo.selection, (n + s0->mark_end.x + 1)*sizeof(char));
- for (j = 0; j < (unsigned)s0->mark_end.x; j++, n++)
-  WpeXInfo.selection[n] = b0->bf[i].s[j];
- WpeXInfo.selection[n] = 0;
 #if defined SELECTION
- XSetSelectionOwner(WpeXInfo.display, WpeXInfo.selection_atom,
-   WpeXInfo.window, CurrentTime);
+  XSetSelectionOwner (WpeXInfo.display, WpeXInfo.selection_atom,
+		      WpeXInfo.window, CurrentTime);
 #else
- XStoreBytes(WpeXInfo.display, WpeXInfo.selection, n);
- free(WpeXInfo.selection);
- WpeXInfo.selection = NULL;
+  XStoreBytes (WpeXInfo.display, WpeXInfo.selection, n);
+  free (WpeXInfo.selection);
+  WpeXInfo.selection = NULL;
 #endif
- return(0);
+  return (0);
 }
 
 #endif
-

--- a/src/we_xterm.h
+++ b/src/we_xterm.h
@@ -6,8 +6,8 @@
 #include "we_block.h"
 #include "we_e_aus.h"
 
-extern int (*e_u_ini_size)(void);
+extern int (*e_u_ini_size) (void);
 
-int e_X_sw_color(void);
+int e_X_sw_color (void);
 
 #endif


### PR DESCRIPTION
This pull request contains only one commit in which all code sources (except config.h which is generated) were formatted. I used the program `indent` without options to format the sources. This results in a format according to the default `-gnu-style` which turns out to be quite readable.

The remaining question is how to get make sure the sources stay formatted, even if someone edits them with different formatting options (like my vim has). I am leaning towards automatic formatting during commit. That would certainly guarantee the format. I just don't know how to realize that, yet.

For now, just this pull request. It solves issue #60 Formatting makes reading and understanding difficult.